### PR TITLE
Issue #847 - Support abstract base models without fields

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
@@ -58,8 +58,8 @@ class SwaggerSchemaConverter
             (for(subType <- cls.getAnnotation(classOf[JsonSubTypes]).value) yield (subType.value.getName)).toList
           else List()
         }
-        sortedProperties.size match {
-          case 0 => None
+        (sortedProperties.size, subTypes.size) match {
+          case (0, 0) => None
           case _ => Some(Model(
             toName(cls),
             toName(cls),

--- a/modules/swagger-core/src/test/scala/converter/SubTypeModelTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/SubTypeModelTest.scala
@@ -32,4 +32,30 @@ class SubTypeModelTest extends FlatSpec with Matchers {
     model.subTypes.size should be (2)
     write(model) should be ("""{"id":"Animal","description":"a model with subtypes","discriminator":"name","properties":{"name":{"type":"string","description":"name of animal"},"date":{"type":"string","format":"date-time","description":"date added"}},"subTypes":["DomesticAnimal","WildAnimal"]}""")
   }
+
+  it should "read an abstract trait with subTypes" in {
+    val models = ModelConverters.readAll(classOf[AbstractBaseModelWithSubTypes])
+    models.size should be (3)
+    val expectedModels = Seq("AbstractBaseModelWithSubTypes", "Thing1", "Thing2")
+    expectedModels.foreach(m => {
+      val modelOpt = models.find(md => md.name == m)
+      modelOpt should be ('defined)
+    })
+    val attrADescription = models.find(m => m.name == "Thing1").flatMap(m => m.properties.get("a").flatMap(a => a.description))
+    attrADescription should be ('defined)
+    attrADescription.get should equal ("Override the abstract a")
+  }
+
+  it should "read an abstract trait with subTypes but without fields" in {
+    val models = ModelConverters.readAll(classOf[AbstractBaseModelWithoutFields])
+    models.size should be (2)
+    val expectedModels = Seq("AbstractBaseModelWithoutFields", "Thing3")
+    expectedModels.foreach(m => {
+      val modelOpt = models.find(md => md.name == m)
+      modelOpt should be ('defined)
+    })
+    val attrADescription = models.find(m => m.name == "Thing3").flatMap(m => m.properties.get("a").flatMap(a => a.description))
+    attrADescription should be ('defined)
+    attrADescription.get should equal ("Additional field a")
+  }
 }

--- a/modules/swagger-core/src/test/scala/models/AbstractModelWithSubTypes.scala
+++ b/modules/swagger-core/src/test/scala/models/AbstractModelWithSubTypes.scala
@@ -1,0 +1,43 @@
+package models
+
+import scala.annotation.meta.{getter, field}
+import com.wordnik.swagger.annotations.{ApiModelProperty, ApiModel}
+
+
+@ApiModel(description = "I am an Abstract Base Model with Sub-Types",
+  discriminator = "_type",
+  subTypes = Array(classOf[Thing1], classOf[Thing2]))
+trait AbstractBaseModelWithSubTypes {
+  @(ApiModelProperty @getter)(value = "This value is used as a discriminator for serialization") val _type: String
+  @(ApiModelProperty @getter)(value = "An arbitrary field") val a: String
+  @(ApiModelProperty @getter)(value = "An arbitrary field") val b: String
+}
+
+@ApiModel(description = "Shake hands with Thing1", parent = classOf[AbstractBaseModelWithSubTypes])
+case class Thing1(
+                   @(ApiModelProperty @field)(value = "Override the abstract a") a: String,
+                   @(ApiModelProperty @field)(value = "Thing1 has an additional field") x: Int)
+  extends AbstractBaseModelWithSubTypes {
+  val _type = "Thing1"
+  val b = "bThing"
+}
+
+@ApiModel(description = "and Thing2", parent = classOf[AbstractBaseModelWithSubTypes])
+case class Thing2(
+                   @(ApiModelProperty @field)(value = "Override the abstract a") a: String,
+                   @(ApiModelProperty @field)(value = "Thing2 has an additional field") s: String)
+  extends AbstractBaseModelWithSubTypes {
+  val _type = "Thing2"
+  val b = "bThing"
+}
+
+@ApiModel(description = "I am an Abstract Base Model without any declared fields and with Sub-Types",
+  subTypes = Array(classOf[Thing3]))
+trait AbstractBaseModelWithoutFields {
+}
+
+@ApiModel(description = "Thing3", parent = classOf[AbstractBaseModelWithoutFields])
+case class Thing3(
+                  @(ApiModelProperty @field)(value = "Additional field a") a: String,
+                  @(ApiModelProperty @field)(value = "Additional field x") x: Int)
+  extends AbstractBaseModelWithoutFields


### PR DESCRIPTION
Support an abstract base model that doesn't directly define any fields by returning a defined Model object from SwaggerSchemaConverter if either there are properties defined or subTypes defined.