### PR TITLE
Add support for scala Vector collection parsing

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -400,10 +400,6 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
       val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
       val valueType = parameterizedType.getActualTypeArguments.head
       "List[" + getDataType(valueType, valueType, isSimple) + "]"
-    } else if (TypeUtil.isParameterizedVector(genericReturnType)) {
-      val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
-      val valueType = parameterizedType.getActualTypeArguments.head
-      "Vector[" + getDataType(valueType, valueType, isSimple) + "]"
     } else if (TypeUtil.isParameterizedSet(genericReturnType)) {
       val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
       val valueType = parameterizedType.getActualTypeArguments.head

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -400,6 +400,10 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
       val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
       val valueType = parameterizedType.getActualTypeArguments.head
       "List[" + getDataType(valueType, valueType, isSimple) + "]"
+    } else if (TypeUtil.isParameterizedVector(genericReturnType)) {
+      val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
+      val valueType = parameterizedType.getActualTypeArguments.head
+      "Vector[" + getDataType(valueType, valueType, isSimple) + "]"
     } else if (TypeUtil.isParameterizedSet(genericReturnType)) {
       val parameterizedType = genericReturnType.asInstanceOf[java.lang.reflect.ParameterizedType]
       val valueType = parameterizedType.getActualTypeArguments.head

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
@@ -70,7 +70,7 @@ object TypeUtil {
   def isParameterizedList(gt: Type): Boolean = {
     if (classOf[ParameterizedType].isAssignableFrom(gt.getClass)) {
       val tp = gt.asInstanceOf[ParameterizedType].getRawType
-      (tp == classOf[java.util.List[_]] || tp == classOf[scala.List[_]] || tp == classOf[Seq[_]])
+      (tp == classOf[java.util.List[_]] || tp == classOf[scala.List[_]] || tp == classOf[Seq[_]] || tp == classOf[Vector[_]])
     }
     else false
   }

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
@@ -114,7 +114,7 @@ object TypeUtil {
     val lb = new ListBuffer[String]
     if(genericType.isInstanceOf[ParameterizedType]) {
       val parameterizedType = genericType.asInstanceOf[ParameterizedType]
-      if (isParameterizedList(genericType) || isParameterizedSet(genericType)) {
+      if (isParameterizedList(genericType) || isParameterizedSet(genericType) || isParameterizedVector(genericType)) {
         for (listType <- parameterizedType.getActualTypeArguments)
           lb ++= extractConcreteObjectTypes(listType)
       } else if (isParameterizedMap(genericType)) {

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
@@ -75,6 +75,14 @@ object TypeUtil {
     else false
   }
 
+  def isParameterizedVector(gt: Type): Boolean = {
+    if (classOf[ParameterizedType].isAssignableFrom(gt.getClass)) {
+      val tp = gt.asInstanceOf[ParameterizedType].getRawType
+      tp == classOf[scala.Vector[_]]
+    }
+    else false
+  }
+
   def isParameterizedSet(genericType: Type): Boolean = {
     if(classOf[ParameterizedType].isAssignableFrom(genericType.getClass)) {
       val tp = genericType.asInstanceOf[ParameterizedType].getRawType

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
@@ -75,14 +75,6 @@ object TypeUtil {
     else false
   }
 
-  def isParameterizedVector(gt: Type): Boolean = {
-    if (classOf[ParameterizedType].isAssignableFrom(gt.getClass)) {
-      val tp = gt.asInstanceOf[ParameterizedType].getRawType
-      tp == classOf[scala.Vector[_]]
-    }
-    else false
-  }
-
   def isParameterizedSet(genericType: Type): Boolean = {
     if(classOf[ParameterizedType].isAssignableFrom(genericType.getClass)) {
       val tp = genericType.asInstanceOf[ParameterizedType].getRawType
@@ -114,7 +106,7 @@ object TypeUtil {
     val lb = new ListBuffer[String]
     if(genericType.isInstanceOf[ParameterizedType]) {
       val parameterizedType = genericType.asInstanceOf[ParameterizedType]
-      if (isParameterizedList(genericType) || isParameterizedSet(genericType) || isParameterizedVector(genericType)) {
+      if (isParameterizedList(genericType) || isParameterizedSet(genericType)) {
         for (listType <- parameterizedType.getActualTypeArguments)
           lb ++= extractConcreteObjectTypes(listType)
       } else if (isParameterizedMap(genericType)) {

--- a/modules/swagger-core/src/test/scala/converter/VectorContainerConverterTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/VectorContainerConverterTest.scala
@@ -1,0 +1,24 @@
+package converter
+
+import com.wordnik.swagger.converter._
+import com.wordnik.swagger.model.ModelRef
+import org.junit.runner.RunWith
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class VectorContainerConverterTest extends FlatSpec with Matchers {
+  it should "read a case class with Vector" in {
+    val model = ModelConverters.read(classOf[CaseClassWithvector]).getOrElse(fail("no model found"))
+    model.properties.map{_._1}.toSet should equal(Set("id", "kidsAges"))
+    val properties = model.properties("kidsAges")
+
+    properties.`type` should equal("Vector")
+    properties.items should be(Some(ModelRef("int", None, Some("java.lang.Integer"))))
+  }
+}
+
+case class CaseClassWithvector(
+                                id: Long,
+                                kidsAges: Vector[java.lang.Integer]
+                                )

--- a/modules/swagger-core/src/test/scala/converter/VectorContainerConverterTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/VectorContainerConverterTest.scala
@@ -13,7 +13,7 @@ class VectorContainerConverterTest extends FlatSpec with Matchers {
     model.properties.map{_._1}.toSet should equal(Set("id", "kidsAges"))
     val properties = model.properties("kidsAges")
 
-    properties.`type` should equal("Vector")
+    properties.`type` should equal("List")
     properties.items should be(Some(ModelRef("int", None, Some("java.lang.Integer"))))
   }
 }


### PR DESCRIPTION
Support for scala's `Vector` should be native to swagger as it is the suggested collection when an algorithm will not just process `head`.

I'm not sure if this should be it's own supported type in `ModelPropertyParser ` and accompanying `TypeUtil` or if it should included in the check for `TypeUtil.isParameterizedList` and be rendered as a `List`. 

As this is my first time working with the swagger code base, please let me know if I'm attempting to merge to the wrong branch or placing this in the wrong spot.