### PR TITLE
XmlEnumValue annotation doesn't override the default value

### DIFF
--- a/modules/swagger-core/src/test/scala/converter/EnumConversionTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/EnumConversionTest.scala
@@ -23,6 +23,6 @@ class EnumConversionTest extends FlatSpec with ShouldMatchers {
     val enumValue = model.properties("enumValue")
     enumValue.`type` should be ("string")
     enumValue.required should be (false)
-    enumValue.allowableValues should be (AllowableListValues(List("PRIVATE", "PUBLIC", "SYSTEM", "INVITE_ONLY")))
+    enumValue.allowableValues should be (AllowableListValues(List("PRIVATE", "PUBLIC", "SYSTEM", "INVITE-ONLY")))
   }
 }

--- a/modules/swagger-core/src/test/scala/converter/models/TestEnum.java
+++ b/modules/swagger-core/src/test/scala/converter/models/TestEnum.java
@@ -10,5 +10,5 @@ public enum TestEnum {
   @XmlEnumValue("PRIVATE")PRIVATE,
   @XmlEnumValue("PUBLIC")PUBLIC,
   @XmlEnumValue("SYSTEM")SYSTEM,
-  @XmlEnumValue("INVITE_ONLY")INVITE_ONLY;
+  @XmlEnumValue("INVITE-ONLY")INVITE_ONLY;
 }


### PR DESCRIPTION
We're using @XmlEnumValue to override the string that our enum values serialize/deserialize as.

Swagger is using the Java enum names, and it seems to be ignoring the XmlEnumValue annotation. This pull request changes the test slightly to expose this issue. On my machine, this causes the test case to fail. I don't know what it'll take to fix.

Our particular XmlEnumValue annotations also change the case to lowercase, but I didn't think that was necessary here.