### PR TITLE
Unwrap optional types in models

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -392,7 +392,11 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
   }
 
   def getDataType(genericReturnType: Type, returnType: Type, isSimple: Boolean = false): String = {
-    if (TypeUtil.isParameterizedList(genericReturnType)) {
+    if (TypeUtil.isOptionalType(genericReturnType)) {
+      val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
+      val valueType = parameterizedType.getActualTypeArguments.head
+      getDataType(valueType, valueType, isSimple)
+    } else if (TypeUtil.isParameterizedList(genericReturnType)) {
       val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
       val valueType = parameterizedType.getActualTypeArguments.head
       "List[" + getDataType(valueType, valueType, isSimple) + "]"

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
@@ -59,6 +59,14 @@ object TypeUtil {
     }).asScala.toSet
   }
 
+  def isOptionalType(gt: Type): Boolean = {
+    if (classOf[ParameterizedType].isAssignableFrom(gt.getClass)) {
+      val tp = gt.asInstanceOf[ParameterizedType].getRawType
+      (tp == classOf[Option[_]] || tp.asInstanceOf[Class[_]].getSimpleName.equals("Optional"))
+    }
+    else false
+  }
+
   def isParameterizedList(gt: Type): Boolean = {
     if (classOf[ParameterizedType].isAssignableFrom(gt.getClass)) {
       val tp = gt.asInstanceOf[ParameterizedType].getRawType

--- a/modules/swagger-core/src/test/scala/converter/ModelWithOptionalFieldsTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/ModelWithOptionalFieldsTest.scala
@@ -1,0 +1,13 @@
+package converter
+
+import models._
+
+import com.wordnik.swagger.converter._
+
+import com.wordnik.swagger.core.util._
+import org.scalatest.{Matchers, FlatSpec}
+
+class ModelWithOptionalFieldsTest extends FlatSpec with Matchers {
+  val models = ModelConverters.readAll(classOf[ModelWithOptionalFields])
+  JsonSerializer.asJson(models) should be ("""[{"id":"ModelWithOptionalFields","properties":{"string":{"type":"string"},"integer":{"type":"integer","format":"int32"}}}]""")
+}

--- a/modules/swagger-core/src/test/scala/converter/models/ModelWithOptionalFields.java
+++ b/modules/swagger-core/src/test/scala/converter/models/ModelWithOptionalFields.java
@@ -1,0 +1,8 @@
+package converter.models;
+
+import com.google.common.base.Optional;
+
+public class ModelWithOptionalFields {
+  public Optional<String> string;
+  public Optional<Integer> integer;
+}


### PR DESCRIPTION
This PR treats optional fields as their unwrapped counterparts (#728). The class name string comparison feels a little janky, but should support both Guava and Java 8 optionals.

/cc @wsorenson @hgschmie @stevenschlansker
