### PR TITLE
Make response headers available to the code generator

### DIFF
--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Response.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Response.java
@@ -9,6 +9,7 @@ public class Response {
   private String description;
   private Property schema;
   private Map<String, String> examples;
+  private Map<String, Property> headers;
 
   public Response schema(Property property) {
     this.setSchema(property);
@@ -45,5 +46,13 @@ public class Response {
   }
   public void setExamples(Map<String, String> examples) {
     this.examples = examples;
+  }
+
+  public Map<String, Property> getHeaders() {
+    return headers;
+  }
+
+  public void setHeaders(Map<String, Property> headers) {
+    this.headers = headers;
   }
 }


### PR DESCRIPTION
With this additional field (and a similar extension to swagger-codegen), it is possible to use response headers (as defined by https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#responseObject) from a specification for code generation
