### PR TITLE
Access-Control-Allow-Origin added to response

### DIFF
--- a/modules/swagger-play2/app/controllers/ApiHelpController.scala
+++ b/modules/swagger-play2/app/controllers/ApiHelpController.scala
@@ -41,6 +41,7 @@ class SwaggerBaseApiController extends Controller {
   protected def jaxbContext(): JAXBContext = JAXBContext.newInstance(classOf[String])
   protected def returnXml(request: Request[_]) = request.path.contains(".xml")
   protected val ok = "OK"
+  protected val AccessControlAllowOrigin = ("Access-Control-Allow-Origin", "*")
 
   protected def XmlResponse(o: Any) = {
     val xmlValue = {
@@ -56,7 +57,8 @@ class SwaggerBaseApiController extends Controller {
   }
 
   protected def returnValue(request: Request[_], obj: Any): Result = {
-    if (returnXml(request)) XmlResponse(obj) else JsonResponse(obj)
+    val response = if (returnXml(request)) XmlResponse(obj) else JsonResponse(obj)
+    response.withHeaders(AccessControlAllowOrigin)
   }
 
   protected def JsonResponse(data: Any) = {


### PR DESCRIPTION
Added an Access-Control-Allow-Origin response header to allow the documentation UI to access resource information and display it properly.
