### PR TITLE
add swagger root and path specific parameters to model, created RefParam...

### DIFF
--- a/modules/swagger-core/src/main/java/com/wordnik/swagger/util/Json.java
+++ b/modules/swagger-core/src/main/java/com/wordnik/swagger/util/Json.java
@@ -1,6 +1,7 @@
 package com.wordnik.swagger.util;
 
 import com.wordnik.swagger.models.Model;
+import com.wordnik.swagger.models.parameters.Parameter;
 import com.wordnik.swagger.models.properties.Property;
 
 import com.fasterxml.jackson.datatype.joda.JodaModule;
@@ -26,6 +27,7 @@ public class Json {
     SimpleModule module = new SimpleModule();
     module.addDeserializer(Property.class, new PropertyDeserializer());
     module.addDeserializer(Model.class, new ModelDeserializer());
+    module.addDeserializer(Parameter.class, new ParameterDeserializer());
     mapper.registerModule(module);
     mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);

--- a/modules/swagger-core/src/main/java/com/wordnik/swagger/util/ParameterDeserializer.java
+++ b/modules/swagger-core/src/main/java/com/wordnik/swagger/util/ParameterDeserializer.java
@@ -1,0 +1,45 @@
+package com.wordnik.swagger.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.wordnik.swagger.models.parameters.*;
+
+import java.io.IOException;
+
+public class ParameterDeserializer extends JsonDeserializer<Parameter> {
+    @Override
+    public Parameter deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        Parameter result = null;
+
+        JsonNode node = jp.getCodec().readTree(jp);
+        JsonNode sub = node.get("$ref");
+
+        JsonNode inNode = node.get("in");
+
+        if (sub != null) {
+            result = Json.mapper().convertValue(sub, RefParameter.class);
+        } else if (inNode != null) {
+
+            String in = inNode.asText();
+            if ("query".equals(in)) {
+                result = Json.mapper().convertValue(node, QueryParameter.class);
+            } else if ("header".equals(in)) {
+                result = Json.mapper().convertValue(node, HeaderParameter.class);
+            } else if ("path".equals(in)) {
+                result = Json.mapper().convertValue(node, PathParameter.class);
+            } else if ("formData".equals(in)) {
+                result = Json.mapper().convertValue(node, FormParameter.class);
+            } else if ("body".equals(in)) {
+                result = Json.mapper().convertValue(node, BodyParameter.class);
+            } else if ("cookie".equals(in)) {
+                result = Json.mapper().convertValue(node, CookieParameter.class);
+            }
+        }
+
+        return result;
+    }
+}

--- a/modules/swagger-core/src/main/java/com/wordnik/swagger/util/Yaml.java
+++ b/modules/swagger-core/src/main/java/com/wordnik/swagger/util/Yaml.java
@@ -1,6 +1,7 @@
 package com.wordnik.swagger.util;
 
 import com.wordnik.swagger.models.Model;
+import com.wordnik.swagger.models.parameters.Parameter;
 import com.wordnik.swagger.models.properties.Property;
 
 import com.fasterxml.jackson.datatype.joda.JodaModule;
@@ -21,6 +22,7 @@ public class Yaml {
       SimpleModule module = new SimpleModule();
       module.addDeserializer(Property.class, new PropertyDeserializer());
       module.addDeserializer(Model.class, new ModelDeserializer());
+      module.addDeserializer(Parameter.class, new ParameterDeserializer());
       mapper.registerModule(module);
       mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
       mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);

--- a/modules/swagger-core/src/test/scala/parameter/ParameterSerializationTest.scala
+++ b/modules/swagger-core/src/test/scala/parameter/ParameterSerializationTest.scala
@@ -1,8 +1,9 @@
+import com.fasterxml.jackson.databind.module.SimpleModule
 import com.wordnik.swagger.models._
 import com.wordnik.swagger.models.properties._
 import com.wordnik.swagger.models.parameters._
 
