### PR TITLE
SwaggerContext should try all of its registered classloaders

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/SwaggerContext.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/SwaggerContext.scala
@@ -22,10 +22,11 @@ object SwaggerContext {
       } catch {
         case e: ClassNotFoundException => {
           LOGGER.debug("Class %s not found in classLoader".format(name))
-          throw new ClassNotFoundException("class " + name + " not found")
         }
       }
     }
+    if (cls == null)
+      throw new ClassNotFoundException("class " + name + " not found")
     cls
   }
 }


### PR DESCRIPTION
A change added in https://github.com/wordnik/swagger-core/commit/a0cbb3a7a45e5aae9f6268f4d0bb601905c3d0f5 made it so if the first class loader can't find the class then it throws an exception and doesn't try the other class loaders in its list.
