### PR TITLE
Recursive subresource detection, subresource detection of parent params.

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/reader/ClassReaders.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/reader/ClassReaders.scala
@@ -3,8 +3,14 @@ package com.wordnik.swagger.reader
 import com.wordnik.swagger.config._
 import com.wordnik.swagger.model._
 
+import java.lang.reflect.Method
+
+import scala.collection.mutable.ListBuffer
+
 trait ClassReader {
-  def read(docRoot: String, cls: Class[_], config: SwaggerConfig): Option[ApiListing]
+  def read(docRoot: String, parentPath: String, cls: Class[_], config: SwaggerConfig,
+           operations: ListBuffer[Tuple3[String, String, ListBuffer[Operation]]],
+           parentMethods: ListBuffer[Method]): Option[ApiListing]
 }
 
 object ClassReaders {

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
@@ -28,16 +28,28 @@ trait JaxrsApiReader extends ClassReader {
   // decorates a Parameter based on annotations, returns None if param should be ignored
   def processParamAnnotations(mutable: MutableParameter, paramAnnotations: Array[Annotation], method: Method): Option[Parameter]
 
-  def parseOperation(method: Method, apiOperation: ApiOperation, errorResponses: List[ErrorResponse], isDeprecated: String) = {
+  def parseOperation(method: Method, apiOperation: ApiOperation, errorResponses: List[ErrorResponse],
+                     isDeprecated: String, parentMethods: ListBuffer[Method]) = {
     val api = method.getAnnotation(classOf[Api])
     val responseClass = apiOperation.responseContainer match {
       case "" => apiOperation.response.getName
       case e: String => "%s[%s]".format(e, apiOperation.response.getName)
     }
 
-    val paramAnnotations = method.getParameterAnnotations
-    val paramTypes = method.getParameterTypes
-    val genericParamTypes = method.getGenericParameterTypes
+    var paramAnnotations: Array[Array[java.lang.annotation.Annotation]] = null
+    var paramTypes: Array[java.lang.Class[_]] = null
+    var genericParamTypes: Array[java.lang.reflect.Type] = null
+
+    if (parentMethods.isEmpty) {
+      paramAnnotations = method.getParameterAnnotations
+      paramTypes = method.getParameterTypes
+      genericParamTypes = method.getGenericParameterTypes
+    } else {
+      paramAnnotations = parentMethods.map(pm => pm.getParameterAnnotations).reduceRight(_ ++ _) ++ method.getParameterAnnotations
+      paramTypes = parentMethods.map(pm => pm.getParameterTypes).reduceRight(_ ++ _) ++ method.getParameterTypes
+      genericParamTypes = parentMethods.map(pm => pm.getGenericParameterTypes).reduceRight(_ ++ _) ++ method.getGenericParameterTypes
+    }
+
     val produces = apiOperation.produces match {
       case e: String if(e != "") => e.split(",").map(_.trim).toList
       case _ => List()
@@ -90,7 +102,7 @@ trait JaxrsApiReader extends ClassReader {
       Option(isDeprecated))
   }
 
-  def readMethod(method: Method) = {
+  def readMethod(method: Method, parentMethods: ListBuffer[Method]) = {
     val apiOperation = method.getAnnotation(classOf[ApiOperation])
     val errorAnnotations = method.getAnnotation(classOf[ApiErrors])
 
@@ -107,7 +119,7 @@ trait JaxrsApiReader extends ClassReader {
     }
     val isDeprecated = Option(method.getAnnotation(classOf[Deprecated])).map(m => "true").getOrElse(null)
 
-    parseOperation(method, apiOperation, errorResponses, isDeprecated)
+    parseOperation(method, apiOperation, errorResponses, isDeprecated, parentMethods)
   }
 
   def appendOperation(endpoint: String, path: String, op: Operation, operations: ListBuffer[Tuple3[String, String, ListBuffer[Operation]]]) = {
@@ -117,10 +129,11 @@ trait JaxrsApiReader extends ClassReader {
     }
   }
 
-  def read(docRoot: String, cls: Class[_], config: SwaggerConfig): Option[ApiListing] = {
+  def read(docRoot: String, parentPath: String, cls: Class[_], config: SwaggerConfig,
+           operations: ListBuffer[Tuple3[String, String, ListBuffer[Operation]]],
+           parentMethods: ListBuffer[Method]): Option[ApiListing] = {
     val api = cls.getAnnotation(classOf[Api])
     if(api != null) {
-      val operations = new ListBuffer[Tuple3[String, String, ListBuffer[Operation]]]()
       val description = api.description match {
         case e: String if(e != "") => Some(e)
         case _ => None
@@ -132,27 +145,18 @@ trait JaxrsApiReader extends ClassReader {
           case e: Path => e.value()
           case _ => ""
         }
+        val endpoint = parentPath + api.value + pathFromMethod(method)
         Option(returnType.getAnnotation(classOf[Api])) match {
           case Some(e) => {
-            // the return class has Api annotations, and should be parsed
-            for(submethod <- returnType.getMethods) {
-              if(submethod.getAnnotation(classOf[ApiOperation]) != null) {
-                val op = readMethod(submethod)
-                val endpoint = api.value + pathFromMethod(method)
-                val subpath = submethod.getAnnotation(classOf[Path]) match {
-                  case e: Path => e.value()
-                  case _ => ""
-                }
-                appendOperation(endpoint, path + subpath, op, operations)
-              }
-            }
+            val root = docRoot + api.value + pathFromMethod(method)
+            parentMethods += method
+            read(root, endpoint, returnType, config, operations, parentMethods)
           }
           case _ => {
             if(method.getAnnotation(classOf[ApiOperation]) != null) {
-              val op = readMethod(method)
-              val endpoint = api.value + pathFromMethod(method)
+              val op = readMethod(method, parentMethods)
               appendOperation(endpoint, path, op, operations)
-            }            
+            }
           }
         }
 
@@ -370,7 +374,7 @@ trait JaxrsApiReader extends ClassReader {
   }
 
   def parseHttpMethod(method: Method, op: ApiOperation): String = {
-    if (op.httpMethod() != null && op.httpMethod().trim().length() > 0) 
+    if (op.httpMethod() != null && op.httpMethod().trim().length() > 0)
       op.httpMethod().trim
     else {
       if(method.getAnnotation(classOf[GET]) != null) "GET"
@@ -411,13 +415,13 @@ class MutableParameter(param: Parameter) {
   def this() = this(null)
 
   def asParameter() = {
-    Parameter(name, 
-      description, 
-      defaultValue, 
-      required, 
-      allowMultiple, 
-      dataType, 
-      allowableValues, 
+    Parameter(name,
+      description,
+      defaultValue,
+      required,
+      allowMultiple,
+      dataType,
+      allowableValues,
       paramType,
       paramAccess)
   }

--- a/modules/swagger-jaxrs/src/test/scala/JaxrsApiReaderTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/JaxrsApiReaderTest.scala
@@ -5,6 +5,8 @@ import com.wordnik.swagger.core.util._
 import com.wordnik.swagger.model._
 import com.wordnik.swagger.config._
 
+import java.lang.reflect.Method
+
 import java.util.Date
 
 import org.junit.runner.RunWith
@@ -12,12 +14,16 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.matchers.ShouldMatchers
 
+import scala.collection.mutable.ListBuffer
+
 @RunWith(classOf[JUnitRunner])
 class BasicResourceTest extends FlatSpec with ShouldMatchers {
   it should "read an api and extract an error model" in {
     val reader = new DefaultJaxrsApiReader
     val config = new SwaggerConfig()
-    val apiResource = reader.read("/api-docs", classOf[BasicResource], config).getOrElse(fail("should not be None"))
+    val apiResource = reader.read("/api-docs", "", classOf[BasicResource], config,
+      new ListBuffer[Tuple3[String, String, ListBuffer[Operation]]](),
+      new ListBuffer[Method]()).getOrElse(fail("should not be None"))
 
     apiResource.apis.size should be (1)
     val api = apiResource.apis.head
@@ -62,7 +68,9 @@ class ContainerResourceTest extends FlatSpec with ShouldMatchers {
   it should "read an api" in {
     val reader = new DefaultJaxrsApiReader
     val config = new SwaggerConfig()
-    val apiResource = reader.read("/api-docs", classOf[ContainerResource], config).getOrElse(fail("should not be None"))
+    val apiResource = reader.read("/api-docs", "", classOf[ContainerResource], config,
+      new ListBuffer[Tuple3[String, String, ListBuffer[Operation]]](),
+      new ListBuffer[Method]()).getOrElse(fail("should not be None"))
     apiResource.apis.size should be (1)
     val api = apiResource.apis.head
     api.path should be ("/container/{id}")
@@ -99,7 +107,9 @@ class ModelExtractionTest extends FlatSpec with ShouldMatchers {
   it should "get the right models" in {
     val reader = new DefaultJaxrsApiReader
     val config = new SwaggerConfig()
-    val apiResource = reader.read("/api-docs", classOf[NestedModelResource], config).getOrElse(fail("should not be None"))
+    val apiResource = reader.read("/api-docs", "", classOf[NestedModelResource], config,
+      new ListBuffer[Tuple3[String, String, ListBuffer[Operation]]](),
+      new ListBuffer[Method]()).getOrElse(fail("should not be None"))
 
     val models = apiResource.models.getOrElse(fail("no models found"))
 


### PR DESCRIPTION
- If a subresource is detected, recursively check its methods for subresources.
- Params of a parent resource are not listed as params for a subresource. Make it so that PetResource and OwnerResource with url /pet/{petId}/owner would list {petId} as a param for OwnerResource.
