### PR TITLE
Migrated to Play 2.3.x and Scala 2.10.4

### DIFF
--- a/modules/swagger-play2-utils/app/controllers/HealthController.scala
+++ b/modules/swagger-play2-utils/app/controllers/HealthController.scala
@@ -24,7 +24,7 @@ object HealthController extends Controller {
     try {
       val health: Health = HealthSnapshot.get()
 
-      new SimpleResult(header = ResponseHeader(200), body = play.api.libs.iteratee.Enumerator(ScalaJsonUtil.mapper.writeValueAsBytes(health))).as("application/json")
+      Result(header = ResponseHeader(200), body = play.api.libs.iteratee.Enumerator(ScalaJsonUtil.mapper.writeValueAsBytes(health))).as("application/json")
         .withHeaders(AccessControlAllowOrigin)
     } catch {
       case e: Exception => LOGGER.error("Error occurred", e); InternalServerError //Error(e.getMessage)
@@ -36,7 +36,7 @@ object HealthController extends Controller {
     produces = "text/plain", httpMethod = "GET")
   def ping() = Action { request =>
     try {
-      new SimpleResult(header = ResponseHeader(200), body = play.api.libs.iteratee.Enumerator("OK".getBytes)).as("text/plain")
+      Result(header = ResponseHeader(200), body = play.api.libs.iteratee.Enumerator("OK".getBytes)).as("text/plain")
         .withHeaders(AccessControlAllowOrigin)
     } catch {
       case e: Exception => LOGGER.error("Error occurred", e); InternalServerError //Error(e.getMessage)

--- a/modules/swagger-play2-utils/project/Build.scala
+++ b/modules/swagger-play2-utils/project/Build.scala
@@ -1,10 +1,9 @@
 import sbt._
 import Keys._
-import play.Project._
 
 object ApplicationBuild extends Build {
   val appName = "swagger-play2-utils"
-  val appVersion = "1.3.1"
+  val appVersion = "1.4.0"
 
   val appDependencies: Seq[sbt.ModuleID] = Seq(
     "org.slf4j" % "slf4j-api" % "1.6.4",
@@ -12,7 +11,10 @@ object ApplicationBuild extends Build {
     "com.wordnik" % "common-utils_2.10.0" % "1.1.5",
     "javax.ws.rs" % "jsr311-api" % "1.1.1")
 
-  val main = play.Project(appName, appVersion, appDependencies).settings(
+  val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(
+    version := appVersion,
+    libraryDependencies ++= appDependencies,
+    scalaVersion := "2.10.4",
     publishTo <<= version { (v: String) =>
       val nexus = "https://oss.sonatype.org/"
       if (v.trim.endsWith("SNAPSHOT"))

--- a/modules/swagger-play2-utils/project/build.properties
+++ b/modules/swagger-play2-utils/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/modules/swagger-play2-utils/project/plugins.sbt
+++ b/modules/swagger-play2-utils/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.1")

--- a/modules/swagger-play2/app/controllers/ApiHelpController.scala
+++ b/modules/swagger-play2/app/controllers/ApiHelpController.scala
@@ -94,10 +94,10 @@ object ApiHelpController extends SwaggerBaseApiController {
           Logger("swagger").error(msg.message)
           returnXml(request) match {
             case true => {
-              new SimpleResult(header = ResponseHeader(500), body = play.api.libs.iteratee.Enumerator(toXmlString(msg).getBytes())).as("application/xml")
+              new Result(header = ResponseHeader(500), body = play.api.libs.iteratee.Enumerator(toXmlString(msg).getBytes())).as("application/xml")
             }
             case false => {
-              new SimpleResult(header = ResponseHeader(500), body = play.api.libs.iteratee.Enumerator(toJsonString(msg).getBytes())).as("application/json")
+              new Result(header = ResponseHeader(500), body = play.api.libs.iteratee.Enumerator(toJsonString(msg).getBytes())).as("application/json")
             }
           }
         }
@@ -185,7 +185,7 @@ class SwaggerBaseApiController extends Controller {
 
   protected def XmlResponse(data: Any) = {
     val xmlValue = toXmlString(data)
-    new SimpleResult(header = ResponseHeader(200), body = play.api.libs.iteratee.Enumerator(xmlValue.getBytes())).as("application/xml")
+    new Result(header = ResponseHeader(200), body = play.api.libs.iteratee.Enumerator(xmlValue.getBytes())).as("application/xml")
   }
 
   protected def returnValue(request: Request[_], obj: Any): Result = {
@@ -206,6 +206,6 @@ class SwaggerBaseApiController extends Controller {
 
   protected def JsonResponse(data: Any) = {
     val jsonValue = toJsonString(data)
-    new SimpleResult(header = ResponseHeader(200), body = play.api.libs.iteratee.Enumerator(jsonValue.getBytes())).as("application/json")
+    new Result(header = ResponseHeader(200), body = play.api.libs.iteratee.Enumerator(jsonValue.getBytes())).as("application/json")
   }
 }

--- a/modules/swagger-play2/project/Build.scala
+++ b/modules/swagger-play2/project/Build.scala
@@ -1,10 +1,9 @@
 import sbt._
 import Keys._
-import play.Project._
 
 object ApplicationBuild extends Build {
   val appName = "swagger-play2"
-  val appVersion = "1.3.2"
+  val appVersion = "1.4.0"
 
   checksums in update := Nil
 
@@ -18,13 +17,16 @@ object ApplicationBuild extends Build {
     "javax.ws.rs" % "jsr311-api" % "1.1.1",
     "org.mockito" % "mockito-core" % "1.9.5" % "test")
 
-  val main = play.Project(appName, appVersion, appDependencies).settings(
+  val main = Project(appName, file(".")).enablePlugins(play.PlayScala).settings(
+    version := appVersion,
+    libraryDependencies ++= appDependencies,
+    scalaVersion := "2.10.4",
     publishTo <<= version { (v: String) =>
       val nexus = "https://oss.sonatype.org/"
       if (v.trim.endsWith("SNAPSHOT"))
-        Some("snapshots" at nexus + "content/repositories/snapshots")
+      Some("snapshots" at nexus + "content/repositories/snapshots")
       else
-        Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+      Some("releases"  at nexus + "service/local/staging/deploy/maven2")
     },
     publishArtifact in Test := false,
     publishMavenStyle := true,

--- a/modules/swagger-play2/project/build.properties
+++ b/modules/swagger-play2/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/modules/swagger-play2/project/plugins.sbt
+++ b/modules/swagger-play2/project/plugins.sbt
@@ -11,4 +11,4 @@ resolvers ++= Seq(
 
 resolvers += "Typesafe Snapshots" at "http://repo.typesafe.com/typesafe/snapshots/"
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.1")


### PR DESCRIPTION
This upgrade breaks backward compatibility with Play because SimpleResult is now out from API. Because of that I've also increased vertsion to 1.4.0. Scala 2.10.4 does not break antyhing.