### PR TITLE
Fix for @JsonProperty annotation

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -110,8 +110,11 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
     }
 
     try {
-      val fieldAnnotations = getDeclaredField(this.cls, name).getAnnotations()
+      val fieldAnnotations = getDeclaredField(this.cls, originalName).getAnnotations()
       var propAnnoOutput = processAnnotations(name, fieldAnnotations)
+      var fieldName = propAnnoOutput("name").asInstanceOf[String] 
+      if (fieldName != null) name =  fieldName 
+    
       var propPosition = propAnnoOutput("position").asInstanceOf[Int]
 
       if(allowableValues == None) 


### PR DESCRIPTION
1. Annotation from field are not read when @JsonProperty annotation is on getter, because it take name from annotation on getter and search for wrong field name.

Current model of parsing annotation on Model class is as follow:
- Read annotations from getter, if there is @JsonProperty replace getter name with value of annotation
- Read annotation from field. Field name is resolved from getter name or wrongly taken from value of @JsonProperty if it existed on getter,

Example:

```
@JsonProperty("access_token")
public String getAccessToken() {
 return accessToken;
}
```

It is try to find property with name access_token not accessToken.
1. It is not possible to use annotation @JsonProperty on field, only on method, because name from getter is resolved in first place:

```
@JsonProperty("access_token")
@ApiModelProperty(value = "The access token.", required = true)
private String accessToken;
```

I add patch which solve both problems.
