### PR TITLE
Removing System.out.println from a previous bugfix under #937

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/ParameterProcessor.java
+++ b/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/ParameterProcessor.java
@@ -35,7 +35,6 @@ public class ParameterProcessor {
           }
 
           if(param.required() == true) {
-            System.out.println(param.required());
             parameter.setRequired(param.required());
           }
 


### PR DESCRIPTION
@fehguy Please have a look when you get a chance. It's an extremely minor fix but the server logs were really getting overloaded by the following message after your bug fix for #937 :
INFO  [2015-03-29 08:11:50,664] org.reflections.Reflections: Reflections took 81 ms to scan 1 urls, producing 22 keys and 41 values 
true
true
true
true
true
true
true
true
true
true
true
true
true
true
true
true
true
true
true
true
true