### PR TITLE
properly unwrap Optionals in Jersey resources

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
@@ -59,7 +59,11 @@ trait JaxrsApiReader extends ClassReader with ClassReaderUtils {
                 case Some(e) => e._2.qualifiedType
                 case None => qt
               }
-              "%s[%s]".format(normalizeContainer(container), b)
+              if (container.endsWith(".Optional") || container.equals("scala.Option")) {
+                b
+              } else {
+                "%s[%s]".format(normalizeContainer(container), b)
+              }
             }
             case _ => paramType.getName
           }

--- a/modules/swagger-jaxrs/src/test/scala/ResourceWithOptionalsTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/ResourceWithOptionalsTest.scala
@@ -1,0 +1,24 @@
+import com.wordnik.swagger.config.SwaggerConfig
+import com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader
+import org.junit.runner.RunWith
+import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.junit.JUnitRunner
+import testresources.ResourceWithOptionals
+
+@RunWith(classOf[JUnitRunner])
+class ResourceWithOptionalsTest extends FlatSpec with Matchers {
+  it should "read an api and extract an error model" in {
+    val reader = new DefaultJaxrsApiReader
+    val config = new SwaggerConfig()
+    val apiResource = reader.read("/api-docs", classOf[ResourceWithOptionals], config).getOrElse(fail("should not be None"))
+
+    apiResource.apis.size should be (1)
+
+    val api = apiResource.apis.filter(_.path == "/optional/test").head
+    val ops = api.operations
+    ops.size should be (1)
+
+    ops.head.parameters.filter(_.paramType == "query").head.dataType should be ("string")
+
+  }
+}

--- a/modules/swagger-jaxrs/src/test/scala/testresources/ResourceWithOptionals.scala
+++ b/modules/swagger-jaxrs/src/test/scala/testresources/ResourceWithOptionals.scala
@@ -1,0 +1,21 @@
+package testresources
+
+import javax.ws.rs.core.Response
+import javax.ws.rs.{QueryParam, GET, Path}
+
+import com.wordnik.swagger.annotations._
+
+@Path("/optional")
+@Api(value = "/optional", description = "Resource with optional query params")
+class ResourceWithOptionals {
+  @GET
+  @Path("/test")
+  @ApiOperation(value = "Test out optional query param",
+    notes = "No details provided",
+    position = 1)
+  @ApiResponses(Array(
+    new ApiResponse(code = 404, message = "object not found")))
+  def getMaybeString(@ApiParam(value = "optional string input", required = false) @QueryParam("maybeString") maybeString: Option[String]) = {
+    Response.ok.entity(maybeString).build
+  }
+}


### PR DESCRIPTION
Redoing #748 on the proper branch.

From the original PR: This PR unwraps optional-like types (Java Optional<> and Scala Option[]) inside Resource methods -- an improvement over failing through to UNKNOWN[].

/cc @fehguy 
