### PR TITLE
Put fields in order that were declared in class

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
@@ -24,9 +24,12 @@ class SwaggerSchemaConverter
         val newProperties = mutable.Buffer.empty[(String, ModelProperty)]
         cls.getDeclaredFields.filter(field => Modifier.isPrivate(field.getModifiers)).map(_.getName).flatMap { field =>
           properties.get(field).map { value =>
+            properties -= field
             newProperties += field -> value
           }
         }
+
+        newProperties ++= properties
 
         val p = (for((key, value) <- newProperties.reverse)
           yield (value.position, key, value)


### PR DESCRIPTION
It's quite annoying when you have to specialize fields order in bean classes. Mostly they are declared in order that we want to have in API. I know that I'm using getDeclaredFields method that does not guarantee order due to documentation but I've found that this note is legacy.

The origin of my pull request is that I wanted to have my case class' fields in API in the same order that were declared. Because case class is mostly generated by in compilation process methods that are used to get access to fields are totally random order. I understand that swagger gets only public methods and fields so I wrote code that gets private fields and returns collection which contains presorted properties by order of those private fields. When you declare your own ordering using position parameter you will get new order of fields. So this modification does not break old APIs.
