### PR TITLE
Add @BeanParam support for Jersey2.

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/reader/BasicJaxrsReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/reader/BasicJaxrsReader.scala
@@ -69,24 +69,7 @@ class BasicJaxrsReader extends JaxrsApiReader {
         else ((List(), List(), List(), None))
       }
       // look for method-level annotated properties
-      val parentParams: List[Parameter] = (for(field <- getAllFields(cls)) 
-        yield {
-          // only process fields with @ApiParam, @QueryParam, @HeaderParam, @PathParam
-          if(field.getAnnotation(classOf[QueryParam]) != null || field.getAnnotation(classOf[HeaderParam]) != null ||
-            field.getAnnotation(classOf[HeaderParam]) != null || field.getAnnotation(classOf[PathParam]) != null ||
-            field.getAnnotation(classOf[ApiParam]) != null) { 
-            val param = new MutableParameter
-            param.dataType = field.getType.getName
-            Option (field.getAnnotation(classOf[ApiParam])) match {
-              case Some(annotation) => toAllowableValues(annotation.allowableValues)
-              case _ =>
-            }
-            val annotations = field.getAnnotations
-            processParamAnnotations(param, annotations)
-          }
-          else None
-        }
-      ).flatten.toList
+      val parentParams: List[Parameter] = getAllParamsFromFields(cls)
 
       for(method <- cls.getMethods) {
         val returnType = findSubresourceType(method)
@@ -146,7 +129,7 @@ class BasicJaxrsReader extends JaxrsApiReader {
   }
 
   // decorates a Parameter based on annotations, returns None if param should be ignored
-  def processParamAnnotations(mutable: MutableParameter, paramAnnotations: Array[Annotation]): Option[Parameter] = {
+  def processParamAnnotations(mutable: MutableParameter, paramAnnotations: Array[Annotation]): List[Parameter] = {
     var shouldIgnore = false
     for (pa <- paramAnnotations) {
       pa match {
@@ -188,9 +171,9 @@ class BasicJaxrsReader extends JaxrsApiReader {
         mutable.paramType = TYPE_BODY
         mutable.name = TYPE_BODY
       }
-      Some(mutable.asParameter)
+      List(mutable.asParameter)
     }
-    else None
+    else List.empty
   }
 
   def findSubresourceType(method: Method): Class[_] = {

--- a/modules/swagger-jaxrs/src/test/scala/PathParamTargetTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/PathParamTargetTest.scala
@@ -89,7 +89,7 @@ class JavaPathParamTargetTest extends FlatSpec with ShouldMatchers {
 
     // verify the 2nd api
     val detailsOps = apis.filter(_.path == "/javaPathParamTest/{id}/details").head.operations
-    val detailOp = detailsOps.head
+    val detailOp = detailsOps.filter(_.method == "POST").head
 
     detailOp.parameters.size should be (3)
 

--- a/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
+++ b/modules/swagger-jersey-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
@@ -75,24 +75,7 @@ class JerseyApiReader extends JaxrsApiReader {
         case _ => None
       }
       // look for method-level annotated properties
-      val parentParams: List[Parameter] = (for(field <- getAllFields(cls)) 
-        yield {
-          // only process fields with @ApiParam, @QueryParam, @HeaderParam, @PathParam
-          if(field.getAnnotation(classOf[QueryParam]) != null || field.getAnnotation(classOf[HeaderParam]) != null ||
-            field.getAnnotation(classOf[HeaderParam]) != null || field.getAnnotation(classOf[PathParam]) != null ||
-            field.getAnnotation(classOf[ApiParam]) != null) { 
-            val param = new MutableParameter
-            param.dataType = field.getType.getName
-            Option (field.getAnnotation(classOf[ApiParam])) match {
-              case Some(annotation) => toAllowableValues(annotation.allowableValues)
-              case _ =>
-            }
-            val annotations = field.getAnnotations
-            processParamAnnotations(param, annotations)
-          }
-          else None
-        }
-      ).flatten.toList
+      val parentParams: List[Parameter] = getAllParamsFromFields(cls)
 
       for(method <- cls.getMethods) {
         val returnType = findSubresourceType(method)
@@ -153,7 +136,7 @@ class JerseyApiReader extends JaxrsApiReader {
     else None
   }
 
-  def processParamAnnotations(mutable: MutableParameter, paramAnnotations: Array[Annotation]): Option[Parameter] = {
+  def processParamAnnotations(mutable: MutableParameter, paramAnnotations: Array[Annotation]): List[Parameter] = {
     var shouldIgnore = false
     for (pa <- paramAnnotations) {
       pa match {
@@ -211,9 +194,9 @@ class JerseyApiReader extends JaxrsApiReader {
         mutable.paramType = TYPE_BODY
         mutable.name = TYPE_BODY
       }
-      Some(mutable.asParameter)
+      List(mutable.asParameter)
     }
-    else None
+    else List()
   }
 
   def findSubresourceType(method: Method): Class[_] = {

--- a/modules/swagger-jersey2-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
+++ b/modules/swagger-jersey2-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
@@ -75,24 +75,7 @@ class JerseyApiReader extends JaxrsApiReader {
         case _ => None
       }
       // look for method-level annotated properties
-      val parentParams: List[Parameter] = (for(field <- getAllFields(cls)) 
-        yield {
-          // only process fields with @ApiParam, @QueryParam, @HeaderParam, @PathParam
-          if(field.getAnnotation(classOf[QueryParam]) != null || field.getAnnotation(classOf[HeaderParam]) != null ||
-            field.getAnnotation(classOf[HeaderParam]) != null || field.getAnnotation(classOf[PathParam]) != null ||
-            field.getAnnotation(classOf[ApiParam]) != null) { 
-            val param = new MutableParameter
-            param.dataType = field.getType.getName
-            Option (field.getAnnotation(classOf[ApiParam])) match {
-              case Some(annotation) => toAllowableValues(annotation.allowableValues)
-              case _ =>
-            }
-            val annotations = field.getAnnotations
-            processParamAnnotations(param, annotations)
-          }
-          else None
-        }
-      ).flatten.toList
+      val parentParams: List[Parameter] = getAllParamsFromFields(cls)
 
       for(method <- cls.getMethods) {
         val returnType = findSubresourceType(method)
@@ -153,7 +136,7 @@ class JerseyApiReader extends JaxrsApiReader {
     else None
   }
 
-  def processParamAnnotations(mutable: MutableParameter, paramAnnotations: Array[Annotation]): Option[Parameter] = {
+  def processParamAnnotations(mutable: MutableParameter, paramAnnotations: Array[Annotation]): List[Parameter] = {
     var shouldIgnore = false
     for (pa <- paramAnnotations) {
       pa match {
@@ -198,6 +181,10 @@ class JerseyApiReader extends JaxrsApiReader {
             }
           }
         }
+        case e: BeanParam => {
+          val cls = SwaggerContext.loadClass(mutable.dataType)
+          return getAllParamsFromFields(cls)
+        }
         case e: Context => shouldIgnore = true
         case _ =>
       }
@@ -207,9 +194,9 @@ class JerseyApiReader extends JaxrsApiReader {
         mutable.paramType = TYPE_BODY
         mutable.name = TYPE_BODY
       }
-      Some(mutable.asParameter)
+      List(mutable.asParameter)
     }
-    else None
+    else List.empty
   }
   def findSubresourceType(method: Method): Class[_] = {
     method.getGenericReturnType match {

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/BeanParamTest.scala
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/BeanParamTest.scala
@@ -1,0 +1,44 @@
+import com.wordnik.swagger.jersey.JerseyApiReader
+import testresources._
+
+import com.wordnik.swagger.jaxrs.reader._
+import com.wordnik.swagger.model._
+import com.wordnik.swagger.config._
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FlatSpec
+import org.scalatest.matchers.ShouldMatchers
+
+@RunWith(classOf[JUnitRunner])
+class BeanParamTest extends FlatSpec with ShouldMatchers {
+  it should "read beanparam parameters" in {
+    val reader = new JerseyApiReader
+    val config = new SwaggerConfig()
+    val apiResource = reader.read("/api-docs", classOf[BeanParamResource], config).getOrElse(fail("should not be None"))
+
+    val apis = apiResource.apis
+    apis.size should be (1)
+
+    val ops = apis.head.operations
+    ops.size should be (1)
+
+    val op = ops.head
+    op.parameters.size should be (3)
+
+    val param0 = op.parameters(0)
+    param0.name should be ("ids")
+    param0.dataType should be ("Set[string]")
+    param0.paramType should be ("query")
+
+    val param1 = op.parameters(1)
+    param1.name should be ("startDate")
+    param1.dataType should be ("Date")
+    param1.paramType should be ("query")
+
+    val param2 = op.parameters(2)
+    param2.name should be ("name")
+    param2.dataType should be ("string")
+    param2.paramType should be ("query")
+  }
+}

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/testmodels/BeanParamModel.scala
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/testmodels/BeanParamModel.scala
@@ -1,0 +1,19 @@
+package testmodels
+
+import com.wordnik.swagger.annotations.ApiParam
+import javax.ws.rs.QueryParam
+import java.util.Date
+
+class BeanParamModel {
+  @ApiParam(value = "sample set param")
+  @QueryParam("ids")
+  var ids: Set[String] = _
+
+  @ApiParam(value = "sample date param")
+  @QueryParam("startDate")
+  var startDate: Date = _
+
+  @ApiParam(value = "sample string param")
+  @QueryParam("name")
+  var name: String = _
+}

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/testresources/BeanParamResource.scala
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/testresources/BeanParamResource.scala
@@ -1,0 +1,16 @@
+package testresources
+
+import javax.ws.rs._
+import com.wordnik.swagger.annotations._
+import testmodels._
+import javax.ws.rs.core.Response
+
+@Path("/beanParam")
+@Api(value = "/beanParam", description = "Bean Param Resource")
+class BeanParamResource {
+  @GET
+  @ApiOperation(value = "Search Object", notes = "No details provided", position = 0)
+  def searchObject(@BeanParam params: BeanParamModel) {
+    Response.ok.entity("ok").build
+  }
+}


### PR DESCRIPTION
Related Issue: https://github.com/wordnik/swagger-core/issues/446
Add `@BeanParam` support.
Add unit test for `@BeanParam` support.
Fix `PathParamTargetTest`. The list detailsOps has two items, POST and GET. The order is not guaranteed. Add filter to make sure POST is used for the unit test.
