### PR TITLE
Add to ApiListing.scala method to invalidate its cache; a must-have in an OSGI environment 

### DIFF
--- a/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/listing/ApiListing.scala
+++ b/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/listing/ApiListing.scala
@@ -46,6 +46,10 @@ object ApiListingResource {
       }
     }
   }
+  
+  def invalidateCache() = {
+    _cache = None
+  }
 }
 
 class ApiListing {
@@ -138,5 +142,9 @@ class ApiListing {
       }
       case _ => None
     }
+  }
+  
+  def invalidateCache() = {
+    ApiListingResource.invalidateCache()
   }
 }


### PR DESCRIPTION
Fixed an issue for OSGI runtime: in OSGI you need to invalidate cache each time a new OSGI component is added/removed, b/c some packages may contain updated information.

In OSGI, the specific ApiListingResource should be responsible to call `invalidateCache()`. I'm also pasting an OSGI component that makes this call:

```
/** Inspired from https://github.com/wordnik/swagger-core/wiki/java-jax-rs */
@Component(immediate = true, metatype = false)
@Service(value = { Object.class, ApiListing.class })
@Property(name = "javax.ws.rs.base", boolValue = true)

@References({
        @Reference(name = "component", referenceInterface = Object.class,
                target = "(javax.ws.rs=true)",
                cardinality = ReferenceCardinality.OPTIONAL_MULTIPLE,
                policy = ReferencePolicy.DYNAMIC) })

@Path("/api-docs.json")
@Api("/api-docs.json")
@Produces(MediaType.APPLICATION_JSON)
public class ApiListingResource extends ApiListing
{
    private static boolean initialized = false;

    public ApiListingResource()
    {
        if ( ! initialized ) {
            SwaggerContext.registerClassLoader(this.getClass().getClassLoader());
            initialized = true;
        }
    }

    protected void bindComponent(Object component) throws IOException,
            ServletException,
            NamespaceException
    {
        this.invalidateCache();
    }

    protected void unbindComponent(Object component) throws IOException,
            ServletException,
            NamespaceException
    {
        this.invalidateCache();
    }


}
```
