### PR TITLE
Enhanced BeanConfig to support @Path JAX-RS resources. Fixed BasicJaxrsReader operations recognition

### DIFF
--- a/modules/swagger-jaxrs/pom.xml
+++ b/modules/swagger-jaxrs/pom.xml
@@ -30,6 +30,11 @@
   </build>
   <dependencies>
     <dependency>
+      <groupId>javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.12.1.GA</version>
+    </dependency>  
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.10</artifactId>
       <scope>test</scope>

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/config/BeanConfig.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/config/BeanConfig.scala
@@ -7,18 +7,15 @@ import com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader
 import com.wordnik.swagger.config._
 import com.wordnik.swagger.reader._
 import com.wordnik.swagger.core.filter._
-
 import org.reflections.Reflections
 import org.reflections.scanners.{ SubTypesScanner, TypeAnnotationsScanner }
 import org.reflections.util.{ ClasspathHelper, ConfigurationBuilder}
-
 import org.slf4j.LoggerFactory
-
 import javax.servlet.ServletConfig
 import javax.ws.rs.core.Application
-
 import scala.collection.JavaConverters._
 import scala.beans.BeanProperty
+import javax.ws.rs.Path
 
 class BeanConfig extends JaxrsScanner {
   private val LOGGER = LoggerFactory.getLogger(classOf[BeanConfig])
@@ -57,7 +54,9 @@ class BeanConfig extends JaxrsScanner {
   def classesFromContext(app: Application, sc: ServletConfig) : List[Class[_]] = {
     val config = new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(resourcePackage)).setScanners(
       new TypeAnnotationsScanner(), new SubTypesScanner())
-    new Reflections(config).getTypesAnnotatedWith(classOf[Api]).asScala.toList
+    var relections = new Reflections(config)
+    (relections.getTypesAnnotatedWith(classOf[Api]).asScala ++ 
+      relections.getTypesAnnotatedWith(classOf[Path]).asScala ).toList
   }
 
   def setApiReader(reader: String) = {

--- a/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/reader/BasicJaxrsReader.scala
+++ b/modules/swagger-jaxrs/src/main/scala/com/wordnik/swagger/jaxrs/reader/BasicJaxrsReader.scala
@@ -16,6 +16,9 @@ import javax.ws.rs.core.Context
 import scala.collection.mutable.{ ListBuffer, HashMap, HashSet }
 
 class BasicJaxrsReader extends JaxrsApiReader {
+  private[this] final val verbsOrApi = Set(classOf[GET], classOf[DELETE], classOf[HEAD], 
+    classOf[OPTIONS], classOf[POST], classOf[PUT], classOf[ApiOperation]) 
+    
   var ignoredRoutes: Set[String] = Set()
 
   def ignoreRoutes = ignoredRoutes
@@ -100,9 +103,11 @@ class BasicJaxrsReader extends JaxrsApiReader {
             parentMethods -= method
           }
           case _ => {
-            readMethod(method, parentParams, parentMethods) match {
-              case Some(op) => appendOperation(endpoint, path, op, operations)
-              case None => None
+            if(verbsOrApi.exists(method.getAnnotation(_) != null)) {
+              readMethod(method, parentParams, parentMethods) match {
+                case Some(op) => appendOperation(endpoint, path, op, operations)
+                case None => None
+              }
             }
           }
         }

--- a/modules/swagger-jaxrs/src/test/scala/NonAnnotatedResourceBeanConfigTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/NonAnnotatedResourceBeanConfigTest.scala
@@ -1,32 +1,37 @@
 import testresources._
-
 import com.wordnik.swagger.jaxrs.reader._
 import com.wordnik.swagger.core.util._
 import com.wordnik.swagger.model._
 import com.wordnik.swagger.config._
 import com.wordnik.swagger.core.filter._
-
 import java.lang.reflect.Method
-
 import java.util.Date
-
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
-
 import scala.collection.mutable.ListBuffer
+import com.wordnik.swagger.jaxrs.config.BeanConfig
+import com.wordnik.swagger.reader.ClassReaders
+import com.wordnik.swagger.config.ConfigFactory
 
 @RunWith(classOf[JUnitRunner])
-class NonAnnotatedResourceTest extends FlatSpec with Matchers {
+class NonAnnotatedResourceBeanConfigTest extends FlatSpec with Matchers {
   it should "read a resource without Api annotations" in {
-    val reader = new BasicJaxrsReader
-    val config = new SwaggerConfig()
+    val beanConfig = new BeanConfig()
+    beanConfig.setApiReader("com.wordnik.swagger.jaxrs.reader.BasicJaxrsReader")
+    beanConfig.setResourcePackage("testresources")
+    
+    val reader =  ClassReaders.reader.get
+    val config = ConfigFactory.config
+    
+    val classes = beanConfig.classesFromContext(null, null)
+    classes should contain (classOf[NonAnnotatedResource])
     
     val apiResource = reader.read("/api-docs", classOf[NonAnnotatedResource], config).getOrElse(fail("should not be None"))
     apiResource.apis should have size 2
-
-    val apis = apiResource.apis.map(m => (m.path -> m)).toMap
+    
+    val apis = apiResource.apis.map(m => (m.path -> m)).toMap    
 
     val api1 = apis("/basic/{id}/r")
     val ops1 = api1.operations.map(m => (m.method -> m)).toMap
@@ -44,5 +49,19 @@ class NonAnnotatedResourceTest extends FlatSpec with Matchers {
 
     val models = apiResource.models.get
     val howdy = models("Howdy")    
+  }
+  
+  it should "not read a resource without Api annotations" in {
+    val beanConfig = new BeanConfig()
+    beanConfig.setResourcePackage("testresources")
+    
+    val reader =  ClassReaders.reader.get
+    val config = ConfigFactory.config
+    
+    val classes = beanConfig.classesFromContext(null, null)
+    classes should contain (classOf[NonAnnotatedResource])
+    
+    val apiResource = reader.read("/api-docs", classOf[NonAnnotatedResource], config)
+    apiResource should be === None 
   }
 }


### PR DESCRIPTION
Hey guys,

Resubmitting https://github.com/swagger-api/swagger-core/pull/793 against develop_scala-2.10 branch.
-----------------------------------------------------------------------------------------------------------------------------------

While working on JAX-RS applications, I have run into the issues that Swagger has a bit limited support of the native JAX-RS services/resources which do not use @ApiXxx annotations, however the most of required implementation is already there, in Swagger JAX-RS module. 

The small change in BeanConfig allows to introspect not only @Api - annotated classes but @Path - annotated ones as well. When used with BasicJaxrsReader, the @ApiXxx annotations are not required anymore. The small fix inside BasicJaxrsReader makes operations recognition more picky (otherwise all Object methods like wait(), equals(), toString() .... will be included, it is current behavior). 

The tests have been added to confirm that by default the BeanConfig behavior is not changed. And, by setting reader to BasicJaxrsReader, the proper JAX-RS API description is being built (without any @ApiXxx annotations) for native JAX-RS service/resource.

I think these small changes allow to integrate Swagger into existing JAX-RS applications much faster and easier, while developers are immediately benefiting from using it in conjunction with Swagger UI. Apache CXF has already support for Swagger but it is going to be better with these fixes.

Thank you.

Best Regards,
 Andriy Redko