### PR TITLE
Add getRootResource method to avoid multiple routes

### DIFF
--- a/modules/swagger-play2/app/controllers/ApiHelpController.scala
+++ b/modules/swagger-play2/app/controllers/ApiHelpController.scala
@@ -76,6 +76,10 @@ object ApiHelpController extends SwaggerBaseApiController {
       }
       returnValue(request, responseStr)
   }
+  
+  def getRootResource(path: String) = Action {
+    getResource("/" + path)
+  }
 
   def getResource(path: String) = Action {
     request =>


### PR DESCRIPTION
This method avoids to write multiple repetitive routes for resources like
```
GET     /api-docs.json/pet            controllers.ApiHelpController.getResource(path = "/pet")
GET     /api-docs.json/cat            controllers.ApiHelpController.getResource(path = "/cat")
```
Thanks to it, adding this route will handle all controllers if the name follows the convention
```
GET     /api-docs.json/*path            controllers.ApiHelpController.getRootResource(path: String)
```