### PR TITLE
Dependency injection of controllers

### DIFF
--- a/modules/swagger-play2/app/play/modules/swagger/ApiHelpInventory.scala
+++ b/modules/swagger-play2/app/play/modules/swagger/ApiHelpInventory.scala
@@ -186,7 +186,7 @@ object ApiHelpInventory {
               case i:Int if (i > 0) => doc._3.substring(0, i)
               case _ => doc._3
             }
-            Some(m1.substring(0, m1.lastIndexOf(".")))
+            Some(m1.substring(0, m1.lastIndexOf(".")).replace("@", ""))
           }
         }
         case None => Seq(None)


### PR DESCRIPTION
Changing getControllerClasses to support Dependency injection, new feature in Play 2.1

Routes: 
GET / @controllers.SwaggerApi.index

And routes_routing.scala will be like
("""GET""", prefix,"""@controllers.SwaggerApi@.index""")

So need to remove @ from routes documentation to find classloader.
