### PR TITLE
Swagger should now work with servlet filter-based deployment as well.

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/ApiListing.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/ApiListing.scala
@@ -23,10 +23,10 @@ import com.wordnik.swagger.annotations._
 import org.slf4j.LoggerFactory
 
 import com.sun.jersey.api.core.ResourceConfig
+import com.sun.jersey.spi.container.servlet.WebConfig
 
 import javax.ws.rs.{ Path, GET }
 import javax.ws.rs.core.{ UriInfo, HttpHeaders, Context, Response }
-import javax.servlet.ServletConfig
 
 import scala.collection.JavaConversions._
 
@@ -36,12 +36,12 @@ trait ApiListing {
   @GET
   @ApiOperation(value = "Returns list of all available api endpoints",
     responseClass = "DocumentationEndPoint", multiValueResponse = true)
-  def getAllApis(@Context sc: ServletConfig,
+  def getAllApis(@Context wc: WebConfig,
     @Context rc: ResourceConfig,
     @Context headers: HttpHeaders,
     @Context uriInfo: UriInfo): Response = {
 
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+    val reader = ConfigReaderFactory.getConfigReader(wc)
     val apiVersion = reader.getApiVersion()
     val swaggerVersion = reader.getSwaggerVersion()
     val basePath = reader.getBasePath()

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/ConfigReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/ConfigReader.scala
@@ -18,11 +18,11 @@ package com.wordnik.swagger.jaxrs
 
 import com.wordnik.swagger.core._
 
-import javax.servlet.ServletConfig
+import com.sun.jersey.spi.container.servlet.WebConfig
 
-class ConfigReader(val sc: ServletConfig) {
+class ConfigReader(val wc: WebConfig) {
   def getBasePath(): String = {
-    if (sc != null) sc.getInitParameter("swagger.api.basepath") else null
+    if (wc != null) wc.getInitParameter("swagger.api.basepath") else null
   }
 
   def getSwaggerVersion(): String = {
@@ -30,12 +30,12 @@ class ConfigReader(val sc: ServletConfig) {
   }
 
   def getApiVersion(): String = {
-    if (sc != null) sc.getInitParameter("api.version") else null
+    if (wc != null) wc.getInitParameter("api.version") else null
   }
 
   def getModelPackages(): String = {
-    sc match {
-      case s: ServletConfig => sc.getInitParameter("api.model.packages") match {
+    wc match {
+      case s: WebConfig => wc.getInitParameter("api.model.packages") match {
         case str: String => str
         case _ => ""
       }
@@ -44,6 +44,6 @@ class ConfigReader(val sc: ServletConfig) {
   }
 
   def getApiFilterClassName(): String = {
-    if (sc != null) sc.getInitParameter("swagger.security.filter") else null
+    if (wc != null) wc.getInitParameter("swagger.security.filter") else null
   }
 }

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/Help.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/Help.scala
@@ -23,8 +23,7 @@ import com.wordnik.swagger.annotations._
 import org.slf4j.LoggerFactory
 
 import com.sun.jersey.api.core.ResourceConfig
-
-import javax.servlet.ServletConfig
+import com.sun.jersey.spi.container.servlet.WebConfig
 
 import javax.ws.rs.{ Path, GET }
 import javax.ws.rs.core.{ UriInfo, HttpHeaders, Context, Response }
@@ -36,8 +35,8 @@ trait Help {
   @GET
   @ApiOperation(value = "Returns information about API parameters",
     responseClass = "com.wordnik.swagger.core.Documentation")
-  def getHelp(@Context sc: ServletConfig, @Context rc: ResourceConfig, @Context headers: HttpHeaders, @Context uriInfo: UriInfo): Response = {
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+  def getHelp(@Context wc: WebConfig, @Context rc: ResourceConfig, @Context headers: HttpHeaders, @Context uriInfo: UriInfo): Response = {
+    val reader = ConfigReaderFactory.getConfigReader(wc)
 
     val apiVersion = reader.getApiVersion()
     val swaggerVersion = reader.getSwaggerVersion()
@@ -82,15 +81,15 @@ trait Help {
 }
 
 object ConfigReaderFactory {
-  def getConfigReader(sc: ServletConfig): ConfigReader = {
+  def getConfigReader(wc: WebConfig): ConfigReader = {
     var configReaderStr = {
-      sc.getInitParameter("swagger.config.reader") match {
+      wc.getInitParameter("swagger.config.reader") match {
         case s: String => s
         case _ => "com.wordnik.swagger.jaxrs.ConfigReader"
       }
     }
-    val constructor = SwaggerContext.loadClass(configReaderStr).getConstructor(classOf[ServletConfig])
-    val configReader = constructor.newInstance(sc).asInstanceOf[ConfigReader]
+    val constructor = SwaggerContext.loadClass(configReaderStr).getConstructor(classOf[WebConfig])
+    val configReader = constructor.newInstance(wc).asInstanceOf[ConfigReader]
     configReader
   }
 }

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JavaHelp.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JavaHelp.scala
@@ -23,8 +23,7 @@ import com.wordnik.swagger.annotations._
 import org.slf4j.LoggerFactory
 
 import com.sun.jersey.api.core.ResourceConfig
-
-import javax.servlet.ServletConfig
+import com.sun.jersey.spi.container.servlet.WebConfig
 
 import javax.ws.rs.{ Path, GET }
 import javax.ws.rs.core.{ UriInfo, HttpHeaders, Context, Response }
@@ -36,8 +35,8 @@ abstract class JavaHelp {
   @GET
   @ApiOperation(value = "Returns information about API parameters",
     responseClass = "com.wordnik.swagger.core.Documentation")
-  def getHelp(@Context sc: ServletConfig, @Context rc: ResourceConfig, @Context headers: HttpHeaders, @Context uriInfo: UriInfo): Response = {
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+  def getHelp(@Context wc: WebConfig, @Context rc: ResourceConfig, @Context headers: HttpHeaders, @Context uriInfo: UriInfo): Response = {
+    val reader = ConfigReaderFactory.getConfigReader(wc)
 
     val apiVersion = reader.getApiVersion()
     val swaggerVersion = reader.getSwaggerVersion()


### PR DESCRIPTION
Swagger was servlet-specific (since it was injecting ServletConfig)
and did not work if Jersey ServletContainer was registered as
a servlet filter rather than a servlet.

See: http://stackoverflow.com/questions/12960479/bootstrapping-jersey-with-a-filter-causes-swagger-to-fail

This patch fixes the issue.

NOTE: I haven't managed to run the integration tests successfully (even without this patch), but the module build and unit tests ran fine.
