### PR TITLE
Fix of CORS filter when using Guice

### DIFF
--- a/samples/java-jersey2-guice/src/main/java/com/wordnik/swagger/sample/SwaggerExampleGuiceContextListener.java
+++ b/samples/java-jersey2-guice/src/main/java/com/wordnik/swagger/sample/SwaggerExampleGuiceContextListener.java
@@ -58,7 +58,7 @@ public class SwaggerExampleGuiceContextListener extends GuiceServletContextListe
 
                 bootstrap();
 
-                filter("/*", ApiOriginFilter.class.getName());
+                filter("/*").through(ApiOriginFilter.class);
             }
         });
     }


### PR DESCRIPTION
The Filter method takes in just Strings about patterns - so the CORS filter will not be actually used.
Fixed just by correcting the call.
