### PR TITLE
"External Documentation Object" implemented (according to spec)

### DIFF
--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/AbstractModel.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/AbstractModel.java
@@ -1,0 +1,15 @@
+package com.wordnik.swagger.models;
+
+public abstract class AbstractModel implements Model {
+
+  private ExternalDocs externalDocs;
+
+  @Override
+  public ExternalDocs getExternalDocs() {
+    return externalDocs;
+  }
+
+  public void setExternalDocs(ExternalDocs value) {
+    externalDocs = value;
+  }
+}

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ArrayModel.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ArrayModel.java
@@ -4,7 +4,7 @@ import com.wordnik.swagger.models.properties.Property;
 
 import java.util.*;
 
-public class ArrayModel implements Model {
+public class ArrayModel extends AbstractModel {
   private Map<String, Property> properties;
   private String type;
   private String description;

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ComposedModel.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ComposedModel.java
@@ -3,13 +3,10 @@ package com.wordnik.swagger.models;
 import com.wordnik.swagger.models.properties.*;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.*;
 
-import javax.xml.bind.annotation.*;
-
-public class ComposedModel implements Model {
+public class ComposedModel extends AbstractModel {
   private List<Model> allOf = new ArrayList<Model>();
   private Model parent;
   private Model child;

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ExternalDocs.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ExternalDocs.java
@@ -1,0 +1,28 @@
+package com.wordnik.swagger.models;
+
+/**
+ * Container for a <a href="https://github.com/wordnik/swagger-spec/blob/master/versions/2.0.md#externalDocumentationObject">External Documentation Object</a>.
+ */
+public class ExternalDocs {
+  /** A short description of the target documentation. GFM syntax can be used for rich text representation. */
+  private String description;
+
+  /** Required. The URL for the target documentation. Value MUST be in the format of a URL. */
+  private String url;
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+}

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Model.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Model.java
@@ -13,4 +13,6 @@ public interface Model {
 
   String getExample();
   void setExample(String example);
+
+  ExternalDocs getExternalDocs();
 }

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ModelImpl.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ModelImpl.java
@@ -11,7 +11,7 @@ import javax.xml.bind.annotation.*;
 
 @XmlType(propOrder = { "required", "properties"})
 @JsonPropertyOrder({ "required", "properties"})
-public class ModelImpl implements Model {
+public class ModelImpl extends AbstractModel {
   private String type;
   private String name;
   private List<String> required;

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Operation.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Operation.java
@@ -21,6 +21,7 @@ public class Operation {
   Map<String, Response> responses;
   Map<String, SecurityRequirement> security;
   String example;
+  private ExternalDocs externalDocs;
 
   public Operation summary(String summary) {
     this.setSummary(summary);
@@ -195,5 +196,13 @@ public class Operation {
       this.security = new HashMap<String, SecurityRequirement>();
     }
     this.security.put(security.getName(), security);
+  }
+
+  public ExternalDocs getExternalDocs() {
+    return externalDocs;
+  }
+
+  public void setExternalDocs(ExternalDocs value) {
+    externalDocs = value;
   }
 }

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/RefModel.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/RefModel.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.*;
 
-public class RefModel implements Model {
+public class RefModel extends AbstractModel {
   String ref;
   private String description;
   private Map<String, Property> properties;

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Swagger.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Swagger.java
@@ -1,7 +1,5 @@
 package com.wordnik.swagger.models;
 
-import com.wordnik.swagger.models.Model;
-
 import com.fasterxml.jackson.annotation.*;
 
 import java.util.*;
@@ -17,6 +15,7 @@ public class Swagger {
   protected Map<String, Path> paths;
   protected Map<String, SecurityDefinition> securityDefinition;
   protected Map<String, Model> definitions;
+  private ExternalDocs externalDocs;
 
   public Swagger info(Info info) {
     this.setInfo(info);
@@ -180,5 +179,13 @@ public class Swagger {
     if(this.definitions == null)
       this.definitions = new HashMap<String, Model>();
     this.definitions.put(key, model);
+  }
+
+  public ExternalDocs getExternalDocs() {
+    return externalDocs;
+  }
+
+  public void setExternalDocs(ExternalDocs value) {
+    externalDocs = value;
   }
 }


### PR DESCRIPTION
This is needed so that the parser reads the "externalDocs" parts from a YAML/JSON file and makes them available to swagger-codegen...
