### PR TITLE
Attempting to fix #770

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/model/SwaggerSerializers.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/model/SwaggerSerializers.scala
@@ -391,8 +391,8 @@ object SwaggerSerializers extends Serializers {
           ""
         }),
         (json \ "allowableValues").extract[AllowableValues],
-        (json \ "type").extractOrElse({
-          !!(json, OPERATION_PARAM, "type", "missing required field", ERROR)
+        (json \ "paramType").extractOrElse({
+          !!(json, OPERATION_PARAM, "paramType", "missing required field", ERROR)
           ""
         }),
         (json \ "paramAccess").extractOpt[String]


### PR DESCRIPTION
- The JsonSchemaParameterSerializer was expecting `type` instead of `paramType` to determine a parameter's paramType. Fix for #770
