### PR TITLE
added support for responseClass=List[com.foo.Bar]

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/ApiReader.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/ApiReader.scala
@@ -84,6 +84,7 @@ trait ApiSpecParserTrait extends BaseApiParser {
     docParam.paramAccess = readString(apiParam.access)
   }
 
+  private val ListRegex: scala.util.matching.Regex = """List\[(.*?)\]""".r
   def parseMethod(method: Method): Any = {
     val apiOperation = method.getAnnotation(classOf[ApiOperation])
     val apiErrors = method.getAnnotation(classOf[ApiErrors])
@@ -103,8 +104,10 @@ trait ApiSpecParserTrait extends BaseApiParser {
         docOperation.notes = readString(apiOperation.notes)
         docOperation.setTags(toObjectList(apiOperation.tags))
         docOperation.nickname = method.getName
-        val apiResponseValue = readString(apiOperation.responseClass)
-        val isResponseMultiValue = apiOperation.multiValueResponse
+        val (apiResponseValue: String, isResponseMultiValue: Boolean) = ((responseClass: String, isMulti: Boolean) => responseClass match {
+          case ListRegex(respClass) => (respClass, true)
+          case _ => (responseClass, isMulti)
+        })(readString(apiOperation.responseClass), apiOperation.multiValueResponse)
 
         docOperation.setResponseTypeInternal(apiResponseValue)
         try {

--- a/modules/swagger-jaxrs/src/test/scala/com/wordnik/test/swagger/core/testdata/BasicResource.scala
+++ b/modules/swagger-jaxrs/src/test/scala/com/wordnik/test/swagger/core/testdata/BasicResource.scala
@@ -58,8 +58,7 @@ class BasicResource {
   @Path("/getStringList")
   @ApiOperation(value = "Get object by ID",
     notes = "No details provided",
-    responseClass = "String",
-    multiValueResponse =  true)
+    responseClass = "List[String]")
   @ApiErrors(Array(
     new ApiError(code = 400, reason = "Invalid ID"),
     new ApiError(code = 404, reason = "object not found")))


### PR DESCRIPTION
Wrt issue #47 

Added support for 

``` java
@ApiOperation(value = "XX", notes="YY", responseClass="List[com.foo.Bar]")
```

and retain support for 

``` java
@ApiOperation(value = "XX", notes="YY", responseClass="com.foo.Bar", multiValueResponse=true)
```
