### PR TITLE
fix for swagger-core issue #769. Only include method if it has a Jersey annotated HTTP method

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
@@ -222,6 +222,8 @@ trait JaxrsApiReader extends ClassReader with ClassReaderUtils {
 
   def readMethod(method: Method, parentParams: List[Parameter], parentMethods: ListBuffer[Method]): Option[Operation] = {
     val apiOperation = method.getAnnotation(classOf[ApiOperation])
+    if (parseHttpMethod(method, apiOperation) == null) return None
+
     val responseAnnotation = method.getAnnotation(classOf[ApiResponses])
     val apiResponses = {
       if(responseAnnotation == null) List()


### PR DESCRIPTION
This fixes issue 769. The issue seems to be that methods not annotated with @GET, @PUT, etc were getting included.  This brought in unwanted methods such as toString/equals/hashCode. I modified the code to first check that such an annotation exists before reading the method.
