### PR TITLE
Bugfix for 867 (incorrect parsing of generic class when generic parameter is inner class)

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/BaseConverter.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/BaseConverter.scala
@@ -2,6 +2,7 @@ package com.wordnik.swagger.converter
 
 import com.wordnik.swagger.core.SwaggerSpec
 import com.wordnik.swagger.annotations.ApiModel
+import com.wordnik.swagger.core.util.TypeUtil
 
 trait BaseConverter {
   def toDescriptionOpt(cls: Class[_]): Option[String] = {
@@ -27,7 +28,7 @@ trait BaseConverter {
       toName(xmlEnum.value())
     else if (xmlRootElement != null) {
       if ("##default".equals(xmlRootElement.name())) {
-        cls.getSimpleName 
+        TypeUtil.getClassSimpleName(cls)
       } else {
         xmlRootElement.name() 
       }
@@ -38,6 +39,6 @@ trait BaseConverter {
       else name
     }
     else if (cls.getName.indexOf(".") < 0) cls.getName
-    else cls.getSimpleName 
+    else TypeUtil.getClassSimpleName(cls)
   }
 }

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -199,10 +199,10 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
     if (!(isTransient && !isXmlElement && !isJsonProperty) && name != null && (isFieldExists || isGetter || isDocumented)) {
       var paramType = getDataType(genericReturnType, returnType, false)
       LOGGER.debug("inspecting " + paramType)
+      val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-0-9$_]*)\\].*".r
       var simpleName = Option(overrideDataType) match {
         case Some(e) => {
           // split out the base part
-          val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-0-9_]*)\\].*".r
           val out = e match {
             case ComplexTypeMatcher(t, e) => e.substring(e.lastIndexOf(".") + 1)
             case _ => e
@@ -214,7 +214,6 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
       if (!"void".equals(paramType) && null != paramType && !processedFields.contains(name)) {
         if(!excludedFieldTypes.contains(paramType)) {
           val items = {
-            val ComplexTypeMatcher = "([a-zA-Z]*)\\[([a-zA-Z\\.\\-0-9_]*)\\].*".r
             val nameToUse = {
               if(overrideDataType != null) 
                 overrideDataType
@@ -522,7 +521,7 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
         else hostClass.getName
       } else if (xmlRootElement != null) {
         if ("##default".equals(xmlRootElement.name())) {
-          if (isSimple) hostClass.getSimpleName
+          if (isSimple) TypeUtil.getClassSimpleName(hostClass)
           else hostClass.getName
         } else {
           if (isSimple) readString(xmlRootElement.name())
@@ -531,7 +530,7 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
       } else if (hostClass.getName.startsWith("java.lang.") && isSimple) {
         hostClass.getName.substring("java.lang.".length)
       } else {
-        if (isSimple) hostClass.getSimpleName
+        if (isSimple) TypeUtil.getClassSimpleName(hostClass)
         else hostClass.getName
       }
     }

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/ModelUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/ModelUtil.scala
@@ -157,7 +157,7 @@ object ModelUtil {
       toName(xmlEnum.value())
     else if (xmlRootElement != null) {
       if ("##default".equals(xmlRootElement.name())) {
-        cls.getSimpleName 
+        TypeUtil.getClassSimpleName(cls)
       } else {
         xmlRootElement.name() 
       }
@@ -168,7 +168,7 @@ object ModelUtil {
       else name
     }
     else if (cls.getName.indexOf(".") < 0) cls.getName
-    else cls.getSimpleName 
+    else TypeUtil.getClassSimpleName(cls)
   }
 
   def shoudIncludeModel(modelname: String) = {

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/core/util/TypeUtil.scala
@@ -231,4 +231,14 @@ object TypeUtil {
   }
 
   def addAllowablePackage(p: String) = Option(p).map(allowablePackages += p)
+
+  def getClassSimpleName(clazz: Class[_]): String = {
+// FIXME: Shall we expand name of inner classes to something like OuterClass$InnerClass to avoid name collisions ?
+//    if (clazz.isMemberClass) {
+//      val packageName = clazz.getPackage.getName
+//      if (!packageName.isEmpty) clazz.getName.substring(packageName.length + 1) else clazz.getName
+//    }
+//    else
+      clazz.getSimpleName
+  }
 }

--- a/modules/swagger-core/src/test/scala/converter/ModelPropertyParserTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/ModelPropertyParserTest.scala
@@ -20,6 +20,14 @@ import scala.beans.BeanProperty
 @RunWith(classOf[JUnitRunner])
 class ModelPropertyParserTest extends FlatSpec with Matchers {
 
+  it should "extract generic list from property where generic parameter is embedded class" in {
+    val cls = classOf[ModelWithEmbeddedClassAsGenericParameter]
+    implicit val properties = new scala.collection.mutable.LinkedHashMap[String, ModelProperty]
+    val parser = new ModelPropertyParser(cls)
+    parser.parse
+    assert(properties("items").items != None)
+  }
+
   it should "extract a string list" in {
     val cls = classOf[List[String]]
     implicit val properties = new scala.collection.mutable.LinkedHashMap[String, ModelProperty]

--- a/modules/swagger-core/src/test/scala/converter/ModelUtilTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/ModelUtilTest.scala
@@ -9,6 +9,12 @@ import org.scalatest.Matchers
 class ModelUtilTest extends FlatSpec with Matchers {
   import com.wordnik.swagger.core.util.ModelUtil._
 
+  it should "convert a fully-qualified inner class type to a SwaggerTypes primitive" in {
+    val fqcn = "models.EmbeddedClassModel$InnerClass"
+    val cleanName = cleanDataType(fqcn)
+    cleanName should equal (fqcn)
+  }
+
   "ModelUtil cleanDataType" should "convert a fully-qualified primitive type to a SwaggerTypes primitive" in {
     val primitiveName = "java.lang.Integer"
     val cleanName = cleanDataType(primitiveName)

--- a/modules/swagger-core/src/test/scala/models/EmbeddedClassModel.java
+++ b/modules/swagger-core/src/test/scala/models/EmbeddedClassModel.java
@@ -1,0 +1,6 @@
+package models;
+
+public class EmbeddedClassModel {
+    public static class InnerClass {
+    }
+}

--- a/modules/swagger-core/src/test/scala/models/ModelWithEmbeddedClassAsGenericParameter.java
+++ b/modules/swagger-core/src/test/scala/models/ModelWithEmbeddedClassAsGenericParameter.java
@@ -1,0 +1,7 @@
+package models;
+
+import java.util.List;
+
+public class ModelWithEmbeddedClassAsGenericParameter {
+    public List<EmbeddedClassModel.InnerClass> items;
+}


### PR DESCRIPTION
Guys, I also replaced Class.getSimpleName calls across the module with TypeUtil.getClassSimpleName because it seems to be used as model ID everywhere. It took me a while to understand why inner class is not being referenced in Swagger-UI because of name difference (in my original fix I named model like "OuterClass$InnerClass")

Bugfix for: https://github.com/swagger-api/swagger-core/issues/867