### PR TITLE
fix for swagger-core issue #769. Only include method if it has a Jersey annotated HTTP method

### DIFF
--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/JaxrsApiReader.scala
@@ -155,7 +155,17 @@ trait JaxrsApiReader extends ClassReader with ClassReaderUtils {
           case _ => List()
         })
       }
-      else(method.getName, List(), List(), List(), List())
+      else(method.getName,
+           method.getAnnotation(classOf[Produces]) match {
+             case e: Produces => e.value.toList
+             case _ => List()
+           },
+           method.getAnnotation(classOf[Consumes]) match {
+             case e: Consumes => e.value.toList
+             case _ => List()
+           },
+           List(),
+           List())
     }
     val params = parentParams ++ (for((annotations, paramType, genericParamType) <- (paramAnnotations, paramTypes, genericParamTypes).zipped.toList) yield {
       if(annotations.length > 0) {

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/reader/BasicJaxrsReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/reader/BasicJaxrsReader.scala
@@ -70,7 +70,17 @@ class BasicJaxrsReader extends JaxrsApiReader {
             case _ => None
           }
         )}
-        else ((List(), List(), List(), None))
+        else ((
+          cls.getAnnotation(classOf[Consumes]) match {
+            case e: Consumes => e.value.toList
+            case _ => List()
+          },
+          cls.getAnnotation(classOf[Produces]) match {
+            case e: Produces => e.value.toList
+            case _ => List()
+          },
+          List(),
+          None))
       }
       // look for method-level annotated properties
       val parentParams: List[Parameter] = getAllParamsFromFields(cls)


### PR DESCRIPTION
This fixes issue 769. The issue seems to be that methods not annotated with @GET, @PUT, etc were getting included. This brought in unwanted methods such as toString/equals/hashCode. I modified the code to first check that such an annotation exists before reading the method.
