### PR TITLE
Fix tests on Windows

### DIFF
--- a/modules/swagger-core/src/test/scala/auth/AuthSerializationTest.scala
+++ b/modules/swagger-core/src/test/scala/auth/AuthSerializationTest.scala
@@ -4,6 +4,8 @@ import com.wordnik.swagger.util.Json
 import com.wordnik.swagger.util.Yaml
 import com.wordnik.swagger.models.auth._
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+
 import scala.collection.JavaConverters._
 
 import org.junit.runner.RunWith
@@ -26,16 +28,13 @@ class AuthSerializationTest extends FlatSpec with Matchers {
   }
 
   it should "convert serialize a header key model to yaml" in {
-    val auth = new ApiKeyAuthDefinition()
-      .name("api-key")
-      .in(In.HEADER)
-    Yaml.mapper.writeValueAsString(auth) should be (
-    """---
+    Yaml.mapper().convertValue(new ApiKeyAuthDefinition().name("api-key").in(In.HEADER),
+                               classOf[ObjectNode]) should equal (
+      Yaml.mapper().readValue("""---
 type: "apiKey"
 name: "api-key"
 in: "header"
-"""
-    )
+""", classOf[ObjectNode]))
   }
 
   it should "convert serialize an oauth2 implicit flow model" in {

--- a/modules/swagger-core/src/test/scala/parameter/ParameterSerializationTest.scala
+++ b/modules/swagger-core/src/test/scala/parameter/ParameterSerializationTest.scala
@@ -6,6 +6,7 @@ import com.wordnik.swagger.models.parameters._
 import com.wordnik.swagger.util._
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.core.JsonGenerator.Feature
 import com.fasterxml.jackson.databind._
@@ -63,15 +64,15 @@ class ParameterSerializationTest extends FlatSpec with Matchers {
       .items(new StringProperty())
       .collectionFormat("multi")
     m.writeValueAsString(p) should be ("""{"in":"path","required":true,"type":"array","items":{"type":"string"},"collectionFormat":"multi"}""")
-    yaml.writeValueAsString(p) should equal (
-"""---
+    Yaml.mapper().convertValue(p, classOf[ObjectNode]) should equal (
+      Yaml.mapper().readValue("""---
 in: "path"
 required: true
 type: "array"
 items:
   type: "string"
 collectionFormat: "multi"
-""")
+""", classOf[ObjectNode]))
   }
 
   it should "deserialize a string array PathParameter" in {
@@ -97,12 +98,12 @@ collectionFormat: "multi"
   it should "serialize a HeaderParameter" in {
     val p = new HeaderParameter().property(new StringProperty())
     m.writeValueAsString(p) should be ("""{"in":"header","required":false,"type":"string"}""")
-    yaml.writeValueAsString(p) should equal(
-"""---
+    Yaml.mapper().convertValue(p, classOf[ObjectNode]) should equal (
+      Yaml.mapper().readValue("""---
 in: "header"
 required: false
 type: "string"
-""")
+""", classOf[ObjectNode]))
   }
 
   it should "deserialize a HeaderParameter" in {
@@ -138,15 +139,15 @@ type: "string"
       .name("Cat")
       .property("name", new StringProperty())
     val p = new BodyParameter().schema(model)
-    yaml.writeValueAsString(p) should equal(
-"""---
+    Yaml.mapper().convertValue(p, classOf[ObjectNode]) should equal (
+      Yaml.mapper().readValue("""---
 in: "body"
 required: false
 schema:
   properties:
     name:
       type: "string"
-""")
+""", classOf[ObjectNode]))
   }
 
   it should "deserialize a BodyParameter" in {


### PR DESCRIPTION
Only YAML tests were impacted because only YAML tests (as of now) were
using multi-line strings for comparison.  The approach taken was to
convert the object under test to an ObjectNode, read the multi-line
YAML into an ObjectNode and then use "should equal" for comparison.

This would make #822 unnecessary and could be used in the future to create a test utility for testing real objects instead of string outputs.