### PR TITLE
Bug in ServletScanner

### DIFF
--- a/modules/swagger-servlet/src/main/scala/com/wordnik/swagger/servlet/config/ServletScanner.scala
+++ b/modules/swagger-servlet/src/main/scala/com/wordnik/swagger/servlet/config/ServletScanner.scala
@@ -21,8 +21,6 @@ class ServletScanner extends Scanner {
   }
 
   def classes(): List[Class[_]] = {
-    val config = new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(resourcePackage)).setScanners(
-      new TypeAnnotationsScanner(), new SubTypesScanner())
-    new Reflections(config).getTypesAnnotatedWith(classOf[Api]).asScala.toList
+    new Reflections(resourcePackage).getTypesAnnotatedWith(classOf[Api]).asScala.toList
   }
 }


### PR DESCRIPTION
The existing code ends up scanning the whole classpath for classes annotated with `Api`. However the scanner allows to specify the `resourcePackage`. 

The proposed change properly scans **only** the classes in the package `resourcePackage` and sub-packages.
