### PR TITLE
Fixes Depreciated DropWizard Calls

### DIFF
--- a/samples/java-dropwizard/src/main/java/com/wordnik/swagger/sample/SwaggerSampleService.java
+++ b/samples/java-dropwizard/src/main/java/com/wordnik/swagger/sample/SwaggerSampleService.java
@@ -26,11 +26,11 @@ public class SwaggerSampleService extends Service<SwaggerSampleConfiguration> {
 
   @Override
   public void run(SwaggerSampleConfiguration configuration, Environment environment) {
-    environment.addResource(new ApiListingResourceJSON());
-    environment.addResource(new PetResource());
+    environment.jersey().register(new ApiListingResourceJSON());
+    environment.jersey().register(new PetResource());
 
-    environment.addProvider(new ResourceListingProvider());
-    environment.addProvider(new ApiDeclarationProvider());
+    environment.jersey().register(new ResourceListingProvider());
+    environment.jersey().register(new ApiDeclarationProvider());
     ScannerFactory.setScanner(new DefaultJaxrsScanner());
     ClassReaders.setReader(new DefaultJaxrsApiReader());
 


### PR DESCRIPTION
The new version of DropWizard has changed the way the Environment class
works[1]. The correct syntax for setting environment for jersey is within the
```java
   jersey().register()
```
method. Before, this was achieved with the
```java
   addProvider
```
method. Sample DropWizard + Swagger fixed.

[1]: https://groups.google.com/d/msg/dropwizard-user/S4K3Ayfij3g/G7Fg7b4T6kEJ

Signed-off-by: Adam Brenner <aebrenne@uci.edu>