### PR TITLE
support inheritance api models defined by interfaces

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -62,7 +62,13 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
         }
       }
 
-      Option(hostClass.getSuperclass).map(parseRecursive(_))
+      if (hostClass.isInterface) {
+        for ( interf <- hostClass.getInterfaces) {
+          Option(interf).map(parseRecursive(_))
+        }
+      } else {
+        Option(hostClass.getSuperclass).map(parseRecursive(_))
+      }
     }
     else {
       LOGGER.debug("Not processing enum class " + hostClass)


### PR DESCRIPTION
For example if I have two interfaces:
```java
@ApiModel(value = "Model A", subTypes = {B.class})
public interface A {
    @ApiModelProperty(value = "A")
    String getA();

    void setA(String a);
}
```
and
```java
@ApiModel(value = "Model B", parent = A.class)
public interface B extends A {
    @ApiModelProperty(value = "B")
    String getB();

    void setB(String b);
}
```
In UI for class B I can see just properties (with getters) that are defined directly in interface B:
```
B {
b (string, optional): B,
}
```
Implementations for interfaces generated automatically (for client and server side) and we aren't able to define annotations on implementations. This pull request fixes the issue.