### PR TITLE
Update swagger-core to return subType models for all dependencies and models defined in a Map

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelConverters.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelConverters.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable.{ ListBuffer, LinkedHashMap, HashSet, HashMap }
 
 object ModelConverters {
   private val LOGGER = LoggerFactory.getLogger(ModelConverters.getClass)
-  val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-]*)\\].*".r
+  val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-,]*)\\].*".r
 
   val converters = new ListBuffer[ModelConverter]() ++ List(
     new JodaDateTimeConverter,
@@ -57,7 +57,11 @@ object ModelConverters {
           case None => property.qualifiedType
         }
         val name = propertyName match {
-          case ComplexTypeMatcher(containerType, basePart) => basePart
+          case ComplexTypeMatcher(containerType, basePart) => {
+            if(basePart.indexOf(",") > 0) // handle maps, i.e. Map[String,String]
+              basePart.split("\\,").last.trim
+            else basePart
+          }
           case e: String => e
         }
         propertyNames += name

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelConverters.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelConverters.scala
@@ -39,22 +39,7 @@ object ModelConverters {
     var model = read(cls)
     val propertyNames = new HashSet[String]
 
-    // add subTypes
-    model.map(_.subTypes.map(typeRef => {
-      try{
-        LOGGER.debug("loading subtype " + typeRef)
-        val cls = SwaggerContext.loadClass(typeRef)
-        read(cls) match {
-          case Some(model) => output += cls.getName -> model
-          case _ =>
-        }
-      }
-      catch {
-        case e: Exception => LOGGER.error("can't load class " + typeRef)
-      }
-    }))
-
-    // add properties
+    // add properties and sub types
     model.map(m => {
       output += cls.getName -> m
       val checkedNames = new HashSet[String]
@@ -77,6 +62,22 @@ object ModelConverters {
         }
         propertyNames += name
       }
+
+      // add subTypes
+      for(typeRef <- model.subTypes) {
+        try{
+          LOGGER.debug("loading subtype " + typeRef)
+          val cls = SwaggerContext.loadClass(typeRef)
+          read(cls) match {
+            case Some(model) => propertyNames += cls.getName
+            case _ =>
+          }
+        }
+        catch {
+          case e: Exception => LOGGER.error("can't load class " + typeRef)
+        }
+      }
+
       for(typeRef <- propertyNames) {
         if(ignoredPackages.contains(getPackage(typeRef))) None
         else if(ignoredClasses.contains(typeRef)) None
@@ -94,7 +95,7 @@ object ModelConverters {
             }
           }
           catch {
-            case e: ClassNotFoundException => 
+            case e: ClassNotFoundException =>
           }
         }
       }

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
@@ -9,8 +9,8 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.LinkedHashMap
 
-class SwaggerSchemaConverter 
-  extends ModelConverter 
+class SwaggerSchemaConverter
+  extends ModelConverter
   with BaseConverter {
 
   def read(cls: Class[_]): Option[Model] = {
@@ -19,7 +19,7 @@ class SwaggerSchemaConverter
         implicit val properties = new LinkedHashMap[String, ModelProperty]()
         new ModelPropertyParser(cls).parse
 
-        val p = (for((key, value) <- properties) 
+        val p = (for((key, value) <- properties)
           yield (value.position, key, value)
         ).toList
 
@@ -31,17 +31,21 @@ class SwaggerSchemaConverter
           case _ => None
         }
         val discriminator = {
-          val v = 
-            if(cls.getAnnotation(classOf[ApiModel]) != null)
+          val v =
+            if(cls.getAnnotation(classOf[ApiModel]) != null
+                && cls.getAnnotation(classOf[ApiModel]).discriminator != null
+                && !cls.getAnnotation(classOf[ApiModel]).discriminator.isEmpty())
               cls.getAnnotation(classOf[ApiModel]).discriminator
-            else if(cls.getAnnotation(classOf[JsonTypeInfo]) != null)
+            else if(cls.getAnnotation(classOf[JsonTypeInfo]) != null && cls.getAnnotation(classOf[JsonTypeInfo]).property != null)
               cls.getAnnotation(classOf[JsonTypeInfo]).property
             else ""
           if(v != null && v != "") Some(v)
           else None
         }
         val subTypes = {
-          if(cls.getAnnotation(classOf[ApiModel]) != null)
+          if(cls.getAnnotation(classOf[ApiModel]) != null
+              && cls.getAnnotation(classOf[ApiModel]).subTypes != null
+              && cls.getAnnotation(classOf[ApiModel]).subTypes.length > 0)
             cls.getAnnotation(classOf[ApiModel]).subTypes.map(_.getName).toList
           else if(cls.getAnnotation(classOf[JsonSubTypes]) != null)
             (for(subType <- cls.getAnnotation(classOf[JsonSubTypes]).value) yield (subType.value.getName)).toList

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/ModelUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/ModelUtil.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.{ ListBuffer, HashMap, HashSet }
 
 object ModelUtil {
   private val LOGGER = LoggerFactory.getLogger(ModelUtil.getClass)
-  val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-]*)\\].*".r
+  val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-,]*)\\].*".r
 
   def stripPackages(apis: List[ApiDescription]): List[ApiDescription] = {
     (for(api <- apis) yield {
@@ -157,9 +157,9 @@ object ModelUtil {
       toName(xmlEnum.value())
     else if (xmlRootElement != null) {
       if ("##default".equals(xmlRootElement.name())) {
-        cls.getSimpleName 
+        cls.getSimpleName
       } else {
-        xmlRootElement.name() 
+        xmlRootElement.name()
       }
     } else if (cls.getName.startsWith("java.lang.")) {
       val name = cls.getName.substring("java.lang.".length)
@@ -168,7 +168,7 @@ object ModelUtil {
       else name
     }
     else if (cls.getName.indexOf(".") < 0) cls.getName
-    else cls.getSimpleName 
+    else cls.getSimpleName
   }
 
   def shoudIncludeModel(modelname: String) = {

--- a/modules/swagger-core/src/test/scala/converter/JacksonSubTypeModelTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/JacksonSubTypeModelTest.scala
@@ -31,11 +31,12 @@ class JacksonSubTypeModelTest extends FlatSpec with ShouldMatchers {
     val model = ModelConverters.read(classOf[JAnimal]).getOrElse(fail("no model found"))
     model.subTypes.size should be (2)
 
-    write(model) should be ("""{"id":"JAnimal","discriminator":"type","properties":{"type":{"type":"string","description":"type of animal"},"date":{"type":"string","format":"date-time","description":"Date added to the zoo"}},"subTypes":["JWildAnimal","JDomesticAnimal"]}""")
+    write(model) should be ("""{"id":"JAnimal","description":"Animal desc","discriminator":"type","properties":{"type":{"type":"string","description":"type of animal"},"date":{"type":"string","format":"date-time","description":"Date added to the zoo"}},"subTypes":["JWildAnimal","JDomesticAnimal"]}""")
 
 /*
 {
   "id": "JAnimal",
+  "description":"Animal desc",
   "discriminator": "type",
   "properties": {
     "type": {

--- a/modules/swagger-core/src/test/scala/converter/ModelPropertyTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/ModelPropertyTest.scala
@@ -22,7 +22,7 @@ class ModelPropertyTest extends FlatSpec with ShouldMatchers {
   it should "extract properties" in {
     val models = ModelConverters.readAll(classOf[Family])
 
-    models.size should be (3)
+    models.size should be (4)
     val person = models.filter(m => m.name == "Person").head
     val employer = person.properties("employer")
 
@@ -34,6 +34,11 @@ class ModelPropertyTest extends FlatSpec with ShouldMatchers {
     awards.`type` should be ("List")
     val awardItems = awards.items.getOrElse(fail("no items found"))
     awardItems.`type` should be ("string")
+
+    val phonebook = person.properties("phonebook")
+    phonebook.`type` should be ("Map[string,Contact]")
+    val contactModel = models.filter(m => m.name == "Contact").head
+    contactModel.name should be ("Contact")
   }
 
   it should "extract a primitive array" in {
@@ -58,14 +63,20 @@ class ModelPropertyTest extends FlatSpec with ShouldMatchers {
 case class Family (membersSince: Date, members: List[Person])
 
 case class Person (
-  firstname: String, 
-  lastname: String, 
-  middlename: Option[String], 
-  age: Int, 
+  firstname: String,
+  lastname: String,
+  middlename: Option[String],
+  age: Int,
   birthday: Date,
   employer: List[Employer],
-  awards: List[String])
+  awards: List[String],
+  phonebook: Map[String,Contact])
 
 case class Employer (
   name: String,
   size: Int)
+
+case class Contact (
+    name: String,
+    phonenumber: String,
+    email: String)

--- a/modules/swagger-core/src/test/scala/converter/SubTypeModelTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/SubTypeModelTest.scala
@@ -54,4 +54,81 @@ class SubTypeModelTest extends FlatSpec with ShouldMatchers {
 }
     */
   }
+
+  it should "read a model that has a field with subTypes" in {
+    val models = ModelConverters.readAll(classOf[Cage])
+    models.size should be (4)
+    println(write(models))
+    write(models) should be ("""[{"id":"Cage","properties":{"name":{"$ref":"Animal","description":"caged animal"}}},{"id":"Animal","description":"a model with subtypes","discriminator":"name","properties":{"name":{"type":"string","description":"name of animal"},"date":{"type":"string","format":"date-time","description":"date added"}},"subTypes":["DomesticAnimal","WildAnimal"]},{"id":"DomesticAnimal","properties":{"name":{"type":"string","description":"name of animal"},"safeForChildren":{"type":"boolean","description":"animals are safe for children"},"date":{"type":"string","format":"date-time","description":"date added"}}},{"id":"WildAnimal","properties":{"name":{"type":"string","description":"name of animal"},"foundInLocation":{"type":"string","description":"location found in"},"date":{"type":"string","format":"date-time","description":"date added"}}}]""")
+
+    /*
+  [
+    {
+      "id": "Cage",
+      "properties": {
+        "name": {
+          "$ref": "Animal",
+          "description": "caged animal"
+        }
+      }
+    },
+    {
+      "id": "Animal",
+      "description": "a model with subtypes",
+      "discriminator": "name",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of animal"
+        },
+        "date": {
+          "type": "string",
+          "format": "date-time",
+          "description": "date added"
+        }
+      },
+      "subTypes": [
+        "DomesticAnimal",
+        "WildAnimal"
+      ]
+    },
+    {
+      "id": "DomesticAnimal",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of animal"
+        },
+        "safeForChildren": {
+          "type": "boolean",
+          "description": "animals are safe for children"
+        },
+        "date": {
+          "type": "string",
+          "format": "date-time",
+          "description": "date added"
+        }
+      }
+    },
+    {
+      "id": "WildAnimal",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "name of animal"
+        },
+        "foundInLocation": {
+          "type": "string",
+          "description": "location found in"
+        },
+        "date": {
+          "type": "string",
+          "format": "date-time",
+          "description": "date added"
+        }
+      }
+    }
+  ]
+    */
+  }
 }

--- a/modules/swagger-core/src/test/scala/converter/models/JAnimal.java
+++ b/modules/swagger-core/src/test/scala/converter/models/JAnimal.java
@@ -1,15 +1,17 @@
 package converter.models;
 
-import com.wordnik.swagger.annotations.ApiModelProperty;
-
-import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
-
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
 @JsonTypeInfo( use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property="type" )
-@JsonSubTypes( { @Type( value = JWildAnimal.class, name = "wild" ), 
+@JsonSubTypes( { @Type( value = JWildAnimal.class, name = "wild" ),
                              @Type( value = JDomesticAnimal.class, name = "domestic" ) } )
+@ApiModel("Animal desc")
 public class JAnimal {
   private String type;
   private Date date;

--- a/modules/swagger-core/src/test/scala/converter/models/ModelWithSubTypes.scala
+++ b/modules/swagger-core/src/test/scala/converter/models/ModelWithSubTypes.scala
@@ -18,3 +18,6 @@ case class WildAnimal (
   @(ApiModelProperty @field)(value = "name of animal", position = 1) name: String,
   @(ApiModelProperty @field)(value = "location found in", position = 2) foundInLocation: String,
   @(ApiModelProperty @field)(value = "date added", position = 3) date: java.util.Date)
+
+case class Cage (
+  @(ApiModelProperty @field)(value = "caged animal", position = 1) name: Animal)


### PR DESCRIPTION
Hello,
I wanted to address a few things in my fork, mainly around supporting model sub types and thought it might be useful to push them back to the main project. 

My changes are:
1. Fix up the annotation handling for a model's discriminator and subType fields
2. Allow all sub type models to be included if they are referenced as a dependent field
3. Include the model for Map[String,MyModel] field types, so the value type of Map would be returned as a model as well (i.e. MyModel)

For 1) this is my fix for #360 so the annotation JsonTypeInfo.property plays nice with ApiModel.discriminator, and JsonSubTypes plays nices with ApiModel.subTypes

For 2) If I had the models

```
@ApiModel(value="a model with subtypes", discriminator = "name", subTypes = Array(classOf[DomesticAnimal], classOf[WildAnimal]))
case class Animal (
  @(ApiModelProperty @field)(value = "name of animal", position = 1) name: String,
  @(ApiModelProperty @field)(value = "date added", position = 2) date: java.util.Date)

case class DomesticAnimal (
  @(ApiModelProperty @field)(value = "name of animal", position = 1) name: String,
  @(ApiModelProperty @field)(value = "animals are safe for children", position = 2) safeForChildren: Boolean,
  @(ApiModelProperty @field)(value = "date added", position = 3) date: java.util.Date)

case class WildAnimal (
  @(ApiModelProperty @field)(value = "name of animal", position = 1) name: String,
  @(ApiModelProperty @field)(value = "location found in", position = 2) foundInLocation: String,
  @(ApiModelProperty @field)(value = "date added", position = 3) date: java.util.Date)

case class Cage (
  @(ApiModelProperty @field)(value = "caged animal", position = 1) name: Animal)
```

Where I have a polymorphic field in Cage, and Cage is my top level model, then the sub type models for Animal were not generated. Maybe this is by design to prevent too many models, but for our purposes we wanted to include these sub types. bca90dacca7e655b470cfbb80e60339cac42dfb4 is my attempt to enhance this.

For 3) I also wanted the value type for maps to be included as well. Previously if we had a model with the field

```
myMap: Map[String, MyModel]
```

Then MyModel was not being included in the API listing models. I tried to enhance this as well.
