### PR TITLE
Find Swagger annotations on interfaces and superclasses

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/listing/AnnotationResolver.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/listing/AnnotationResolver.scala
@@ -1,0 +1,26 @@
+package com.wordnik.swagger.jaxrs.listing
+
+import java.lang.annotation.Annotation
+
+/**
+ * Look for a particular annotation on a class and it's interfaces/superclasses
+ *
+ * @author jbaxter - 17/05/13
+ */
+object AnnotationResolver {
+  def getClassWithAnnotation(clazz: Class[_], annotation: Class[_ <: Annotation]): Class[_] = {
+    if (clazz.isAnnotationPresent(annotation)) {
+      return clazz
+    }
+    for (intf <- clazz.getInterfaces) {
+      if (intf.isAnnotationPresent(annotation)) {
+        return intf
+      }
+    }
+    val superClass: Class[_] = clazz.getSuperclass
+    if (superClass != classOf[AnyRef] && superClass != null) {
+      return getClassWithAnnotation(superClass, annotation)
+    }
+    null
+  }
+}

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/listing/ApiListing.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/listing/ApiListing.scala
@@ -27,19 +27,15 @@ object ApiListingResource {
     _cache match {
       case Some(cache) => cache
       case None => {
-        val resources = app.getClasses().asScala ++ app.getSingletons().asScala.map(ref => ref.getClass)
+        val resources = app.getClasses().asScala ++ app.getSingletons().asScala.map(ref => AnnotationResolver.getClassWithAnnotation(ref.getClass, classOf[Api])).filter(_ != null)
         val cache = new LinkedHashMap[String, Class[_]]
         resources.foreach(resource => {
-          resource.getAnnotation(classOf[Api]) match {
-            case ep: Annotation => {
-              val path = ep.value.startsWith("/") match {
-                case true => ep.value.substring(1)
-                case false => ep.value
-              }
-              cache += path -> resource
-            }
-            case _ => 
+          val api = resource.getAnnotation(classOf[Api])
+          val path = api.value.startsWith("/") match {
+            case true => api.value.substring(1)
+            case false => api.value
           }
+          cache += path -> resource
         })
         _cache = Some(cache)
         cache


### PR DESCRIPTION
Our rest endpoints are written in Scala and this change allowed us to put the swagger annotations on traits and keep the implementations clean.
