### PR TITLE
Enhanced BeanConfig to support @Path JAX-RS resources and fixed Reader operations recognition.

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/config/BeanConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/config/BeanConfig.java
@@ -191,7 +191,10 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
     }
 
     reader.getSwagger().setInfo(info);
-    Set<Class<?>> classes = new Reflections(config).getTypesAnnotatedWith(Api.class);
+    final Reflections reflections = new Reflections(config);
+	Set<Class<?>> classes = reflections.getTypesAnnotatedWith(Api.class);
+    classes.addAll(reflections.getTypesAnnotatedWith(javax.ws.rs.Path.class));
+    
     Set<Class<?>> output = new HashSet<Class<?>>();
     for(Class<?> cls : classes) {
       if(acceptablePackages.contains(cls.getPackage().getName()))

--- a/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
@@ -149,6 +149,30 @@ class SimpleScannerTest extends FlatSpec with Matchers {
     val swagger = new Reader(new Swagger()).read(classOf[ResourceWithEmptyModel])
     Json.prettyPrint(swagger)
   }
+  
+  it should "scan a simple resource without annotations" in {
+    val swagger = new Reader(new Swagger()).read(classOf[SimpleResourceWithoutAnnotations])
+    swagger.getPaths().size should be (2)
+
+    val path = swagger.getPaths().get("/{id}")
+    val get = path.getGet()
+    get should not be (null)
+    get.getParameters().size should be (2)
+
+    val param1 = get.getParameters().get(0).asInstanceOf[PathParameter]
+
+    param1.getIn() should be ("path")
+    param1.getName() should be ("id")
+    param1.getRequired() should be (true)
+    param1.getDescription() should be (null)
+    param1.getDefaultValue() should be ("5")
+
+    val param2 = get.getParameters().get(1)
+    param2.getIn() should be ("query")
+    param2.getName() should be ("limit")
+    param2.getRequired() should be (false)
+    param2.getDescription() should be (null)
+  }
 }
 
 @RunWith(classOf[JUnitRunner])
@@ -161,3 +185,4 @@ class SimpleScannerTest2 extends FlatSpec with Matchers {
     param.getDefaultValue should be ("dogs")
   }
 }
+  

--- a/modules/swagger-jaxrs/src/test/scala/resources/SimpleResourceWithoutAnnotations.java
+++ b/modules/swagger-jaxrs/src/test/scala/resources/SimpleResourceWithoutAnnotations.java
@@ -1,0 +1,41 @@
+package resources;
+
+import models.*;
+
+import com.wordnik.swagger.annotations.*;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+@Produces({"application/xml"})
+public class SimpleResourceWithoutAnnotations {
+  @GET
+  @Path("/{id}")
+  public Sample getTest(      
+      @DefaultValue("5")
+      @PathParam("id") String id,
+      @QueryParam("limit") Integer limit
+      ) throws WebApplicationException {
+    Sample out = new Sample();
+    out.setName("foo");
+    out.setValue("bar");
+    return out;
+  }
+
+  @GET
+  @Path("/{id}/value")
+  @Produces({"text/plain"})
+  public Response getStringValue() throws WebApplicationException {
+    return Response.ok().entity("ok").build();
+  }
+
+  @PUT
+  @Path("/{id}")
+  public Response updateTest(
+    @ApiParam(value = "sample param data", required = true)Sample sample,
+    @HeaderParam(value = "Authorization") String authorization,
+    @QueryParam(value = "dateUpdated") java.util.Date dateUpdated,
+    @CookieParam(value = "X-your-cookie") String cookieId) {
+    return Response.ok().build();
+  }
+}


### PR DESCRIPTION
Hey guys,

Resubmitting https://github.com/swagger-api/swagger-core/pull/797 against Swagger 1.5.

While working on JAX-RS applications, I have run into the issues that Swagger has a bit limited support of the native JAX-RS services/resources which do not use @ApiXxx annotations, however the most of required implementation is already there, in Swagger JAX-RS module. 

The small change in BeanConfig allows to introspect not only @Api - annotated classes but @Path - annotated ones as well. When used with Reader, the @ApiXxx annotations are not required anymore. . 

The tests have been added to confirm that the proper JAX-RS API description is being built (without any @ApiXxx annotations) for native JAX-RS service/resource.

I think these small changes allow to integrate Swagger into existing JAX-RS applications much faster and easier, while developers are immediately benefiting from using it in conjunction with Swagger UI. Apache CXF has already support for Swagger but it is going to be better with these fixes.

Thank you.

Best Regards,
 Andriy Redko