### PR TITLE
ApiListingResourceJSON supports Accepts: application/json

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/listing/ApiListingResource.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/listing/ApiListingResource.scala
@@ -8,5 +8,5 @@ import javax.ws.rs.core.MediaType
 
 @Path("/api-docs")
 @Api("/api-docs")
-@Produces(Array("application/json; charset=utf-8"))
+@Produces(Array("application/json; charset=utf-8", "application/json"))
 class ApiListingResourceJSON extends ApiListingResource


### PR DESCRIPTION
Header "Accepts: application/json" as sent from swagger-ui is being rejected. Only "Accepts: application/json; charset=utf-8" accepted.