### PR TITLE
Fix #468: Ignore bridge methods

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -57,7 +57,7 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
   }
 
   def parseMethod(method: Method) = {
-    if (method.getParameterTypes == null || method.getParameterTypes.length == 0) {
+    if ((method.getParameterTypes == null || method.getParameterTypes.length == 0) && !method.isBridge) {
       LOGGER.debug("processing method " + method)
       val returnClass = method.getReturnType
       parsePropertyAnnotations(returnClass, method.getName, method.getAnnotations, method.getGenericReturnType, method.getReturnType, false)
@@ -106,7 +106,7 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
     var isXmlElement = processedAnnotations("isXmlElement").asInstanceOf[Boolean]
     val isDocumented = processedAnnotations("isDocumented").asInstanceOf[Boolean]
     var allowableValues = {
-      if(returnClass.isEnum) 
+      if(returnClass.isEnum)
         Some(AllowableListValues((for(v <- returnClass.getEnumConstants) yield v.toString).toList))
       else
         processedAnnotations("allowableValues").asInstanceOf[Option[AllowableValues]]
@@ -121,9 +121,9 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
         name = propAnnoOutput("name").asInstanceOf[String]
       }
 
-      if(allowableValues == None) 
+      if(allowableValues == None)
         allowableValues = propAnnoOutput("allowableValues").asInstanceOf[Option[AllowableValues]]
-      if(description == None && propAnnoOutput.contains("description") && propAnnoOutput("description") != null) 
+      if(description == None && propAnnoOutput.contains("description") && propAnnoOutput("description") != null)
         description = Some(propAnnoOutput("description").asInstanceOf[String])
       if(propPosition != 0) position = propAnnoOutput("position").asInstanceOf[Int]
       if(required == false) required = propAnnoOutput("required").asInstanceOf[Boolean]
@@ -263,7 +263,7 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
           updatedName = readString(e.value, name)
           isJsonProperty = true
         }
-        case _ => 
+        case _ =>
       }
     }
     val output = new HashMap[String, Any]
@@ -408,7 +408,7 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
         else hostClass.getName
       } else if (xmlRootElement != null) {
         if ("##default".equals(xmlRootElement.name())) {
-          if (isSimple) hostClass.getSimpleName 
+          if (isSimple) hostClass.getSimpleName
           else hostClass.getName
         } else {
           if (isSimple) readString(xmlRootElement.name())

--- a/modules/swagger-core/src/test/scala/converter/CovariantGetterTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/CovariantGetterTest.scala
@@ -1,0 +1,28 @@
+package converter
+
+import converter.models._
+
+import com.wordnik.swagger.model._
+import com.wordnik.swagger.converter._
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+import converter.models.JCovariantGetter
+
+@RunWith(classOf[JUnitRunner])
+class CovariantGetterTest extends FlatSpec with ShouldMatchers {
+  implicit val formats = SwaggerSerializers.formats
+
+  it should "read a getter with covariant return type" in {
+    val model = ModelConverters.read(classOf[JCovariantGetter.Sub]).getOrElse(fail("no model found"))
+    val myProperty = model.properties.get("myProperty")
+    myProperty should not be (None)
+    myProperty.get.qualifiedType should be ("java.lang.Integer")
+    val myOtherProperty = model.properties.get("myOtherProperty")
+    myOtherProperty should not be (None)
+    myOtherProperty.get.qualifiedType should be ("java.lang.Integer")
+  }
+
+}

--- a/modules/swagger-core/src/test/scala/converter/models/JCovariantGetter.java
+++ b/modules/swagger-core/src/test/scala/converter/models/JCovariantGetter.java
@@ -1,0 +1,27 @@
+package converter.models;
+
+public abstract class JCovariantGetter {
+
+    public Object getMyProperty() {
+        return "42";
+    }
+
+    public Object getMyOtherProperty() {
+        return "42";
+    }
+
+    public static class Sub extends JCovariantGetter {
+
+        @Override
+        public Integer getMyProperty() {
+            return 42;
+        }
+
+        @Override
+        public Integer getMyOtherProperty() {
+            return 42;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Bridge methods created by the compiler should be ignored for property parsing
