### PR TITLE
Include OSGi headers in the manifest.

### DIFF
--- a/modules/swagger-annotations/pom.xml
+++ b/modules/swagger-annotations/pom.xml
@@ -10,11 +10,25 @@
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-annotations</artifactId>
   <version>1.3.8-SNAPSHOT</version>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <name>swagger-annotations</name>
 
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <defaultGoal>install</defaultGoal>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>com.wordnik.swagger.annotations</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+
   </build>
 </project>

--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.wordnik</groupId>
   <artifactId>swagger-core_2.10</artifactId>
-  <packaging>jar</packaging>
+  <packaging>bundle</packaging>
   <name>swagger-core</name>
   <version>1.3.8-SNAPSHOT</version>
   <build>
@@ -27,6 +27,31 @@
         <directory>src/test/resources</directory>
       </testResource>
     </testResources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Export-Package>
+              com.wordnik.swagger.converter,
+              com.wordnik.swagger.core,
+              com.wordnik.swagger.core.util,
+              com.wordnik.swagger.reader,
+              com.wordnik.swagger.config,
+              com.wordnik.swagger.model
+            </Export-Package>
+            <Import-Package>
+              org.json4s.jackson,
+              *
+            </Import-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+
   </build>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,13 @@
     		    </dependency>
     		  </dependencies>
         </plugin>
+
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>${felix-version}</version>
+        </plugin>
+
       </plugins>
     </pluginManagement>
   </build>
@@ -495,7 +502,7 @@
   </dependencyManagement>
   <properties>
     <scala-version>2.10.4</scala-version>
-    <felix-version>2.3.4</felix-version>
+    <felix-version>2.3.7</felix-version>
     <servlet-api-version>2.5</servlet-api-version>
     <jersey-version>1.13</jersey-version>
     <jersey2-version>2.1</jersey2-version>


### PR DESCRIPTION
This allows swagger-core and swagger-annotations JARs to be used in a OSGi container such as Eclipse Virgo. The new headers should not impact non-OSGi usage in any way.

I am creating a new pull request with "develop" as the base. My earlier one (#623) was using "master" as base so the diff shows lot of commits. 
