### PR TITLE
Added handling of java.util.Collection in TypeUtil.scala

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -349,6 +349,10 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
       val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
       val valueType = parameterizedType.getActualTypeArguments.head
       "Set[" + getDataType(valueType, valueType, isSimple) + "]"
+    } else if (TypeUtil.isParameterizedCollection(genericReturnType)) {
+      val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
+      val valueType = parameterizedType.getActualTypeArguments.head
+      "Array[" + getDataType(valueType, valueType, isSimple) + "]"
     } else if (TypeUtil.isParameterizedMap(genericReturnType)) {
       val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
       val typeArgs = parameterizedType.getActualTypeArguments

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
@@ -62,7 +62,15 @@ object TypeUtil {
   def isParameterizedList(gt: Type): Boolean = {
     if (classOf[ParameterizedType].isAssignableFrom(gt.getClass)) {
       val tp = gt.asInstanceOf[ParameterizedType].getRawType
-        (tp == classOf[java.util.List[_]] || tp == classOf[java.util.Collection[_]] || tp == classOf[scala.List[_]] || tp == classOf[Seq[_]])
+        (tp == classOf[java.util.List[_]] || tp == classOf[scala.List[_]] || tp == classOf[Seq[_]])
+    }
+    else false
+  }
+
+  def isParameterizedCollection(gt: Type): Boolean = {
+    if (classOf[ParameterizedType].isAssignableFrom(gt.getClass)) {
+      val tp = gt.asInstanceOf[ParameterizedType].getRawType
+      (tp == classOf[java.util.Collection[_]])
     }
     else false
   }


### PR DESCRIPTION
Because of the missing support for java.util.Collection, using this class as a return value is not serialized to any of the basic types by Swagger.
This fix makes Swagger map Collection as an array.
