### PR TITLE
Swagger only honors classes with alphabet characters

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/ModelUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/ModelUtil.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.{ ListBuffer, HashMap, HashSet }
 
 object ModelUtil {
   private val LOGGER = LoggerFactory.getLogger(ModelUtil.getClass)
-  val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-]*)\\].*".r
+  val ComplexTypeMatcher = "([\\w]*)\\[([\\w\\.\\-]*)\\].*".r
 
   def stripPackages(apis: List[ApiDescription]): List[ApiDescription] = {
     (for(api <- apis) yield {


### PR DESCRIPTION
Java class names and packages can potentially contain characters other than just alphabet characters (such as numeric characters).  This pull request patch allows Swagger to capture classes with regular expression "word" characters in their names and packages.
