### PR TITLE
Fix for #847. Implemented findSubtypes.

### DIFF
--- a/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/AbstractModelConverter.java
+++ b/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/AbstractModelConverter.java
@@ -1,5 +1,7 @@
 package com.wordnik.swagger.jackson;
 
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 import com.wordnik.swagger.converter.ModelConverter;
 import com.wordnik.swagger.converter.ModelConverterContext;
@@ -35,7 +37,10 @@ public abstract class AbstractModelConverter implements ModelConverter {
             new SimpleModule("swagger", Version.unknownVersion()) {
               @Override
               public void setupModule(SetupContext context) {
-                context.insertAnnotationIntrospector(new SwaggerAnnotationIntrospector());
+                context.insertAnnotationIntrospector(
+                        new AnnotationIntrospectorPair(
+                                new SwaggerAnnotationIntrospector(),
+                                new JacksonAnnotationIntrospector()));
               }
             });
           _mapper = mapper;

--- a/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/SwaggerAnnotationIntrospector.java
+++ b/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/SwaggerAnnotationIntrospector.java
@@ -70,18 +70,6 @@ public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
   
   @Override
   public List<NamedType> findSubtypes(Annotated a) {
-    final JsonSubTypes jst = a.getAnnotation(JsonSubTypes.class);
-    if (jst != null) {
-      final JsonSubTypes.Type[] subTypes = jst.value();
-      final List<NamedType> names = new ArrayList<NamedType>(subTypes.length);
-      for (JsonSubTypes.Type subType : subTypes) {
-        names.add(new NamedType(subType.value()));
-      }
-      if (!names.isEmpty()) {
-        return names;
-      }
-    }
-
     final ApiModel api = a.getAnnotation(ApiModel.class);
     if (api != null) {
       final Class<?>[] classes = api.subTypes();

--- a/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/SwaggerAnnotationIntrospector.java
+++ b/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/SwaggerAnnotationIntrospector.java
@@ -1,5 +1,6 @@
 package com.wordnik.swagger.jackson;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.wordnik.swagger.annotations.ApiModel;
 import com.wordnik.swagger.annotations.ApiModelProperty;
 
@@ -10,6 +11,8 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 
 import javax.xml.bind.annotation.*;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
@@ -67,7 +70,31 @@ public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
   
   @Override
   public List<NamedType> findSubtypes(Annotated a) {
-    return null;
+    final JsonSubTypes jst = a.getAnnotation(JsonSubTypes.class);
+    if (jst != null) {
+      final JsonSubTypes.Type[] subTypes = jst.value();
+      final List<NamedType> names = new ArrayList<NamedType>(subTypes.length);
+      for (JsonSubTypes.Type subType : subTypes)
+        names.add(new NamedType(subType.value()));
+
+      if (!names.isEmpty()) {
+        return names;
+      }
+    }
+
+    final ApiModel api = a.getAnnotation(ApiModel.class);
+    if (api != null) {
+      final Class<?>[] classes = api.subTypes();
+      final List<NamedType> names = new ArrayList<NamedType>(classes.length);
+      for (Class<?> subType : classes)
+        names.add(new NamedType(subType));
+
+      if (!names.isEmpty()) {
+        return names;
+      }
+    }
+
+    return Collections.emptyList();
   }
 
   @Override    

--- a/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/SwaggerAnnotationIntrospector.java
+++ b/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/SwaggerAnnotationIntrospector.java
@@ -74,9 +74,9 @@ public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
     if (jst != null) {
       final JsonSubTypes.Type[] subTypes = jst.value();
       final List<NamedType> names = new ArrayList<NamedType>(subTypes.length);
-      for (JsonSubTypes.Type subType : subTypes)
+      for (JsonSubTypes.Type subType : subTypes) {
         names.add(new NamedType(subType.value()));
-
+      }
       if (!names.isEmpty()) {
         return names;
       }
@@ -86,9 +86,9 @@ public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
     if (api != null) {
       final Class<?>[] classes = api.subTypes();
       final List<NamedType> names = new ArrayList<NamedType>(classes.length);
-      for (Class<?> subType : classes)
+      for (Class<?> subType : classes) {
         names.add(new NamedType(subType));
-
+      }
       if (!names.isEmpty()) {
         return names;
       }

--- a/modules/swagger-core/src/test/scala/CompositionTest.scala
+++ b/modules/swagger-core/src/test/scala/CompositionTest.scala
@@ -129,7 +129,7 @@ class CompositionTest extends FlatSpec with Matchers {
   it should "create a model" in {
     val schemas = ModelConverters.getInstance().readAll(classOf[AbstractBaseModelWithoutFields])
     schemas should serializeToJson (
-      """{
+"""{
   "AbstractBaseModelWithoutFields" : {
     "type" : "object",
     "description" : "I am an Abstract Base Model without any declared fields and with Sub-Types"

--- a/modules/swagger-core/src/test/scala/CompositionTest.scala
+++ b/modules/swagger-core/src/test/scala/CompositionTest.scala
@@ -126,4 +126,32 @@ class CompositionTest extends FlatSpec with Matchers {
 }""")
   }
 
+  it should "create a model" in {
+    val schemas = ModelConverters.getInstance().readAll(classOf[AbstractBaseModelWithoutFields])
+    schemas should serializeToJson (
+      """{
+  "AbstractBaseModelWithoutFields" : {
+    "type" : "object",
+    "description" : "I am an Abstract Base Model without any declared fields and with Sub-Types"
+  },
+    "Thing3" : {
+      "allOf" : [ {
+      "$ref" : "#/definitions/AbstractBaseModelWithoutFields"
+      }, {
+      "properties" : {
+        "a" : {
+          "type" : "string",
+          "description" : "Additional field a"
+        },
+        "x" : {
+          "type" : "integer",
+          "format" : "int32",
+          "description" : "Additional field a"
+        }
+      },
+      "description" : "Thing3"
+    } ]
+  }
+}""")
+  }
 }

--- a/modules/swagger-core/src/test/scala/models/composition/AbstractBaseModelWithoutFields.java
+++ b/modules/swagger-core/src/test/scala/models/composition/AbstractBaseModelWithoutFields.java
@@ -1,0 +1,8 @@
+package models.composition;
+
+import com.wordnik.swagger.annotations.ApiModel;
+
+@ApiModel(description = "I am an Abstract Base Model without any declared fields and with Sub-Types",
+             subTypes = {Thing3.class})
+public abstract class AbstractBaseModelWithoutFields {
+}

--- a/modules/swagger-core/src/test/scala/models/composition/Thing3.java
+++ b/modules/swagger-core/src/test/scala/models/composition/Thing3.java
@@ -1,0 +1,27 @@
+package models.composition;
+
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+@ApiModel(description = "Thing3", parent = AbstractBaseModelWithoutFields.class)
+public class Thing3 extends AbstractBaseModelWithoutFields {
+
+    @ApiModelProperty (value = "Additional field a") String a;
+    @ApiModelProperty (value = "Additional field a") int x;
+
+    public String getA() {
+        return a;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    public void setA(String a) {
+        this.a = a;
+    }
+}


### PR DESCRIPTION
Since the method findSubtypes was not implemented after jackson-swagger-module had been moved to the  swagger-core, ModelConverter could not find subtypes of passed class. Fixed it. Added unit-test.