### PR TITLE
Outstanding Minor Fixes

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
@@ -126,18 +126,16 @@ trait JaxrsApiReader extends ClassReader with ClassReaderUtils {
         param.dataType = processDataType(paramType, genericParamType)
         processParamAnnotations(param, annotations)
       }
-      else if(paramTypes.size > 0) {
-        //  it's a body param w/o annotations, which means POST.  Only take the first one!
-        val p = paramTypes.head
-
+      else /* If it doesn't have annotations, it must be a body parameter, and it's safe to assume that there will only
+              ever be one of these in the sequence according to JSR-339 JAX-RS 2.0 section 3.3.2.1. */
+      {
         val param = new MutableParameter
-        param.dataType = p.getName
+        param.dataType = paramType.getName
         param.name = TYPE_BODY
         param.paramType = TYPE_BODY
 
         Some(param.asParameter)
       }
-      else None
     }).flatten.toList
 
     val implicitParams = {

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
@@ -274,6 +274,7 @@ trait JaxrsApiReader extends ClassReader with ClassReaderUtils {
             val root = docRoot + api.value + pathFromMethod(method)
             parentMethods += method
             readRecursive(root, endpoint, returnType, config, operations, parentMethods)
+            parentMethods -= method
           }
           case _ => {
             if(method.getAnnotation(classOf[ApiOperation]) != null) {


### PR DESCRIPTION
**Use of Sub-resource Locator Results in Redundant Parameters**
Using of sub-resource locators in an API causes redundant parameters to appear in other operations of the main resource.  It is caused by pushing the sub-resource locator method of the main resource to a stack while recursively scanning through the sub-resource for operations and then neglecting to remove the sub-resource locator method from the stack after returning from recursion.

**Wrong Entity Parameter is Captured from Resource Method Parameters**
Unless the entity parameter (a method parameter without any annotations) is first of the method's formal parameter list, the wrong data type will be applied to the entity parameter.  Essentially, regardless of where the entity parameter occurs in the formal parameter list, the data type of the first formal parameter will be applied to it.  For example:

```Java
@Path("/{name}")
@PUT public Response updateCar(@PathParam("name") String name, Car newCarDetails)
{
...
}
```

In the above example the data type for _newCarDetails_ will be taken from the _name_ parameter and therefore will be cast as a _String_ type as opposed to a _Car_ type.  The simplest work-around is to swap the order of those two parameters, the following snippet works properly:

```Java
@Path("/{name}")
@PUT public Response updateCar(Car newCarDetails, @PathParam("name") String name)
{
...
}
```