### PR TITLE
Add the ability to specify an API version

### DIFF
--- a/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/Api.java
+++ b/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/Api.java
@@ -54,6 +54,13 @@ public @interface Api {
      */
     String filter() default "";
     /**
+     * Use a path alias.
+     * <p/>
+     * This is the path that the API will generate in the URL instead of the path used internally (related to filter).
+     */
+    String pathAlias() default "";
+
+    /**
      * Corresponds to the `description` field of the Resource Listing API operation.
      * <p/>
      * This should be a short description of the resource.

--- a/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/Api.java
+++ b/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/Api.java
@@ -48,6 +48,12 @@ public @interface Api {
     String value();
 
     /**
+     * Filter the Api listings.
+     * <p/>
+     * This should be a version or other short string.
+     */
+    String filter() default "";
+    /**
      * Corresponds to the `description` field of the Resource Listing API operation.
      * <p/>
      * This should be a short description of the resource.

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/model/SwaggerModels.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/model/SwaggerModels.scala
@@ -80,6 +80,7 @@ case class ApiListing (
   apis: List[ApiDescription] = List(),
   models: Option[Map[String, Model]] = None,
   description: Option[String] = None,
+  filter: Option[String] = None,
   position: Int = 0)
 
 case class ApiDescription (

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/model/SwaggerModels.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/model/SwaggerModels.scala
@@ -37,7 +37,7 @@ case class LoginEndpoint(url: String)
 case class TokenRequestEndpoint(url: String, clientIdName: String, clientSecretName: String)
 case class TokenEndpoint(url: String, tokenName: String)
 
-case class ApiListingReference(path:String, description: Option[String], position: Int = 0)
+case class ApiListingReference(path:String, description: Option[String], position: Int = 0, pathAlias: Option[String] = None)
 
 trait AllowableValues
 case object AnyAllowableValues extends AllowableValues
@@ -81,6 +81,7 @@ case class ApiListing (
   models: Option[Map[String, Model]] = None,
   description: Option[String] = None,
   filter: Option[String] = None,
+  pathAlias: Option[String] = None,
   position: Int = 0)
 
 case class ApiDescription (

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/model/SwaggerSerializers.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/model/SwaggerSerializers.scala
@@ -586,12 +586,18 @@ trait Serializers {
           !!(json, RESOURCE, "path", "missing required field", ERROR)
           ""
         }),
-        (json \ "description").extractOpt[String]
+        (json \ "description").extractOpt[String],
+        pathAlias = (json \ "pathAlias").extractOpt[String]
       )
     }, {
       case x: ApiListingReference =>
       implicit val fmts = formats
-      ("path" -> x.path) ~
+        ("path" -> {
+          x.pathAlias match {
+            case Some(alias) => alias
+            case _ => x.path
+          }
+        }) ~
       ("description" -> x.description)
     }
   ))

--- a/modules/swagger-jersey2-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
+++ b/modules/swagger-jersey2-jaxrs/src/main/scala/com/wordnik/swagger/jersey/JerseyApiReader.scala
@@ -126,6 +126,10 @@ class JerseyApiReader extends JaxrsApiReader {
         else
           api.basePath
       }
+      val filter = api.filter match {
+        case e: String if(e != "") => Some(e)
+        case _ => None
+      }
       Some(ApiListing (
         apiVersion = config.apiVersion,
         swaggerVersion = config.swaggerVersion,
@@ -137,7 +141,8 @@ class JerseyApiReader extends JaxrsApiReader {
         produces = produces,
         consumes = consumes,
         protocols = protocols,
-        position = api.position)
+        position = api.position,
+        filter = filter)
       )
     }
     else None

--- a/modules/swagger-play2/app/controllers/ApiHelpController.scala
+++ b/modules/swagger-play2/app/controllers/ApiHelpController.scala
@@ -138,7 +138,7 @@ class SwaggerBaseApiController extends Controller {
     ).filter(m => m.apis.size > 0 && m.filter == filter)
 
     val references = (for (listing <- listings) yield {
-      ApiListingReference(listing.resourcePath, listing.description)
+      ApiListingReference(listing.resourcePath, listing.description, pathAlias = listing.pathAlias)
     }).toList
 
     references.foreach {

--- a/modules/swagger-play2/app/controllers/ApiHelpController.scala
+++ b/modules/swagger-play2/app/controllers/ApiHelpController.scala
@@ -65,11 +65,11 @@ class ErrorResponse(@XmlElement var code: Int, @XmlElement var message: String) 
 
 object ApiHelpController extends SwaggerBaseApiController {
 
-  def getResources = Action {
+  def getResources(filter: String = null) = Action {
     request =>
       implicit val requestHeader: RequestHeader = request
 
-      val resourceListing = getResourceListing
+      val resourceListing = getResourceListing(if (filter == null || filter.trim.isEmpty) None else Some(filter))
 
       val responseStr = returnXml(request) match {
         case true => toXmlString(resourceListing)
@@ -112,7 +112,7 @@ class SwaggerBaseApiController extends Controller {
   /**
    * Get a list of all top level resources
    */
-  protected def getResourceListing(implicit requestHeader: RequestHeader) = {
+  protected def getResourceListing(filter: Option[String])(implicit requestHeader: RequestHeader) = {
     Logger("swagger").debug("ApiHelpInventory.getRootResources")
     val docRoot = ""
     val queryParams = (for((key, value) <- requestHeader.queryString) yield {
@@ -135,7 +135,7 @@ class SwaggerBaseApiController extends Controller {
     // val specs = l.getOrElse(Map: Map[String, com.wordnik.swagger.model.ApiListing] ()).map(_._2).toList
     val listings = (for (spec <- specs)
       yield f.filter(spec, FilterFactory.filter, queryParams, cookies, headers)
-    ).filter(m => m.apis.size > 0)
+    ).filter(m => m.apis.size > 0 && m.filter == filter)
 
     val references = (for (listing <- listings) yield {
       ApiListingReference(listing.resourcePath, listing.description)

--- a/modules/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
+++ b/modules/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
@@ -133,6 +133,11 @@ class PlayApiReader(val routes: Option[Routes]) extends JaxrsApiReader {
         case _ => None
       }
 
+      val pathAlias = api.pathAlias match {
+        case e: String if e != "" => Some(e)
+        case _ => None
+      }
+
       Some(ApiListing (
         apiVersion = config.apiVersion,
         swaggerVersion = config.swaggerVersion,
@@ -145,6 +150,7 @@ class PlayApiReader(val routes: Option[Routes]) extends JaxrsApiReader {
         consumes = consumes,
         protocols = protocols,
         filter = filter,
+        pathAlias = pathAlias,
         position = api.position)
       )
     }
@@ -222,6 +228,11 @@ class PlayApiReader(val routes: Option[Routes]) extends JaxrsApiReader {
         case _ => None
       }
 
+      val pathAlias = api.pathAlias match {
+        case e: String if e != "" => Some(e)
+        case _ => None
+      }
+
       Some(
         ApiListing(
           config.apiVersion,
@@ -235,7 +246,8 @@ class PlayApiReader(val routes: Option[Routes]) extends JaxrsApiReader {
           ModelUtil.stripPackages(apiDescriptions), //  List[com.wordnik.swagger.model.ApiDescription]
           models,
           description,
-          filter
+          filter,
+          pathAlias
           // position
         )
       )

--- a/modules/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
+++ b/modules/swagger-play2/app/play/modules/swagger/PlayApiReader.scala
@@ -127,6 +127,12 @@ class PlayApiReader(val routes: Option[Routes]) extends JaxrsApiReader {
           orderedOperations.toList)
       }).toList
       val models = ModelUtil.modelsFromApis(apis)
+
+      val filter = api.filter match {
+        case e: String if e != "" => Some(e)
+        case _ => None
+      }
+
       Some(ApiListing (
         apiVersion = config.apiVersion,
         swaggerVersion = config.swaggerVersion,
@@ -138,6 +144,7 @@ class PlayApiReader(val routes: Option[Routes]) extends JaxrsApiReader {
         produces = produces,
         consumes = consumes,
         protocols = protocols,
+        filter = filter,
         position = api.position)
       )
     }
@@ -210,6 +217,11 @@ class PlayApiReader(val routes: Option[Routes]) extends JaxrsApiReader {
 
       val models = ModelUtil.modelsFromApis(apiDescriptions)
 
+      val filter = api.filter match {
+        case e: String if e != "" => Some(e)
+        case _ => None
+      }
+
       Some(
         ApiListing(
           config.apiVersion,
@@ -222,7 +234,8 @@ class PlayApiReader(val routes: Option[Routes]) extends JaxrsApiReader {
           List(),
           ModelUtil.stripPackages(apiDescriptions), //  List[com.wordnik.swagger.model.ApiDescription]
           models,
-          description
+          description,
+          filter
           // position
         )
       )


### PR DESCRIPTION
This is related to https://github.com/wordnik/swagger-core/issues/712.

I have also created some documentation: https://github.com/wordnik/swagger-core/wiki/API-Filtering

This feature allows me to maintain several versions of an API in the same code base. The path name is then used as a filter ("v1", "v2", etc.). The default API can then be used to point to one of the APIs as well as configure in the routes file.

This has only been developed in Scala Play. It should work in Java, but has not been tested there.