### PR TITLE
Dropwizard support: Look for init-params in ServletContext as well as Servlet.

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JerseyConfigReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JerseyConfigReader.scala
@@ -22,31 +22,33 @@ import com.wordnik.swagger.core._
 import scala.collection.JavaConverters._
 
 class JerseyConfigReader(val sc: ServletConfig) extends ConfigReader {
-  def basePath(): String = {
-    if (sc != null) sc.getInitParameter("swagger.api.basepath") else null
-  }
+
+  def basePath(): String = findInitParam("swagger.api.basepath")
 
   def swaggerVersion(): String = {
     SwaggerSpec.version
   }
 
-  def apiVersion(): String = {
-    if (sc != null) sc.getInitParameter("api.version") else null
-  }
+  def apiVersion(): String = findInitParam("api.version")
 
   def modelPackages(): String = {
-    sc match {
-      case s: ServletConfig => sc.getInitParameter("api.model.packages") match {
-        case str: String => str
-        case _ => ""
-      }
+    findInitParam("api.model.packages") match {
+      case str: String => str
       case _ => ""
     }
   }
 
-  def apiFilterClassName(): String = {
-    if (sc != null)
-      sc.getInitParameter("swagger.security.filter")
-    else null
+  def apiFilterClassName(): String = findInitParam("swagger.security.filter")
+
+  /**
+   * Look for an initParameter in either the ServletConfig or the ServletContext
+   */
+  private def findInitParam(key: String): String = {
+    val scOpt = Option.apply(sc)
+    scOpt.map { sc => 
+      Option.apply(sc.getInitParameter(key))
+        .getOrElse(sc.getServletContext.getInitParameter(key))
+    } orNull
   }
+
 }


### PR DESCRIPTION
Dropwizard supports passing of init-params to the ServletContext, but (as far I can tell) there is no way to pass init-params to the Jersey Servlet. This means that Swagger is unable to find its configuration parameters (api.version, swagger.api.basepath, etc.).

This simple fix tells Swagger to check both the Servlet's and the ServletContext's init-params when looking for its configuration. So the required parameters can be passed to Swagger via the Dropwizard config file:

``` yaml
http:
    contextParameters:
        swagger.api.basepath: http://localhost:8080
        api.version: 1.0
```
