### PR TITLE
Fix complication of DefaultParameterExtension

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/DefaultParameterExtension.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.lang.reflect.*;
 import java.lang.annotation.Annotation;
 
 import javax.ws.rs.QueryParam;


### PR DESCRIPTION
DefaultParameterExtension imports both java.lang.reflect.* and com.wordnik.swagger.models.parameters.* making the correct package for class Parameter ambiguous. java.lang.reflect.* is not required so remove it to fix compilation.