### PR TITLE
enum fields not displaying allowed values

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -71,7 +71,7 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
 
   def parseField(field: Field) = {
     LOGGER.debug("processing field " + field)
-    val returnClass = field.getDeclaringClass
+    val returnClass = field.getType
     parsePropertyAnnotations(returnClass, field.getName, field.getAnnotations, field.getGenericType, field.getType, true)
   }
 

--- a/modules/swagger-core/src/test/scala/converter/ModelPropertyParserTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/ModelPropertyParserTest.scala
@@ -26,4 +26,24 @@ class ModelPropertyParserTest extends FlatSpec with ShouldMatchers {
     val parser = new ModelPropertyParser(cls)
     parser.parse
   }
+
+  it should "extract enum values from fields" in {
+    val cls = classOf[ModelWithEnumField]
+    implicit val properties = new scala.collection.mutable.LinkedHashMap[String, ModelProperty]
+    val parser = new ModelPropertyParser(cls)
+    parser.parse
+    val result = properties.get("enumValue").get.allowableValues
+    val expectedList = (for(v <- TestEnum.values()) yield v.toString).toList
+    assert(AllowableListValues(expectedList) === result)
+  }
+
+  it should "extract enum values from method return types" in {
+    val cls = classOf[ModelWithEnumProperty]
+    implicit val properties = new scala.collection.mutable.LinkedHashMap[String, ModelProperty]
+    val parser = new ModelPropertyParser(cls)
+    parser.parse
+    val result = properties.get("enumValue").get.allowableValues
+    val expectedList = (for(v <- TestEnum.values()) yield v.toString).toList
+    assert(AllowableListValues(expectedList) === result)
+  }
 }

--- a/modules/swagger-core/src/test/scala/converter/models/ModelWithEnumField.java
+++ b/modules/swagger-core/src/test/scala/converter/models/ModelWithEnumField.java
@@ -1,0 +1,5 @@
+package converter.models;
+
+public class ModelWithEnumField {
+    public TestEnum enumValue;
+}


### PR DESCRIPTION
When an enum is declared as a field then allowed values are not displayed. If an enum has a getter it works fine. The problem is that the Class.getDeclaringClass used in the ModelPropertyParser.parseField returns a class where the "isEnum" method returns false for enums. It is now fixed by using the Class.getType instead. The printing of Allowed Values for enums functionality should now be the same for both enums with and without getters. Tests provided cover both cases.
