### PR TITLE
Ignoring @InjectParam annotation

### DIFF
--- a/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
+++ b/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
@@ -35,6 +35,7 @@ import java.lang.annotation.Annotation
 
 import com.sun.jersey.core.header.FormDataContentDisposition
 import com.sun.jersey.multipart.FormDataParam
+import com.sun.jersey.api.core.InjectParam
 
 class JerseyApiReader extends JaxrsApiReader {
   private val LOGGER = LoggerFactory.getLogger(classOf[JerseyApiReader])
@@ -87,6 +88,7 @@ class JerseyApiReader extends JaxrsApiReader {
         case e: DefaultValue => {
           mutable.defaultValue = Option(readString(e.value))
         }
+        case e: InjectParam => shouldIgnore = true
         case e: Context => shouldIgnore = true
         case _ =>
       }


### PR DESCRIPTION
The @InjectParam annotation is similar to @Context, but can pull from Spring or Guice or whatnot (whatever is plugged into Jersey).

Wasn't sure if you need a test case or a bug report.  If so, just let me know where to create those things.

Thanks Tony!
