### PR TITLE
Handle subresource locators with return type Class

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
@@ -26,6 +26,10 @@ trait JaxrsApiReader extends ClassReader with ClassReaderUtils {
   // decorates a Parameter based on annotations, returns None if param should be ignored
   def processParamAnnotations(mutable: MutableParameter, paramAnnotations: Array[Annotation]): Option[Parameter]
 
+  // Finds the type of the subresource this method produces, in case it's a subresource locator
+  // In case it's not a subresource locator the entity type is returned
+  def findSubresourceType(method: Method): Class[_]
+
   def processDataType(paramType: Class[_], genericParamType: Type) = {
     paramType.getName match {
       case "[I" => "Array[int]"
@@ -261,7 +265,7 @@ trait JaxrsApiReader extends ClassReader with ClassReaderUtils {
       ).flatten.toList
 
       for(method <- cls.getMethods) {
-        val returnType = method.getReturnType
+        val returnType = findSubresourceType(method)
         val path = method.getAnnotation(classOf[Path]) match {
           case e: Path => e.value()
           case _ => ""

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/reader/DefaultJaxrsReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/reader/DefaultJaxrsReader.scala
@@ -59,4 +59,8 @@ class DefaultJaxrsApiReader extends JaxrsApiReader {
     }
     else None
   }
+
+  def findSubresourceType(method: Method): Class[_] = {
+    method.getReturnType
+  }
 }

--- a/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
+++ b/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
@@ -102,5 +102,9 @@ class JerseyApiReader extends JaxrsApiReader {
     }
     else None
   }
+
+  def findSubresourceType(method: Method): Class[_] = {
+    method.getReturnType
+  }
 }
 

--- a/modules/swagger-jersey2-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
+++ b/modules/swagger-jersey2-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory
 import javax.ws.rs._
 import core.Context
 
-import java.lang.reflect.{ Type, Field, Modifier, Method }
+import java.lang.reflect.{ ParameterizedType, Type, Field, Modifier, Method }
 import java.lang.annotation.Annotation
 
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition
@@ -96,6 +96,22 @@ class JerseyApiReader extends JaxrsApiReader {
       Some(mutable.asParameter)
     }
     else None
+  }
+
+  def findSubresourceType(method: Method): Class[_] = {
+    method.getGenericReturnType match {
+      case c: Class[_] => c
+      case pt: ParameterizedType =>
+        val typeArguments = pt.getActualTypeArguments
+        if (pt.getRawType.equals(classOf[Class[_]]) && typeArguments.length == 1)
+          typeArguments(0) match {
+            case c: Class[_] => c
+            case _ => method.getReturnType
+          }
+        else
+          method.getReturnType
+      case _ => method.getReturnType
+    }
   }
 }
 

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/SubresourceClassLocatorTest.scala
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/SubresourceClassLocatorTest.scala
@@ -1,0 +1,19 @@
+import com.wordnik.swagger.jersey.JerseyApiReader
+import testresources._
+import com.wordnik.swagger.config._
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+
+@RunWith(classOf[JUnitRunner])
+class SubresourceClassLocatorTest extends FlatSpec with ShouldMatchers {
+  it should "find a class subresource" in {
+    val reader = new JerseyApiReader
+    val config = new SwaggerConfig()
+    val apiResource = reader.read("/api-docs", classOf[SubresourceLocatorParentTest], config).getOrElse(fail("should not be None"))
+
+    apiResource.apis should (have length 1)
+  }
+}

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/testresources/SubresourceLocatorChildTest.scala
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/testresources/SubresourceLocatorChildTest.scala
@@ -1,0 +1,19 @@
+package testresources
+
+import com.wordnik.swagger.annotations._
+
+import javax.ws.rs._
+import javax.ws.rs.core.Response
+
+@Api(value = "/child",
+  description = "Media Type Test",
+  produces = "application/json; charset=utf8",
+  protocols = "http, https")
+class SubresourceLocatorChildTest {
+  @GET
+  @ApiOperation(value = "Return a string",
+    notes = "No details provided",
+    position = 0)
+  def getTest =
+    Response.ok.entity("ok").build
+}

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/testresources/SubresourceLocatorParentTest.scala
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/testresources/SubresourceLocatorParentTest.scala
@@ -1,0 +1,20 @@
+package testresources
+
+import com.wordnik.swagger.core._
+import com.wordnik.swagger.annotations._
+
+import javax.ws.rs._
+import javax.ws.rs.core.{Response, MediaType}
+
+import javax.xml.bind.annotation._
+
+import scala.reflect.BeanProperty
+import javax.ws.rs.core.{MediaType, Response}
+
+@Path("/parent")
+@Api(value = "/parent",
+  description = "Subresource Class Locator Test")
+class SubresourceLocatorParentTest {
+  @Path("/child")
+  def subresourceLocator = classOf[SubresourceLocatorChildTest]
+}


### PR DESCRIPTION
This is an extension to the JAX-RS 2.0 standard supported by jersey.
Subresource locators can return a Class<?> in which case the subresource will
be managed by jersey. See section 3.3 of the jersey 2.5 documentation.

https://jersey.java.net/documentation/latest/user-guide.html#d0e2081 (example 3.21)
