### PR TITLE
Use the correct body type for methods without ApiParam annotations

### DIFF
--- a/modules/swagger-jaxrs/src/test/scala/ResourceWithoutApiParamsTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/ResourceWithoutApiParamsTest.scala
@@ -1,0 +1,49 @@
+import com.wordnik.swagger.jaxrs.reader._
+import com.wordnik.swagger.core.util._
+import com.wordnik.swagger.config._
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+import testresources.ResourceWithoutApiParams
+
+@RunWith(classOf[JUnitRunner])
+class ResourceWithoutApiParamsTest extends FlatSpec with ShouldMatchers {
+  it should "read an API without ApiParam annotations" in {
+    val reader = new DefaultJaxrsApiReader
+    val config = new SwaggerConfig()
+    val apiResource = reader.read("/api-docs", classOf[ResourceWithoutApiParams], config).getOrElse(fail("should not be None"))
+    println(JsonSerializer.asJson(apiResource))
+    apiResource.apis.size should be (1)
+    val api = apiResource.apis.head
+    api.path should be ("/withoutApiParams/{id}")
+
+    val ops = api.operations
+    ops.size should be (2)
+
+    val getOp = ops(0)
+    getOp.method should be ("GET")
+    getOp.parameters.size should be (1)
+
+    val getParam = getOp.parameters(0)
+    getParam.name should be ("id")
+    getParam.dataType should be ("string")
+    getParam.required should be (false)
+    getParam.defaultValue should be (Some("1"))
+
+    val putOp = ops(1)
+    putOp.method should be ("PUT")
+    putOp.parameters.size should be (2)
+
+    val putParam1 = putOp.parameters(0)
+    putParam1.name should be ("id")
+    putParam1.dataType should be ("string")
+    putParam1.required should be (false)
+
+    val putParam2 = putOp.parameters(1)
+    putParam2.name should be ("body")
+    putParam2.dataType should be ("Howdy")
+    putParam2.required should be (false)
+  }
+}

--- a/modules/swagger-jaxrs/src/test/scala/testresources/ResourceWithoutApiParams.scala
+++ b/modules/swagger-jaxrs/src/test/scala/testresources/ResourceWithoutApiParams.scala
@@ -1,0 +1,39 @@
+package testresources
+
+import testmodels._
+import com.wordnik.swagger.annotations._
+
+import javax.ws.rs._
+import javax.ws.rs.core.Response
+
+
+@Path("/withoutApiParams")
+@Api(value = "/withoutApiParams", description = "Resource without ApiParam annotations")
+class ResourceWithoutApiParams {
+  @GET
+  @Path("/{id}")
+  @ApiOperation(value = "Get object by ID",
+    notes = "No details provided",
+    response = classOf[Sample],
+    position = 0)
+  @ApiResponses(Array(
+    new ApiResponse(code = 400, message = "Invalid ID", response = classOf[NotFoundModel]),
+    new ApiResponse(code = 404, message = "object not found")))
+  def getTest(@DefaultValue("1") @QueryParam("id") id: String) = {
+    val out = new Sample
+    out.name = "foo"
+    out.value = "bar"
+    Response.ok.entity(out).build
+  }
+
+  @PUT
+  @Path("/{id}")
+  @ApiOperation(value = "Update by ID",
+    notes = "No details provided",
+    position = 1)
+  @ApiResponses(Array(
+    new ApiResponse(code = 400, message = "Invalid ID"),
+    new ApiResponse(code = 404, message = "object not found")))
+  def updateTest(@QueryParam("id") id: String, sample: Sample) = {
+  }
+}


### PR DESCRIPTION
In JAX-RS, the body is bound to the first unannotated parameter of a resource method.  Swagger attempts to cope with this by looking up the type of this parameter, but it gets this wrong, choosing instead the type of the first parameter to the method (which could be, for example, a PathParam).  It will also add multiple copies if there is more than one unannotated parameter.

This doesn't happen if the body is annotated in any way (for example, with @ApiParam).

This pull request contains a test to reproduce the problem, and a fix.
