### PR TITLE
Add nicknames for Health and Ping operations so that they work in SwaggerUI

### DIFF
--- a/modules/swagger-play2-utils/app/controllers/HealthController.scala
+++ b/modules/swagger-play2-utils/app/controllers/HealthController.scala
@@ -19,7 +19,7 @@ object HealthController extends Controller {
   @Path("/health")
   @ApiOperation(value = "Returns health report on this JVM",
     response = classOf[com.wordnik.util.perf.Health],
-    nickname= "Health endpoint",
+    nickname = "Health endpoint",
     httpMethod = "GET")
   def getHealth() = Action { request =>
     try {
@@ -35,7 +35,7 @@ object HealthController extends Controller {
   @Path("/ping")
   @ApiOperation(value = "Pings service",
     response = classOf[String],
-    nickname= "Ping endpoint",
+    nickname = "Ping endpoint",
     produces = "text/plain",
     httpMethod = "GET")
   def ping() = Action { request =>


### PR DESCRIPTION
As the title says, this PR simply adds the nickname setting to the @ApiOperation declaration of the HealthController so that Swagger-UI doesn't complain.
