### PR TITLE
Re-add ApiProperty.dataType which was accidentally removed with 3f95978b

### DIFF
--- a/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiProperty.java
+++ b/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiProperty.java
@@ -42,7 +42,10 @@ public @interface ApiProperty {
 	/**
 	 * The dataType. See the documentation for the supported datatypes. If the data type is a custom object, set
 	 * it's name, or nothing. In case of an enum use 'string' and allowableValues for the enum constants.
-	 * /**
+     */
+    String dataType() default "";
+
+	/**
 	 * Whether or not the property is required, defaults to false.
 	 * 
 	 * @return true if required, false otherwise


### PR DESCRIPTION
As of 3f95978b, compilation fails with the message:
  SwaggerJsonSchemaProvider.scala:205: error: value dataType is not a
  member of com.wordnik.swagger.annotations.ApiProperty

This commit re-adds the dataType field and now it builds and all tests
pass.
