### PR TITLE
Change ApiHelpController to trait for both testing and extension

### DIFF
--- a/modules/swagger-play2/app/controllers/ApiHelpController.scala
+++ b/modules/swagger-play2/app/controllers/ApiHelpController.scala
@@ -63,7 +63,8 @@ class ErrorResponse(@XmlElement var code: Int, @XmlElement var message: String) 
   def setMessage(message: String) = this.message = message
 }
 
-object ApiHelpController extends SwaggerBaseApiController {
+trait ApiHelpController extends SwaggerBaseApiController {
+  this: Controller =>
 
   def getResources = Action {
     request =>
@@ -102,7 +103,11 @@ object ApiHelpController extends SwaggerBaseApiController {
   }
 }
 
-class SwaggerBaseApiController extends Controller {
+object ApiHelpController extends Controller with ApiHelpController
+
+trait SwaggerBaseApiController {
+  this: Controller =>
+
   protected def jaxbContext = JAXBContext.newInstance(classOf[String], classOf[ResourceListing])
 
   protected def returnXml(request: Request[_]) = request.path.contains(".xml")


### PR DESCRIPTION
I needed to extend getResource and getResources of ApiHelpController in order to add a custom Actions, but still use the parent methods. I also wanted the ability to do some unit tests with mock controllers. So, I made ApiHelpController into a trait with a Cake parameter. I also added a companion object so nothing existing will break.