### PR TITLE
Merge ApiListing in swagger-jersey2-jaxrs

### DIFF
--- a/modules/swagger-jersey2-jaxrs/src/main/scala/com/wordnik/swagger/jersey/listing/ApiListing.scala
+++ b/modules/swagger-jersey2-jaxrs/src/main/scala/com/wordnik/swagger/jersey/listing/ApiListing.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable.LinkedHashMap
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 
-object ApiListingCache {
+object ApiListingCache extends ReaderUtil {
   private val LOGGER = LoggerFactory.getLogger(ApiListingCache.getClass)
 
   var _cache: Option[Map[String, ApiListing]] = None
@@ -42,7 +42,8 @@ object ApiListingCache {
           }
           // For each top level resource, parse it and look for swagger annotations.
           val listings = (for(cls <- classes) yield reader.read(docRoot, cls, ConfigFactory.config)).flatten.toList
-          _cache = Some((listings.map(m => {
+          val mergedListings = groupByResourcePath(listings)
+          _cache = Some((mergedListings.map(m => {
             // always start with "/"
             val resourcePath = m.resourcePath.startsWith ("/") match {
               case true => m.resourcePath


### PR DESCRIPTION
If there are two @Api("myApis") annotation, the final ApiListing will
only show APIs from one class. The merge logic is available in
swagger-jaxrs. The change copied the logic from swagger-jaxrs.

Fix the issue: https://github.com/wordnik/swagger-core/issues/500
