### PR TITLE
Merge models from multiple resource definition

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/ReaderUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/ReaderUtil.scala
@@ -17,6 +17,8 @@
 package com.wordnik.swagger.core.util
 
 import com.wordnik.swagger.model._
+import java.util.LinkedHashMap
+import scala.collection.mutable.Map 
 
 trait ReaderUtil {
   def groupByResourcePath(listings: List[com.wordnik.swagger.model.ApiListing]): List[com.wordnik.swagger.model.ApiListing] = {
@@ -24,7 +26,15 @@ trait ReaderUtil {
     val grouped = tuples.groupBy(_._1)
     (for (group <- grouped) yield {
       val apiDescriptions = (for(g <- group._2; api <- g._2.apis) yield api).toList
-      group._2(0)._2.copy(apis = apiDescriptions)
+             
+      val models:Map[String,Model] = Map();
+      group._2.foreach(g => g._2.models.foreach(y => y.foreach(z => { models += (z._1 -> z._2)})));      
+      var modelsOption:Option[scala.collection.immutable.Map[String, Model]] = None;
+      if (models.size > 0) {
+    	  modelsOption = Some((collection.immutable.HashMap() ++ models));
+      }
+      
+      group._2(0)._2.copy(apis = apiDescriptions, models = modelsOption)
     }).toList
   }
 }


### PR DESCRIPTION
I'm using swagger with JAX-RS. My project has resource which is split into two facades. Both facades have the same path and api key. Swagger correctly merge all methods from both facades with description but it is not merging definition of models. So models definitions are present only for facade which was scanned first and second has only empty class name. I'm referring to models definitions which are used inside “Response Class” and for input parameters “Data Type”.

I have created example patch which fix the problem. Unfortunately my scala knowledge is poor and it most likely could be improved. 