-import com.wordnik.swagger.util.Json
+import com.wordnik.swagger.util._
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -18,11 +19,7 @@ import org.scalatest.Matchers
 @RunWith(classOf[JUnitRunner])
 class ParameterSerializationTest extends FlatSpec with Matchers {
   val m = Json.mapper()
-
-  val yaml = new ObjectMapper(new YAMLFactory())
-  yaml.setSerializationInclusion(JsonInclude.Include.NON_NULL)
-  yaml.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-  yaml.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+  val yaml = Yaml.mapper()
 
   it should "serialize a QueryParameter" in {
     val p = new QueryParameter().property(new StringProperty())
@@ -67,7 +64,8 @@ class ParameterSerializationTest extends FlatSpec with Matchers {
       .collectionFormat("multi")
     m.writeValueAsString(p) should be ("""{"in":"path","required":true,"type":"array","items":{"type":"string"},"collectionFormat":"multi"}""")
     yaml.writeValueAsString(p) should equal (
-"""--- !<path>
+"""---
+in: "path"
 required: true
 type: "array"
 items:
@@ -100,8 +98,11 @@ collectionFormat: "multi"
     val p = new HeaderParameter().property(new StringProperty())
     m.writeValueAsString(p) should be ("""{"in":"header","required":false,"type":"string"}""")
     yaml.writeValueAsString(p) should equal(
-"--- !<header>\nrequired: false\ntype: \"string\"\n"
-    )
+"""---
+in: "header"
+required: false
+type: "string"
+""")
   }
 
   it should "deserialize a HeaderParameter" in {
@@ -138,7 +139,8 @@ collectionFormat: "multi"
       .property("name", new StringProperty())
     val p = new BodyParameter().schema(model)
     yaml.writeValueAsString(p) should equal(
-"""--- !<body>
+"""---
+in: "body"
 required: false
 schema:
   properties:

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Path.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Path.java
@@ -2,6 +2,11 @@ package com.wordnik.swagger.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.wordnik.swagger.models.parameters.Parameter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @JsonPropertyOrder({ "get", "post", "put", "delete", "options", "patch"})
 public class Path {
@@ -11,6 +16,7 @@ public class Path {
   private Operation delete;
   private Operation patch;
   private Operation options;
+  private List<Parameter> parameters;
 
   public Path set(String method, Operation op) {
     if("get".equals(method))
@@ -93,6 +99,19 @@ public class Path {
   }
   public void setOptions(Operation options) {
     this.options = options;
+  }
+
+  public List<Parameter> getParameters() {
+    return parameters;
+  }
+  public void setParameters(List<Parameter> parameters) {
+    this.parameters = parameters;
+  }
+  public void addParameter(Parameter parameter) {
+    if(this.parameters == null) {
+        this.parameters = new ArrayList<Parameter>();
+    }
+    this.parameters.add(parameter);
   }
 
   @JsonIgnore

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Swagger.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Swagger.java
@@ -198,17 +198,7 @@ public class Swagger {
   }
 
   public Map<String, Parameter> getParameters() {
-    if(paths == null)
-      return null;
-    Map<String, Parameter> sorted = new LinkedHashMap<String, Parameter>();
-    List<String> keys = new ArrayList<String>();
-    keys.addAll(paths.keySet());
-    Collections.sort(keys);
-
-    for(String key: keys) {
-      sorted.put(key, parameters.get(key));
-    }
-    return sorted;
+    return parameters;
   }
 
   public void setParameters(Map<String, Parameter> parameters) {
@@ -220,6 +210,11 @@ public class Swagger {
         return null;
     return this.parameters.get(parameter);
   }
+    public void addParameters(String key, Parameter parameter) {
+        if(this.parameters == null)
+            this.parameters = new HashMap<String, Parameter>();
+        this.parameters.put(key, parameter);
+    }
 
   public ExternalDocs getExternalDocs() {
     return externalDocs;

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Swagger.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Swagger.java
@@ -3,6 +3,7 @@ package com.wordnik.swagger.models;
 import com.wordnik.swagger.models.auth.SecuritySchemeDefinition;
 
 import com.fasterxml.jackson.annotation.*;
+import com.wordnik.swagger.models.parameters.Parameter;
 
 import java.util.*;
 
@@ -18,6 +19,7 @@ public class Swagger {
   protected Map<String, Path> paths;
   protected Map<String, SecuritySchemeDefinition> securityDefinitions;
   protected Map<String, Model> definitions;
+  protected Map<String, Parameter> parameters;
   protected ExternalDocs externalDocs;
 
   public Swagger info(Info info) {
@@ -193,6 +195,30 @@ public class Swagger {
     if(this.definitions == null)
       this.definitions = new HashMap<String, Model>();
     this.definitions.put(key, model);
+  }
+
+  public Map<String, Parameter> getParameters() {
+    if(paths == null)
+      return null;
+    Map<String, Parameter> sorted = new LinkedHashMap<String, Parameter>();
+    List<String> keys = new ArrayList<String>();
+    keys.addAll(paths.keySet());
+    Collections.sort(keys);
+
+    for(String key: keys) {
+      sorted.put(key, parameters.get(key));
+    }
+    return sorted;
+  }
+
+  public void setParameters(Map<String, Parameter> parameters) {
+    this.parameters = parameters;
+  }
+
+  public Parameter getParameter(String parameter) {
+    if(this.parameters == null)
+        return null;
+    return this.parameters.get(parameter);
   }
 
   public ExternalDocs getExternalDocs() {

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/parameters/AbstractParameter.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/parameters/AbstractParameter.java
@@ -1,9 +1,7 @@
 package com.wordnik.swagger.models.parameters;
 
-import com.fasterxml.jackson.annotation.*;
 
 public abstract class AbstractParameter {
-  @JsonIgnore
   protected String in;
   protected String name;
   protected String description;

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/parameters/Parameter.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/parameters/Parameter.java
@@ -3,6 +3,7 @@ package com.wordnik.swagger.models.parameters;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeId;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 public interface Parameter {

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/parameters/Parameter.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/parameters/Parameter.java
@@ -5,17 +5,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-@JsonTypeInfo(
-  use = JsonTypeInfo.Id.NAME,
-  include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
-  property = "in")
-@JsonSubTypes({  
-  @Type(value = BodyParameter.class, name = "body"),
-  @Type(value = HeaderParameter.class, name = "header"),
-  @Type(value = PathParameter.class, name = "path"),
-  @Type(value = QueryParameter.class, name = "query"),
-  @Type(value = FormParameter.class, name = "formData"),
-  @Type(value = CookieParameter.class, name = "cookie")})
 public interface Parameter {
   // @JsonIgnore
   String getIn();

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/parameters/RefParameter.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/parameters/RefParameter.java
@@ -1,0 +1,43 @@
+package com.wordnik.swagger.models.parameters;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.wordnik.swagger.models.properties.AbstractProperty;
+import com.wordnik.swagger.models.properties.Property;
+
+public class RefParameter extends AbstractParameter implements Parameter {
+  String ref;
+
+  public RefParameter(String ref) {
+    set$ref(ref);
+  }
+
+  public RefParameter asDefault(String ref) {
+    this.set$ref("#/parameters/" + ref);
+    return this;
+  }
+  public RefParameter description(String description) {
+    this.setDescription(description);
+    return this;
+  }
+
+  public String get$ref() {
+    return ref;
+  }
+  public void set$ref(String ref) {
+    this.ref = ref;
+  }
+
+  @JsonIgnore
+  public String getSimpleRef() {
+    if(ref.indexOf("#/definitions/") == 0)
+      return ref.substring("#/definitions/".length());
+    else
+      return ref;
+  }
+
+  public static boolean isType(String type, String format) {
+    if("$ref".equals(type))
+      return true;
+    else return false;
+  }
+}


### PR DESCRIPTION
Proposing this as a first draft to fix #705.

* Added a map of Parameter objects to Swagger.java
* Added a List of Parameter objects to Path.java
* Created RefParameter.java to mirror RefProperty.java 
 * RefParameters only have one field of interest (i.e. $ref) which is not exposed in the Parameter interface
 * I am assuming that anyone iterating over a list of Parameter objects, will need to do an instance-of check if they want to handle refs (e.g. in codegen)
* Removed Jackson JsonTypeInfo and JsonSubTypes annotations from Parameter.java
 * I am a Jackson novice, but it appears after some googling that these annotations do not work for the RefParameter edge case
* Created a ParameterDeserializer class to handle the more complex deserialization logic
 * If there is a clever way to do this with Jackson annotations please advise and I will change it
* Added ParameterDeserializer to YAML.java and JSON.java ObjectMapper configuration logic

I am interested in getting Ref's working in swagger-codegen develop_2.0. Please advise. 