### PR TITLE
Make singleton resources visible to swagger

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/ApiListing.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/ApiListing.scala
@@ -57,6 +57,8 @@ trait ApiListing {
     }
 
     val resources = rc.getRootResourceClasses
+    rc.getRootResourceSingletons.foreach( ref => resources.add(ref.getClass))
+
     val apiListingEndpoint = this.getClass.getAnnotation(classOf[Api])
     val resourceListingType = this.getClass.getAnnotation(classOf[javax.ws.rs.Produces]).value.toSet
 


### PR DESCRIPTION
Swagger only lists resources added by class. It misses those added by instance reference. This is a fix so that not only resource classes are discovered by swagger.

In my code I made a delegate for ApiListing in which I joined the two class sets and it worked. This patch should fix things in swagger. I didn't test the patch but it's a trivial change, should work. 
