### PR TITLE
Support generic class in responseClass

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/Documentation.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/Documentation.scala
@@ -462,8 +462,12 @@ class DocumentationSchema {
     schema.required = required
     schema.name = name
     schema.id = id
+    if (properties == null) {
     schema.properties = new java.util.HashMap[String, DocumentationSchema]
-    // todo: clone
+    } else {
+      schema.properties = properties;
+    }
+
     schema.allowableValues = allowableValues
     schema.description = description
     schema.notes = notes

--- a/modules/swagger-jaxrs/src/test/scala/com/wordnik/test/swagger/core/testdata/ResourceWithGenerics.scala
+++ b/modules/swagger-jaxrs/src/test/scala/com/wordnik/test/swagger/core/testdata/ResourceWithGenerics.scala
@@ -46,6 +46,10 @@ class ReturnObject[T] {
   var theReturnObjectName: String = _
 }
 
+class ReturnObject2[T1,T2] {
+  var theReturnObjectName: String = _
+}
+
 @Path("/generics.json")
 @Api(value = "/generics", description = "generics resource")
 @Produces(Array("application/json"))
@@ -96,6 +100,20 @@ class ResourceWithGenerics {
   def getStringList() = {
     val out = new ReturnObject[DoubleValue]
     out.theReturnObjectName = "the return object"
+    Response.ok.entity(out).build
+  }
+
+  @GET
+  @Path("/genericReturnType2")
+  @ApiOperation(value = "Get object2 by ID",
+    notes = "No details provided",
+    responseClass = "com.wordnik.test.swagger.core.testdata.ReturnObject2<com.wordnik.test.swagger.core.testdata.DoubleValue,com.wordnik.test.swagger.core.testdata.IntValue>")
+  @ApiErrors(Array(
+    new ApiError(code = 400, reason = "Invalid ID"),
+    new ApiError(code = 404, reason = "object not found")))
+  def getStringList2() = {
+    val out = new ReturnObject2[DoubleValue, IntValue]
+    out.theReturnObjectName = "the return object 2"
     Response.ok.entity(out).build
   }
 }

--- a/modules/swagger-jaxrs/src/test/scala/com/wordnik/test/swagger/jaxrs/ResourceReaderTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/com/wordnik/test/swagger/jaxrs/ResourceReaderTest.scala
@@ -173,20 +173,9 @@ class ResourceReaderTest extends FlatSpec with ShouldMatchers {
       null,
       null)
 
-    ((for(api <- doc.getApis) yield api.path).toSet
-       &
-     Set(
-       "/generics.{format}/genericReturnType",
-       "/generics.{format}/{id}",
-       "/generics.{format}")).size should be (3)
+    ((for(api <- doc.getApis) yield api.path).toSet).size should be (4)
 
-    ((for(model <- doc.getModels) yield model._1).toSet
-      &
-    Set(
-      "Path_Object",
-      "Post_Object",
-      "Return_Object"
-    )).size should be (3)
+    ((for(model <- doc.getModels) yield model._1).toSet).size should be (7)
   }
 
   it should "support deep model hierarchy" in {


### PR DESCRIPTION
If `@ApiOperation.responseClass="foo.bar.A<foo.bar.B,foo.bar.C>"`, class `A`, `B`, and `C` will be added in doc.models in listing response, and the operation's `responseClass` will be rewrite as `A<B,C>`.
`B`, and `C` will be added in doc.models in listing response, and the operation's `responseClass` will be rewrite as `A<B,C>`
