### PR TITLE
Get build to run on windows from new checkout

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -91,12 +91,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.swagger</groupId>
-      <artifactId>swagger-parser</artifactId>
-      <version>${swagger-parser-version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-scala_2.10</artifactId>
       <version>${jackson-version}</version>

--- a/modules/swagger-core/src/test/scala/1_3/converter/BoxedTypesTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/BoxedTypesTest.scala
@@ -14,6 +14,8 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class BoxedTypesTest extends FlatSpec with Matchers {
   Json.mapper().registerModule(DefaultScalaModule)
@@ -27,7 +29,7 @@ class BoxedTypesTest extends FlatSpec with Matchers {
     properties should not be (null)
     properties.size should be (5)
 
-Json.pretty(models) should equal (
+models should serializeToJson (
 """{
   "BoxedTypesIssue31" : {
     "properties" : {
@@ -77,7 +79,7 @@ Json.pretty(models) should equal (
     properties should not be (null)
     properties.size should be (5)
 
-Json.pretty(models) should equal (
+    models should serializeToJson (
 """{
   "BoxedTypesIssue31WithDataType" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/ByteConverterTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/ByteConverterTest.scala
@@ -15,13 +15,15 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class ByteConverterTest extends FlatSpec with Matchers {
   val m = Json.mapper()
   m.registerModule(DefaultScalaModule)
 
   val models = ModelConverters.getInstance().read(classOf[ByteConverterModel])
-  Json.pretty(models) should equal(
+  models should serializeToJson (
 """{
   "ByteConverterModel" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/CovariantGetterTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/CovariantGetterTest.scala
@@ -14,6 +14,8 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import models.JCovariantGetter
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class CovariantGetterTest extends FlatSpec with Matchers {
   val m = Json.mapper()
@@ -22,7 +24,7 @@ class CovariantGetterTest extends FlatSpec with Matchers {
   it should "read a getter with covariant return type" in {
     val models = ModelConverters.getInstance().read(classOf[JCovariantGetter.Sub])
     models.size should be (1)
-Json.pretty(models) should be (
+    models should serializeToJson (
 """{
   "Sub" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/EnumConversionPropertyTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/EnumConversionPropertyTest.scala
@@ -14,6 +14,8 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class EnumConversionPropertyTest extends FlatSpec with Matchers {
   val m = Json.mapper()
@@ -21,7 +23,7 @@ class EnumConversionPropertyTest extends FlatSpec with Matchers {
 
   it should "read a model with an enum property" in {
     val models = ModelConverters.getInstance().read(classOf[ModelWithEnumProperty])
-    Json.pretty(models) should be (
+    models should serializeToJson (
 """{
   "ModelWithEnumProperty" : {
     "properties" : {
@@ -36,7 +38,7 @@ class EnumConversionPropertyTest extends FlatSpec with Matchers {
 
   it should "read a model with enums" in {
     val models = ModelConverters.getInstance().read(classOf[ATM])
-    Json.pretty(models) should be (
+    models should serializeToJson (
 """{
   "ATM" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/JsonIgnoreModelTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/JsonIgnoreModelTest.scala
@@ -13,10 +13,12 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class JsonIgnoreModelTest extends FlatSpec with Matchers {
   val models = ModelConverters.getInstance().read(classOf[ModelWithIgnoreAnnotation])
-  Json.pretty(models) should equal (
+  models should serializeToJson (
 """{
   "ModelWithIgnoreAnnotation" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/JsonIgnorePropertiesModelTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/JsonIgnorePropertiesModelTest.scala
@@ -13,11 +13,13 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class JsonIgnorePropertiesModelTest extends FlatSpec with Matchers {
   it should "ignore a property with ignore annotations" in {
     val models = ModelConverters.getInstance().read(classOf[ModelWithIgnorePropertiesAnnotation])
-    Json.pretty(models) should equal(
+    models should serializeToJson (
 """{
   "ModelWithIgnorePropertiesAnnotation" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/JsonPropertyModelTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/JsonPropertyModelTest.scala
@@ -13,10 +13,12 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class JsonPropertyModelTest extends FlatSpec with Matchers {
   val models = ModelConverters.getInstance().read(classOf[ModelWithJsonProperty])
-  Json.pretty(models) should be (
+  models should serializeToJson (
 """{
   "ModelWithJsonProperty" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/ModelConversionTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/ModelConversionTest.scala
@@ -17,6 +17,8 @@ import java.util.Date
 
 import scala.annotation.meta.field
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class ModelConversionTest extends FlatSpec with Matchers {
   Json.mapper().registerModule(DefaultScalaModule)
@@ -25,7 +27,7 @@ class ModelConversionTest extends FlatSpec with Matchers {
     val models = ModelConverters.getInstance().read(classOf[DateModel])
     val model = models.get("DateModel")
     model.getProperties().size should be (5)
-    Json.pretty(model) should equal(
+    model should serializeToJson (
 """{
   "properties" : {
     "date" : {
@@ -61,7 +63,7 @@ class ModelConversionTest extends FlatSpec with Matchers {
     val models = ModelConverters.getInstance().read(classOf[SetModel])
     val model = models.get("SetModel")
     model.getProperties().size should be (1)
-    Json.pretty(model) should be (
+    model should serializeToJson (
 """{
   "properties" : {
     "longs" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/ModelPropertyParserTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/ModelPropertyParserTest.scala
@@ -21,13 +21,15 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class ModelPropertyParserTest extends FlatSpec with Matchers {
   Json.mapper().registerModule(DefaultScalaModule)
 
   it should "extract a string list" in {
     val property = ModelConverters.getInstance().readAsProperty(classOf[List[String]])
-    Json.pretty(property) should equal(
+    property should serializeToJson (
 """{
   "type" : "array",
   "items" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/ModelPropertyTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/ModelPropertyTest.scala
@@ -20,6 +20,8 @@ import org.scalatest.Matchers
 
 import scala.beans.BeanProperty
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class ModelPropertyTest extends FlatSpec with Matchers {
   Json.mapper().registerModule(DefaultScalaModule)
@@ -76,7 +78,7 @@ class ModelPropertyTest extends FlatSpec with Matchers {
 class ModelPropertyOverrideTest extends FlatSpec with Matchers {
   it should "read a model with property dataTypes configured #679" in {
     val models = ModelConverters.getInstance().readAll(classOf[ModelWithModelPropertyOverrides])
-    Json.pretty(models) should equal(
+    models should serializeToJson (
 """{
   "Children" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/ModelWithOptionalFieldsTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/ModelWithOptionalFieldsTest.scala
@@ -12,13 +12,15 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class ModelWithOptionalFieldsTest extends FlatSpec with Matchers {
   Json.mapper().registerModule(new GuavaModule())
 
   ignore should "read a model with guava optionals" in {
     val property = ModelConverters.getInstance().readAll(classOf[ModelWithOptionalFields])
-    Json.pretty(property) should equal (
+    property should serializeToJson (
 """{
   "ModelWithOptionalFields" : {
     "id" : "ModelWithOptionalFields",

--- a/modules/swagger-core/src/test/scala/1_3/converter/PropertyAnnotationTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/PropertyAnnotationTest.scala
@@ -20,11 +20,13 @@ import org.scalatest.Matchers
 
 import javax.xml.bind.annotation._
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class PropertyAnnotationTest extends FlatSpec with Matchers {
   it should "read annotations on a property" in {
     val a = ModelConverters.getInstance().readAll(classOf[ModelWithAnnotationOnProperty])
-    Json.pretty(a) should equal (
+    a should serializeToJson (
 """{
   "ModelWithAnnotationOnProperty" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/1_3/converter/SnakeCaseConverterTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/SnakeCaseConverterTest.scala
@@ -24,6 +24,8 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class SnakeCaseConverterTest extends FlatSpec with Matchers {
   it should "ignore properties with type Bar" in {
@@ -34,7 +36,7 @@ class SnakeCaseConverterTest extends FlatSpec with Matchers {
     converters.addConverter(snakeCaseConverter)
 
     val models = converters.readAll(classOf[SnakeCaseModel])
-    Json.pretty(models) should equal (
+    models should serializeToJson (
 """{
   "bar" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/CompositionTest.scala
+++ b/modules/swagger-core/src/test/scala/CompositionTest.scala
@@ -9,6 +9,8 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class CompositionTest extends FlatSpec with Matchers {
   val m = Json.mapper()
@@ -16,7 +18,7 @@ class CompositionTest extends FlatSpec with Matchers {
   ignore should "read a model with required params and description" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[Human])
 
-    Json.pretty(schemas) should equal (
+    schemas should serializeToJson (
 """{
   "Human" : {
     "properties" : {
@@ -63,7 +65,7 @@ class CompositionTest extends FlatSpec with Matchers {
 
   ignore should "read a model with composition" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[Animal])
-    Json.pretty(schemas) should equal (
+    schemas should serializeToJson (
 """{
   "Animal" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/ModelConverterTest.scala
+++ b/modules/swagger-core/src/test/scala/ModelConverterTest.scala
@@ -11,11 +11,13 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class ModelConverterTest extends FlatSpec with Matchers {
   it should "convert a model" in {
     val schemas = ModelConverters.getInstance().read(classOf[Person])
-    Json.pretty(schemas) should equal(
+    schemas should serializeToJson (
 """{
   "Person" : {
     "properties" : {
@@ -59,7 +61,7 @@ class ModelConverterTest extends FlatSpec with Matchers {
 
   it should "read an interface" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[Pet])
-    Json.pretty(schemas) should equal (
+    schemas should serializeToJson (
 """{
   "Pet" : {
     "required" : [ "isDomestic", "name", "type" ],
@@ -85,7 +87,7 @@ class ModelConverterTest extends FlatSpec with Matchers {
 
   it should "read an inherited interface" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[Cat])
-    Json.pretty(schemas) should equal (
+    schemas should serializeToJson (
 """{
   "Cat" : {
     "required" : [ "isDomestic", "name", "type" ],

--- a/modules/swagger-core/src/test/scala/ScalaModelTest.scala
+++ b/modules/swagger-core/src/test/scala/ScalaModelTest.scala
@@ -14,13 +14,15 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class ScalaModelTest extends FlatSpec with Matchers {
   Json.mapper().registerModule(DefaultScalaModule)
 
   it should "convert a simple scala case class" in {
     val schemas = ModelConverters.getInstance().read(classOf[SimpleCaseClass])
-    Json.pretty(schemas) should equal (
+    schemas should serializeToJson (
 """{
   "SimpleCaseClass" : {
     "properties" : {
@@ -38,7 +40,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
 
   it should "convert a scala case class with List property" in {
     val schemas = ModelConverters.getInstance().read(classOf[CaseClassWithList])
-    Json.pretty(schemas) should equal(
+    schemas should serializeToJson (
 """{
   "CaseClassWithList" : {
     "properties" : {
@@ -68,7 +70,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
     keys(3) should be ("dateValue")
     keys(4) should be ("booleanValue")
 
-    Json.pretty(schemas) should equal (
+    schemas should serializeToJson (
 """{
   "CaseClassWithOptionLong" : {
     "properties" : {
@@ -103,7 +105,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
 
   it should "convert a scala case class with nested models" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[NestedModel])
-    Json.pretty(schemas) should equal ( 
+    schemas should serializeToJson ( 
 """{
   "ComplexModel" : {
     "properties" : {
@@ -132,7 +134,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
 
   it should "read an interface" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[Pet])
-    Json.pretty(schemas) should equal (
+    schemas should serializeToJson (
 """{
   "Pet" : {
     "required" : [ "isDomestic", "name", "type" ],

--- a/modules/swagger-core/src/test/scala/ScalaTest.scala
+++ b/modules/swagger-core/src/test/scala/ScalaTest.scala
@@ -11,13 +11,15 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class ScalaTest extends FlatSpec with Matchers {
   val m = Json.mapper()
 
   it should "convert a model with scala list" in {
     val schemas = ModelConverters.getInstance().read(classOf[ClassWithScalaField])
-    Json.pretty(schemas) should be (
+    schemas should serializeToJson (
 """{
   "ClassWithScalaField" : {
     "properties" : {

--- a/modules/swagger-core/src/test/scala/auth/AuthSerializationTest.scala
+++ b/modules/swagger-core/src/test/scala/auth/AuthSerializationTest.scala
@@ -13,6 +13,8 @@ import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 
+import matchers.SerializationMatchers._
+
 @RunWith(classOf[JUnitRunner])
 class AuthSerializationTest extends FlatSpec with Matchers {
   it should "convert serialize a basic auth model" in {
@@ -28,13 +30,12 @@ class AuthSerializationTest extends FlatSpec with Matchers {
   }
 
   it should "convert serialize a header key model to yaml" in {
-    Yaml.mapper().convertValue(new ApiKeyAuthDefinition().name("api-key").in(In.HEADER),
-                               classOf[ObjectNode]) should equal (
-      Yaml.mapper().readValue("""---
+    val auth = new ApiKeyAuthDefinition().name("api-key").in(In.HEADER) 
+    auth should serializeToYaml ("""---
 type: "apiKey"
 name: "api-key"
 in: "header"
-""", classOf[ObjectNode]))
+""")
   }
 
   it should "convert serialize an oauth2 implicit flow model" in {

--- a/modules/swagger-core/src/test/scala/filter/SpecFilterTest.scala
+++ b/modules/swagger-core/src/test/scala/filter/SpecFilterTest.scala
@@ -1,9 +1,8 @@
 package filter
 
+import com.wordnik.swagger.models._
 import com.wordnik.swagger.util._
 import com.wordnik.swagger.core.filter._
-
-import io.swagger.parser.SwaggerParser;
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -14,15 +13,16 @@ import scala.collection.JavaConverters._
 
 @RunWith(classOf[JUnitRunner])
 class SpecFilterTest extends FlatSpec with Matchers {
+  val m = Json.mapper()
   it should "clone everything" in {
-    val swagger = new SwaggerParser().read("src/test/scala/specFiles/petstore.json")
+    val swagger = m.readValue(new java.io.File("src/test/scala/specFiles/petstore.json"), classOf[Swagger])
     val filtered = new SpecFilter().filter(swagger, new NoOpOperationsFilter(), null, null, null)
 
     Json.pretty(swagger) should equal(Json.pretty(filtered))
   }
 
   it should "filter away get operations in a resource" in {
-    val swagger = new SwaggerParser().read("src/test/scala/specFiles/petstore.json")
+    val swagger = m.readValue(new java.io.File("src/test/scala/specFiles/petstore.json"), classOf[Swagger])
     val filter = new NoGetOperationsFilter()
 
     val filtered = new SpecFilter().filter(swagger, filter, null, null, null)
@@ -37,7 +37,7 @@ class SpecFilterTest extends FlatSpec with Matchers {
   }
 
   it should "filter away the store resource" in {
-    val swagger = new SwaggerParser().read("src/test/scala/specFiles/petstore.json")
+    val swagger = m.readValue(new java.io.File("src/test/scala/specFiles/petstore.json"), classOf[Swagger])
     val filter = new NoUserOperationsFilter()
 
     val filtered = new SpecFilter().filter(swagger, filter, null, null, null)
@@ -52,7 +52,7 @@ class SpecFilterTest extends FlatSpec with Matchers {
   }
 
   it should "filter away secret parameters" in {
-    val swagger = new SwaggerParser().read("src/test/scala/specFiles/sampleSpec.json")
+    val swagger = m.readValue(new java.io.File("src/test/scala/specFiles/sampleSpec.json"), classOf[Swagger])
     val filter = new RemoveInternalParamsFilter()
 
     val filtered = new SpecFilter().filter(swagger, filter, null, null, null)
@@ -71,7 +71,7 @@ class SpecFilterTest extends FlatSpec with Matchers {
   }
 
   it should "filter away internal model properties" in {
-    val swagger = new SwaggerParser().read("src/test/scala/specFiles/sampleSpec.json")
+    val swagger = m.readValue(new java.io.File("src/test/scala/specFiles/sampleSpec.json"), classOf[Swagger])
     val filter = new InternalModelPropertiesRemoverFilter()
 
     val filtered = new SpecFilter().filter(swagger, filter, null, null, null)

--- a/modules/swagger-core/src/test/scala/matchers/SerializationMatchers.scala
+++ b/modules/swagger-core/src/test/scala/matchers/SerializationMatchers.scala
@@ -1,0 +1,26 @@
+package matchers
+
+import org.scalatest.matchers.MatchResult
+import org.scalatest.matchers.Matcher
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.wordnik.swagger.util._
+
+trait SerializationMatchers {
+
+  class SerializeToStringMatcher(str: String, mapper: ObjectMapper) extends Matcher[Object] {
+    def apply(left: Object) = {
+      MatchResult(
+        mapper.convertValue(left, classOf[ObjectNode]).equals(mapper.readValue(str, classOf[ObjectNode])),
+        s"""Serialized object does not equal expected serialized string"""",
+        s"""Serialized object equals expected serialized string""""
+      )
+    }
+  }
+
+  def serializeToYaml(yamlStr: String) = new SerializeToStringMatcher(yamlStr, Yaml.mapper())
+  def serializeToJson(jsonStr: String) = new SerializeToStringMatcher(jsonStr, Json.mapper())
+}
+
+object SerializationMatchers extends SerializationMatchers

--- a/pom.xml
+++ b/pom.xml
@@ -535,13 +535,12 @@
     <jackson-version>2.4.2</jackson-version>
     <jackson-guava-version>2.4.2</jackson-guava-version>
     <logback-version>1.0.1</logback-version>
-    <swagger-parser-version>1.0.3-SNAPSHOT</swagger-parser-version>
 
     <junit-version>4.8.1</junit-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <commons-lang-version>3.2.1</commons-lang-version>
     <slf4j-version>1.6.3</slf4j-version>
-    <scala-test-version>2.1.3</scala-test-version>
+    <scala-test-version>2.2.4</scala-test-version>
     <jetty-version>8.1.11.v20130520</jetty-version>
     <servlet-api-version>2.5</servlet-api-version>
     <scala-maven-plugin-version>3.1.5</scala-maven-plugin-version>


### PR DESCRIPTION
I was trying to do some research on the new java models on the develop_2.0 branch and tried to checkout and build and was unable to do so.

Swagger-core  was unable to build because it depended on swagger-parser, and swagger-parser would't build because it depended on swagger-core.  I know that swagger-core depended on a slightly older snapshot version, but, looking through the test it wasn't that hard to remove the dependency on swagger-parser.

I also upgraded scala test on swagger core to stop the maven warning about multiple scala versions.