### PR TITLE
Added non-working sample test for JBoss7 with empty web.xml

### DIFF
--- a/samples/jboss7-empty-web-xml/pom.xml
+++ b/samples/jboss7-empty-web-xml/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+   <modelVersion>4.0.0</modelVersion>
+   <groupId>com.wordnik</groupId>
+   <artifactId>jboss7-empty-web-xml_2.10</artifactId>
+   <name>jboss7-empty-web-xml</name>
+   <version>1.3.1</version>
+   <packaging>pom</packaging>
+
+   <modules>
+      <module>sample-ear</module>
+      <module>sample-war</module>
+   </modules>
+
+   <dependencyManagement>
+      <dependencies>
+         <dependency>
+            <groupId>org.jboss.spec</groupId>
+            <artifactId>jboss-javaee-6.0</artifactId>
+            <version>3.0.0.Final</version>
+            <type>pom</type>
+            <scope>provided</scope>
+         </dependency>
+
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jaxrs</artifactId>
+            <version>2.3.3.Final</version>
+            <scope>provided</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson-provider</artifactId>
+            <version>2.3.3.Final</version>
+            <scope>provided</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.2</version>
+            <scope>provided</scope>
+         </dependency>
+
+         <dependency>
+            <groupId>com.wordnik</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.3.1</version>
+         </dependency>
+         <dependency>
+            <groupId>com.wordnik</groupId>
+            <artifactId>swagger-core_2.10</artifactId>
+            <version>1.3.1</version>
+         </dependency>
+         <dependency>
+            <groupId>com.wordnik</groupId>
+            <artifactId>swagger-jaxrs_2.10</artifactId>
+            <version>1.3.1</version>
+         </dependency>
+      </dependencies>
+   </dependencyManagement>
+</project>

--- a/samples/jboss7-empty-web-xml/sample-ear/pom.xml
+++ b/samples/jboss7-empty-web-xml/sample-ear/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <parent>
+      <groupId>com.wordnik</groupId>
+      <artifactId>jboss7-empty-web-xml_2.10</artifactId>
+      <version>1.3.1</version>
+   </parent>
+   <modelVersion>4.0.0</modelVersion>
+
+   <artifactId>jboss7-empty-web-xml_2.10-ear</artifactId>
+   <packaging>ear</packaging>
+
+   <build>
+      <plugins>
+         <plugin>
+            <artifactId>maven-ear-plugin</artifactId>
+            <configuration>
+               <displayName>Sample no-webxml JBoss7 test</displayName>
+               <filtering>true</filtering>
+               <workDirectory>${project.build.directory}/exploded/${project.artifactId}.ear</workDirectory>
+               <version>6</version>
+               <defaultLibBundleDir>lib</defaultLibBundleDir>
+               <generateApplicationXml>true</generateApplicationXml>
+               <modules>
+                  <webModule>
+                     <groupId>com.wordnik</groupId>
+                     <artifactId>jboss7-empty-web-xml_2.10-war</artifactId>
+                     <contextRoot>sample</contextRoot>
+                     <bundleFileName>sample-no-webxml-rest.war</bundleFileName>
+                  </webModule>
+               </modules>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+
+   <dependencies>
+      <dependency>
+         <groupId>com.wordnik</groupId>
+         <artifactId>jboss7-empty-web-xml_2.10-war</artifactId>
+         <version>${project.version}</version>
+         <type>war</type>
+      </dependency>
+   </dependencies>
+</project>

--- a/samples/jboss7-empty-web-xml/sample-ear/src/main/application/META-INF/jboss-app.xml
+++ b/samples/jboss7-empty-web-xml/sample-ear/src/main/application/META-INF/jboss-app.xml
@@ -1,0 +1,4 @@
+<jboss-app xmlns="http://www.jboss.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           version="7.0">
+</jboss-app>

--- a/samples/jboss7-empty-web-xml/sample-ear/src/main/application/META-INF/jboss-deployment-structure.xml
+++ b/samples/jboss7-empty-web-xml/sample-ear/src/main/application/META-INF/jboss-deployment-structure.xml
@@ -1,0 +1,11 @@
+<jds:jboss-deployment-structure xmlns:jds="urn:jboss:deployment-structure:1.2">
+   <sub-deployment name="sample-no-webxml-rest.war">
+      <module-alias name="deployment.sample-no-webxml-rest" />
+      <dependencies>
+         <module name="org.jboss.resteasy.resteasy-jaxrs" />
+         <module name="org.jboss.resteasy.resteasy-jackson-provider" />
+         <module name="org.codehaus.jackson.jackson-jaxrs" />
+         <module name="org.codehaus.jackson.jackson-mapper-asl" />
+      </dependencies>
+   </sub-deployment>
+</jds:jboss-deployment-structure>

