### PR TITLE
Support mixing Jackson annotation with @ApiModel annotations

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
@@ -35,15 +35,15 @@ class SwaggerSchemaConverter
         val sortedProperties = new LinkedHashMap[String, ModelProperty]()
         p.sortWith(_._1 < _._1).foreach(e => sortedProperties += e._2 -> e._3)
 
-        val parent = Option(cls.getAnnotation(classOf[ApiModel])) match {
+        val apiModelAnnotation: ApiModel = cls.getAnnotation(classOf[ApiModel])
+        val parent = Option(apiModelAnnotation) match {
           case Some(e) => Some(e.parent.getName)
           case _ => None
         }
         val discriminator = {
           val v = {
-            val apiAnno = cls.getAnnotation(classOf[ApiModel])
-            if(apiAnno != null && apiAnno.discriminator != null)
-              apiAnno.discriminator
+            if (apiModelAnnotation != null && apiModelAnnotation.discriminator != null && ! apiModelAnnotation.discriminator().isEmpty)
+              apiModelAnnotation.discriminator
             else if(cls.getAnnotation(classOf[JsonTypeInfo]) != null)
               cls.getAnnotation(classOf[JsonTypeInfo]).property
             else "" 
@@ -52,8 +52,8 @@ class SwaggerSchemaConverter
           else None
         }
         val subTypes = {
-          if(cls.getAnnotation(classOf[ApiModel]) != null)
-            cls.getAnnotation(classOf[ApiModel]).subTypes.map(_.getName).toList
+          if(apiModelAnnotation != null && apiModelAnnotation.subTypes() != null && ! apiModelAnnotation.subTypes().isEmpty)
+            apiModelAnnotation.subTypes.map(_.getName).toList
           else if(cls.getAnnotation(classOf[JsonSubTypes]) != null)
             (for(subType <- cls.getAnnotation(classOf[JsonSubTypes]).value) yield (subType.value.getName)).toList
           else List()

--- a/modules/swagger-core/src/test/scala/converter/JacksonSubTypeModelTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/JacksonSubTypeModelTest.scala
@@ -31,7 +31,7 @@ class JacksonSubTypeModelTest extends FlatSpec with Matchers {
     val model = ModelConverters.read(classOf[JAnimal]).getOrElse(fail("no model found"))
     model.subTypes.size should be (2)
 
-    write(model) should be ("""{"id":"JAnimal","discriminator":"type","properties":{"type":{"type":"string","description":"type of animal"},"date":{"type":"string","format":"date-time","description":"Date added to the zoo"}},"subTypes":["JWildAnimal","JDomesticAnimal"]}""")
+    write(model) should be ("""{"id":"JAnimal","description":"a java model with subtypes","discriminator":"type","properties":{"type":{"type":"string","description":"type of animal"},"date":{"type":"string","format":"date-time","description":"Date added to the zoo"}},"subTypes":["JWildAnimal","JDomesticAnimal"]}""")
 
 /*
 {

--- a/modules/swagger-core/src/test/scala/models/JAnimal.java
+++ b/modules/swagger-core/src/test/scala/models/JAnimal.java
@@ -1,5 +1,6 @@
 package models;
 
+import com.wordnik.swagger.annotations.ApiModel;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
 import com.fasterxml.jackson.annotation.*;
@@ -7,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 
 import java.util.Date;
 
+@ApiModel(description="a java model with subtypes")
 @JsonTypeInfo( use=JsonTypeInfo.Id.NAME, include=JsonTypeInfo.As.PROPERTY, property="type" )
 @JsonSubTypes( { @Type( value = JWildAnimal.class, name = "wild" ), 
                              @Type( value = JDomesticAnimal.class, name = "domestic" ) } )


### PR DESCRIPTION
In some cases we want to add for example a description to a class with existing @JsonSubTypes and @JsonTypeInfo annotations.

With this fix the @ApiModel annotation will not override discriminator and subtypes if they are not set.