### PR TITLE
Support for Jackson field-renames-getter heuristic

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -93,6 +93,7 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
 
     var required = processedAnnotations("required").asInstanceOf[Boolean]
     var position = processedAnnotations("position").asInstanceOf[Int]
+    var renamed = (processedAnnotations("name").asInstanceOf[String] != processedAnnotations("originalName").asInstanceOf[String])
 
     var description = {
       if(processedAnnotations.contains("description") && processedAnnotations("description") != null)
@@ -113,6 +114,9 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
       val fieldAnnotations = getDeclaredField(this.cls, originalName).getAnnotations()
       var propAnnoOutput = processAnnotations(name, fieldAnnotations)
       var propPosition = propAnnoOutput("position").asInstanceOf[Int]
+
+      if(!renamed && propAnnoOutput("isJsonProperty").asInstanceOf[Boolean])
+        name = propAnnoOutput("name").asInstanceOf[String]
 
       if(allowableValues == None) 
         allowableValues = propAnnoOutput("allowableValues").asInstanceOf[Option[AllowableValues]]

--- a/modules/swagger-core/src/test/scala/converter/ModelPropertyParserTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/ModelPropertyParserTest.scala
@@ -26,4 +26,17 @@ class ModelPropertyParserTest extends FlatSpec with ShouldMatchers {
     val parser = new ModelPropertyParser(cls)
     parser.parse
   }
+
+  it should "mimic Jackson's field->method annotation inheritance" in {
+    val cls = classOf[ModelWithJacksonAnnotatedPrivateField]
+    implicit val properties = new scala.collection.mutable.LinkedHashMap[String, ModelProperty]
+    val parser = new ModelPropertyParser(cls)
+    parser.parse
+
+    properties.keySet.size should be (4)
+    properties.getOrElse("rawFieldProp", null) should not be (null)
+    properties.getOrElse("renamedJacksonProp", null) should not be (null)
+    properties.getOrElse("renamedJacksonMethod", null) should not be (null)
+    properties.getOrElse("fieldLevelJacksonProp", null) should not be (null)
+  }
 }

--- a/modules/swagger-core/src/test/scala/converter/models/ModelWithJacksonAnnotatedPrivateField.java
+++ b/modules/swagger-core/src/test/scala/converter/models/ModelWithJacksonAnnotatedPrivateField.java
@@ -1,0 +1,31 @@
+package converter.models;
+
+import com.fasterxml.jackson.annotation.*;
+
+public class ModelWithJacksonAnnotatedPrivateField {
+  
+  @JsonProperty("hiddenFieldLevelJacksonProp") private String hiddenFieldProp;
+  @JsonProperty public String rawFieldProp;
+  @JsonProperty("fieldLevelJacksonProp") public String renamableFieldProp;
+
+  @JsonProperty("renamedJacksonProp") private String renamableJackonProp;
+  @JsonProperty("renamedJacksonProp2") private String renamableJackonProp2;
+  @JsonIgnore private String ignoredJacksonProp;
+
+  public String getIgnoredJacksonProp() {
+    return ignoredJacksonProp;
+  }
+
+  public String getRenamableJackonProp() { 
+    return renamableJackonProp; 
+  }
+
+  @JsonProperty("renamedJacksonMethod") public String getRenamableJackonProp2() {
+    return renamableJackonProp2;
+  }
+
+  @JsonIgnore public String getIgnoredJacksonMethod() {
+    return "";
+  }
+
+}


### PR DESCRIPTION
Jackson supports the following behaviour:

```
public class Foo {
    @JsonProperty("renamed") private String foo;
    public String getFoo() { return foo; }    
}
```

When rendering JSON with Jackson, the `getFoo` method will correctly be interpreted as belonging to the marshalled "renamed" property.

Although support for `@JsonProperty` and `@JsonIgnore` were added in #321, the model parser was not respecting renames found at the field level after inspecting a corresponding public getter method. This patch is a fix. 

Apologies if any of the code is horribly naive - totally open to receiving feedback and making this PR better.