--- a/samples/jboss7-empty-web-xml/sample-war/pom.xml
+++ b/samples/jboss7-empty-web-xml/sample-war/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <parent>
+      <groupId>com.wordnik</groupId>
+      <artifactId>jboss7-empty-web-xml_2.10</artifactId>
+      <version>1.3.1</version>
+   </parent>
+   <modelVersion>4.0.0</modelVersion>
+
+   <artifactId>jboss7-empty-web-xml_2.10-war</artifactId>
+   <packaging>war</packaging>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.jboss.spec</groupId>
+         <artifactId>jboss-javaee-6.0</artifactId>
+         <type>pom</type>
+         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.resteasy</groupId>
+         <artifactId>resteasy-jaxrs</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.jboss.resteasy</groupId>
+         <artifactId>resteasy-jackson-provider</artifactId>
+         <scope>provided</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.codehaus.jackson</groupId>
+         <artifactId>jackson-mapper-asl</artifactId>
+         <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>com.wordnik</groupId>
+         <artifactId>swagger-annotations</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>com.wordnik</groupId>
+         <artifactId>swagger-core_2.10</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>com.wordnik</groupId>
+         <artifactId>swagger-jaxrs_2.10</artifactId>
+      </dependency>
+   </dependencies>
+</project>

--- a/samples/jboss7-empty-web-xml/sample-war/src/main/java/sample/swagger/nowebxml/SampleApplication.java
+++ b/samples/jboss7-empty-web-xml/sample-war/src/main/java/sample/swagger/nowebxml/SampleApplication.java
@@ -1,0 +1,23 @@
+package sample.swagger.nowebxml;
+
+import com.wordnik.swagger.jaxrs.config.BeanConfig;
+import sample.swagger.nowebxml.resource.LowercaseResource;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath( "/api" )
+public class SampleApplication
+   extends Application
+{
+   public SampleApplication ()
+   {
+      System.out.println( "Initializing SampleApplication" );
+      BeanConfig beanConfig = new BeanConfig();
+      beanConfig.setVersion( "1.0" );
+      beanConfig.setResourcePackage( LowercaseResource.class.getPackage().getName() );
+      beanConfig.setBasePath( "http://localhost:9080/sample/api" );
+      beanConfig.setDescription( "Sample RESTful resources" );
+      beanConfig.setTitle( "Sample RESTful API" );
+      beanConfig.setScan( true );   }
+}

--- a/samples/jboss7-empty-web-xml/sample-war/src/main/java/sample/swagger/nowebxml/resource/LowercaseResource.java
+++ b/samples/jboss7-empty-web-xml/sample-war/src/main/java/sample/swagger/nowebxml/resource/LowercaseResource.java
@@ -1,0 +1,38 @@
+package sample.swagger.nowebxml.resource;
+
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.Arrays;
+import java.util.List;
+
+@Path("/lowercase")
+@Api(value = "/lowercase", description = "Sample Lowercase RESTful service")
+public class LowercaseResource
+{
+   @GET
+   @Path("/")
+   @Produces(MediaType.APPLICATION_JSON)
+   @ApiOperation(value = "Get static lowercase messages")
+   public List<String> getLowercaseMessages ()
+   {
+      return Arrays.asList( "lowercase", "messages" );
+   }
+
+   @GET
+   @Path("/{message}")
+   @Produces(MediaType.APPLICATION_JSON)
+   @ApiOperation(value = "Get lowercase message")
+   public String getLowercaseMessage (
+      @ApiParam(required = true, name = "message")
+      @PathParam("message") String message )
+   {
+      return message.toLowerCase();
+   }
+}

--- a/samples/jboss7-empty-web-xml/sample-war/src/main/java/sample/swagger/nowebxml/resource/UppercaseResource.java
+++ b/samples/jboss7-empty-web-xml/sample-war/src/main/java/sample/swagger/nowebxml/resource/UppercaseResource.java
@@ -1,0 +1,38 @@
+package sample.swagger.nowebxml.resource;
+
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.Arrays;
+import java.util.List;
+
+@Path("/uppercase")
+@Api(value = "/uppercase", description = "Sample Uppercase RESTful service")
+public class UppercaseResource
+{
+   @GET
+   @Path("/")
+   @Produces(MediaType.APPLICATION_JSON)
+   @ApiOperation(value = "Get static uppercase messages")
+   public List<String> getUppercaseMessages ()
+   {
+      return Arrays.asList( "UPPERCASE", "MESSAGES" );
+   }
+
+   @GET
+   @Path("/{message}")
+   @Produces(MediaType.APPLICATION_JSON)
+   @ApiOperation(value = "Get uppercase message")
+   public String getUppercaseMessage (
+      @ApiParam(required = true, name = "message")
+      @PathParam("message") String message )
+   {
+      return message.toUpperCase();
+   }
+}

--- a/samples/jboss7-empty-web-xml/sample-war/src/main/webapp/WEB-INF/web.xml
+++ b/samples/jboss7-empty-web-xml/sample-war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+                             http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0">
+</web-app>


### PR DESCRIPTION
A non-working sample using JBoss7 and RESTEasy with an empty web.xml file per issue https://github.com/wordnik/swagger-core/issues/412

Everything starts up fine, you can hit the resources (ie: localhost:port/sample/api/lowercase) and api-docs returns some information which does not include the Api resources.