### PR TITLE
Scope slf4j-log4j12 to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -429,6 +429,7 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <version>${slf4j-version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
This lets consumers of this library choose whatever slf4j binding they wish.
As it is right now, this example project:
https://github.com/scalatra/scalatra-website-examples/tree/master/2.2/swagger-example
on startup gives an slf4j warning about multiple bindings on the classpath (log4j and logback), then log4j complains about the lack of a config file, and nothing gets logged.
