### PR TITLE
Missing dependency in JavaApiListing ServletConfig with Jersey filter

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/ApiListing.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/ApiListing.scala
@@ -16,13 +16,12 @@
 
 package com.wordnik.swagger.jaxrs
 
+import com.sun.jersey.spi.container.servlet.WebConfig
 import com.wordnik.swagger.core._
 import com.wordnik.swagger.core.util.TypeUtil
 import com.wordnik.swagger.annotations._
 
 import org.slf4j.LoggerFactory
-
-import javax.servlet.ServletConfig
 
 import javax.ws.rs.{ Path, GET }
 import javax.ws.rs.core.{ UriInfo, HttpHeaders, Context, Response, Application }
@@ -37,12 +36,12 @@ trait ApiListing {
   @ApiOperation(value = "Returns list of all available api endpoints",
     responseClass = "List[DocumentationEndPoint]")
   def getAllApis(
-    @Context sc: ServletConfig,
+    @Context wc: WebConfig,
     @Context app: Application,
     @Context headers: HttpHeaders,
     @Context uriInfo: UriInfo): Response = {
 
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+    val reader = ConfigReaderFactory.getConfigReader(wc)
     val apiVersion = reader.apiVersion()
     val swaggerVersion = reader.swaggerVersion()
     val basePath = reader.basePath()

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/Help.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/Help.scala
@@ -16,6 +16,7 @@
 
 package com.wordnik.swagger.jaxrs
 
+import com.sun.jersey.spi.container.servlet.WebConfig
 import com.wordnik.swagger.core._
 import com.wordnik.swagger.core.util.TypeUtil
 import com.wordnik.swagger.annotations._
@@ -26,8 +27,6 @@ import javax.ws.rs.{ Path, GET }
 import javax.ws.rs.core.{ UriInfo, HttpHeaders, Context, Response }
 import javax.ws.rs.core.Response.Status
 
-import javax.servlet.ServletConfig
-
 import scala.collection.JavaConversions._
 
 trait Help {
@@ -35,10 +34,10 @@ trait Help {
   @ApiOperation(value = "Returns information about API parameters",
     responseClass = "com.wordnik.swagger.core.Documentation")
   def getHelp(
-    @Context sc: ServletConfig, 
-    @Context headers: HttpHeaders, 
+    @Context wc: WebConfig,
+    @Context headers: HttpHeaders,
     @Context uriInfo: UriInfo): Response = {
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+    val reader = ConfigReaderFactory.getConfigReader(wc)
 
     val apiVersion = reader.apiVersion
     val swaggerVersion = reader.swaggerVersion
@@ -83,15 +82,15 @@ trait Help {
 }
 
 object ConfigReaderFactory {
-  def getConfigReader(sc: ServletConfig): ConfigReader = {
+  def getConfigReader(wc: WebConfig): ConfigReader = {
     var configReaderStr = {
-      sc.getInitParameter("swagger.config.reader") match {
+      wc.getInitParameter("swagger.config.reader") match {
         case s: String => s
         case _ => "com.wordnik.swagger.jaxrs.JerseyConfigReader"
       }
     }
-    val constructor = SwaggerContext.loadClass(configReaderStr).getConstructor(classOf[ServletConfig])
-    val configReader = constructor.newInstance(sc).asInstanceOf[ConfigReader]
+    val constructor = SwaggerContext.loadClass(configReaderStr).getConstructor(classOf[WebConfig])
+    val configReader = constructor.newInstance(wc).asInstanceOf[ConfigReader]
     configReader
   }
 }

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JavaHelp.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JavaHelp.scala
@@ -16,6 +16,7 @@
 
 package com.wordnik.swagger.jaxrs
 
+import com.sun.jersey.spi.container.servlet.WebConfig
 import com.wordnik.swagger.core._
 import com.wordnik.swagger.core.util.TypeUtil
 import com.wordnik.swagger.annotations._
@@ -26,8 +27,6 @@ import javax.ws.rs.{ Path, GET }
 import javax.ws.rs.core.{ UriInfo, HttpHeaders, Context, Response }
 import javax.ws.rs.core.Response.Status
 
-import javax.servlet.ServletConfig
-
 import scala.collection.JavaConversions._
 
 abstract class JavaHelp {
@@ -35,10 +34,10 @@ abstract class JavaHelp {
   @ApiOperation(value = "Returns information about API parameters",
     responseClass = "com.wordnik.swagger.core.Documentation")
   def getHelp(
-    @Context sc: ServletConfig,
-    @Context headers: HttpHeaders, 
+    @Context wc: WebConfig,
+    @Context headers: HttpHeaders,
     @Context uriInfo: UriInfo): Response = {
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+    val reader = ConfigReaderFactory.getConfigReader(wc)
     val apiVersion = reader.apiVersion()
     val swaggerVersion = reader.swaggerVersion()
     val basePath = reader.basePath()

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JerseyConfigReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JerseyConfigReader.scala
@@ -16,12 +16,11 @@
 
 package com.wordnik.swagger.jaxrs
 
-import javax.servlet.ServletConfig
-
+import com.sun.jersey.spi.container.servlet.WebConfig
 import com.wordnik.swagger.core._
 import scala.collection.JavaConverters._
 
-class JerseyConfigReader(val sc: ServletConfig) extends ConfigReader {
+class JerseyConfigReader(val wc: WebConfig) extends ConfigReader {
 
   def basePath(): String = findInitParam("swagger.api.basepath")
 
@@ -44,10 +43,10 @@ class JerseyConfigReader(val sc: ServletConfig) extends ConfigReader {
    * Look for an initParameter in either the ServletConfig or the ServletContext
    */
   private def findInitParam(key: String): String = {
-    val scOpt = Option.apply(sc)
-    scOpt.map { sc => 
-      Option.apply(sc.getInitParameter(key))
-        .getOrElse(sc.getServletContext.getInitParameter(key))
+    val scOpt = Option.apply(wc)
+    scOpt.map { wc =>
+      Option.apply(wc.getInitParameter(key))
+        .getOrElse(wc.getServletContext.getInitParameter(key))
     } orNull
   }
 

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/listing/ApiListing.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/listing/ApiListing.scala
@@ -1,5 +1,6 @@
 package com.wordnik.swagger.jaxrs.listing
 
+import com.sun.jersey.spi.container.servlet.WebConfig
 import com.wordnik.swagger.core.{ Documentation, DocumentationEndPoint }
 import com.wordnik.swagger.annotations._
 import com.wordnik.swagger.jaxrs._
@@ -10,8 +11,6 @@ import javax.ws.rs.core.{ UriInfo, HttpHeaders, Context, Response, MediaType, Ap
 import javax.ws.rs.core.Response._
 import javax.ws.rs._
 
-import javax.servlet.ServletConfig
-
 import scala.collection.mutable.HashMap
 import scala.collection.JavaConverters._
 
@@ -20,7 +19,7 @@ object ApiListingResource {
 
   def routes(
     app: Application,
-    sc: ServletConfig,
+    wc: WebConfig,
     headers: HttpHeaders,
     uriInfo: UriInfo
   ) = {
@@ -38,7 +37,7 @@ object ApiListingResource {
               }
               cache += path -> resource
             }
-            case _ => 
+            case _ =>
           }
         })
         _cache = Some(cache.toMap)
@@ -52,21 +51,21 @@ class ApiListing {
   @GET
   def resourceListing(
     @Context app: Application,
-    @Context sc: ServletConfig,
+    @Context wc: WebConfig,
     @Context headers: HttpHeaders,
     @Context uriInfo: UriInfo
   ): Response = {
     val listingRoot = this.getClass.getAnnotation(classOf[Api]).value
 
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+    val reader = ConfigReaderFactory.getConfigReader(wc)
     val apiFilterClassName = reader.apiFilterClassName()
     val apiVersion = reader.apiVersion()
     val swaggerVersion = reader.swaggerVersion()
     val basePath = reader.basePath()
-    val routes = ApiListingResource.routes(app, sc, headers, uriInfo)
+    val routes = ApiListingResource.routes(app, wc, headers, uriInfo)
 
     val apis = (for(route <- routes.map(m => m._1)) yield {
-      docForRoute(route, app, sc, headers, uriInfo) match {
+      docForRoute(route, app, wc, headers, uriInfo) match {
         case Some(doc) if(doc.getApis !=null && doc.getApis.size > 0) => {
           Some(new DocumentationEndPoint(listingRoot + JaxrsApiReader.FORMAT_STRING + doc.resourcePath, ""))
         }
@@ -91,11 +90,11 @@ class ApiListing {
   def apiListing(
     @PathParam("route") route: String,
     @Context app: Application,
-    @Context sc: ServletConfig,
+    @Context wc: WebConfig,
     @Context headers: HttpHeaders,
     @Context uriInfo: UriInfo
   ): Response = {
-    docForRoute(route, app, sc, headers, uriInfo) match {
+    docForRoute(route, app, wc, headers, uriInfo) match {
       case Some(doc) => Response.ok.entity(doc).build
       case None => Response.status(Status.NOT_FOUND).build
     }
@@ -104,16 +103,16 @@ class ApiListing {
   def docForRoute(
     route: String,
     app: Application,
-    sc: ServletConfig,
+    wc: WebConfig,
     headers: HttpHeaders,
     uriInfo: UriInfo
   ): Option[Documentation] = {
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+    val reader = ConfigReaderFactory.getConfigReader(wc)
     val apiFilterClassName = reader.apiFilterClassName()
     val apiVersion = reader.apiVersion()
     val swaggerVersion = reader.swaggerVersion()
     val basePath = reader.basePath()
-    val routes = ApiListingResource.routes(app, sc, headers, uriInfo)
+    val routes = ApiListingResource.routes(app, wc, headers, uriInfo)
 
     routes.contains(route) match {
       case true => {

--- a/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/listing/ApiListing.scala
+++ b/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/listing/ApiListing.scala
@@ -1,5 +1,6 @@
 package com.wordnik.swagger.jersey.listing
 
+import com.sun.jersey.spi.container.servlet.WebConfig
 import com.wordnik.swagger.core.{ Documentation, DocumentationEndPoint }
 import com.wordnik.swagger.annotations._
 import com.wordnik.swagger.jersey._
@@ -11,8 +12,6 @@ import javax.ws.rs.core.{ UriInfo, HttpHeaders, Context, Response, MediaType, Ap
 import javax.ws.rs.core.Response._
 import javax.ws.rs._
 
-import javax.servlet.ServletConfig
-
 import scala.collection.mutable.HashMap
 import scala.collection.JavaConverters._
 
@@ -21,7 +20,7 @@ object ApiListingResource {
 
   def routes(
     app: Application,
-    sc: ServletConfig,
+    wc: WebConfig,
     headers: HttpHeaders,
     uriInfo: UriInfo
   ) = {
@@ -39,7 +38,7 @@ object ApiListingResource {
               }
               cache += path -> resource
             }
-            case _ => 
+            case _ =>
           }
         })
         _cache = Some(cache.toMap)
@@ -53,21 +52,21 @@ class ApiListing {
   @GET
   def resourceListing(
     @Context app: Application,
-    @Context sc: ServletConfig,
+    @Context wc: WebConfig,
     @Context headers: HttpHeaders,
     @Context uriInfo: UriInfo
   ): Response = {
     val listingRoot = this.getClass.getAnnotation(classOf[Api]).value
 
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+    val reader = ConfigReaderFactory.getConfigReader(wc)
     val apiFilterClassName = reader.apiFilterClassName()
     val apiVersion = reader.apiVersion()
     val swaggerVersion = reader.swaggerVersion()
     val basePath = reader.basePath()
-    val routes = ApiListingResource.routes(app, sc, headers, uriInfo)
+    val routes = ApiListingResource.routes(app, wc, headers, uriInfo)
 
     val apis = (for(route <- routes.map(m => m._1)) yield {
-      docForRoute(route, app, sc, headers, uriInfo) match {
+      docForRoute(route, app, wc, headers, uriInfo) match {
         case Some(doc) if(doc.getApis !=null && doc.getApis.size > 0) => {
           Some(new DocumentationEndPoint(listingRoot + JerseyApiReader.FORMAT_STRING + doc.resourcePath, ""))
         }
@@ -92,11 +91,11 @@ class ApiListing {
   def apiListing(
     @PathParam("route") route: String,
     @Context app: Application,
-    @Context sc: ServletConfig,
+    @Context wc: WebConfig,
     @Context headers: HttpHeaders,
     @Context uriInfo: UriInfo
   ): Response = {
-    docForRoute(route, app, sc, headers, uriInfo) match {
+    docForRoute(route, app, wc, headers, uriInfo) match {
       case Some(doc) => Response.ok.entity(doc).build
       case None => Response.status(Status.NOT_FOUND).build
     }
@@ -105,16 +104,16 @@ class ApiListing {
   def docForRoute(
     route: String,
     app: Application,
-    sc: ServletConfig,
+    wc: WebConfig,
     headers: HttpHeaders,
     uriInfo: UriInfo
   ): Option[Documentation] = {
-    val reader = ConfigReaderFactory.getConfigReader(sc)
+    val reader = ConfigReaderFactory.getConfigReader(wc)
     val apiFilterClassName = reader.apiFilterClassName()
     val apiVersion = reader.apiVersion()
     val swaggerVersion = reader.swaggerVersion()
     val basePath = reader.basePath()
-    val routes = ApiListingResource.routes(app, sc, headers, uriInfo)
+    val routes = ApiListingResource.routes(app, wc, headers, uriInfo)
 
     routes.contains(route) match {
       case true => {


### PR DESCRIPTION
This fix re-adds mmatula's Pull #64 which was reverted by commit
20a1ab8. This simply replaces javax.servlet.ServletConfig with
com.sun.jersey.api.container.servlet.WebConfig.
