### PR TITLE
Ignore ApiParam.

### DIFF
--- a/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiParam.java
+++ b/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiParam.java
@@ -24,6 +24,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiParam {
+    /** Ignores parameter in documentation. */
+    boolean ignore() default false;
+
     /** Name of the parameter */
     String name() default "";
 

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
@@ -85,7 +85,10 @@ class JaxrsApiSpecParser(val _hostClass: Class[_], _apiVersion: String, _swagger
     var ignoreParam = false
     for (pa <- paramAnnotations) {
       pa match {
-        case apiParam: ApiParam => parseApiParam(docParam, apiParam, method)
+        case apiParam: ApiParam => {
+          ignoreParam = apiParam.ignore()
+          parseApiParam(docParam, apiParam, method)
+        }
         case wsParam: QueryParam => {
           docParam.name = readString(wsParam.value, docParam.name)
           docParam.paramType = readString(TYPE_QUERY, docParam.paramType)

--- a/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
+++ b/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
@@ -90,6 +90,7 @@ class JerseyApiSpecParser(val _hostClass: Class[_], _apiVersion: String, _swagge
     for (pa <- paramAnnotations) {
       pa match {
         case param: ApiParam => {
+          ignoreParam = param.ignore()
           parseApiParam(docParam, param, method)
         }
         case param: QueryParam => {

--- a/modules/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
+++ b/modules/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
@@ -178,7 +178,10 @@ private class PlayApiSpecParser(_hostClass: Class[_], _apiVersion: String, _swag
     var ignoreParam = false
     for (pa <- paramAnnotations) {
       pa match {
-        case apiParam: ApiParam => parseApiParam(docParam, apiParam, method)
+        case apiParam: ApiParam => {
+          ignoreParam = apiParam.ignore()
+          parseApiParam(docParam, apiParam, method)
+        }
         case wsParam: QueryParam => {
           docParam.name = readString(wsParam.value, docParam.name)
           docParam.paramType = readString(TYPE_QUERY, docParam.paramType)


### PR DESCRIPTION
There are several scenarios which may necessitate a parameter to be excluded from the documentation.

This works by adding an "ignore" flag to the ApiParam annotation and then checking for it when creating the documentation.
