### PR TITLE
Configure Jackson to only scan fields and setters of @BeanParam classes

### DIFF
--- a/modules/swagger-jersey2-jaxrs/src/main/java/com/wordnik/swagger/jersey/SwaggerJersey2Jaxrs.java
+++ b/modules/swagger-jersey2-jaxrs/src/main/java/com/wordnik/swagger/jersey/SwaggerJersey2Jaxrs.java
@@ -8,6 +8,8 @@ import com.wordnik.swagger.jaxrs.utils.ParameterUtils;
 import com.wordnik.swagger.models.parameters.Parameter;
 import com.wordnik.swagger.util.Json;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
@@ -24,7 +26,14 @@ import java.util.*;
  * Swagger extension for handling JAX-RS 2.0 processing.
  */
 public class SwaggerJersey2Jaxrs extends AbstractSwaggerExtension implements SwaggerExtension {
-  final ObjectMapper mapper = Json.mapper();
+  final ObjectMapper mapper;
+
+  public SwaggerJersey2Jaxrs() {
+    mapper = Json.mapper();
+    mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+    mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    mapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.ANY);
+  }
 
   public List<Parameter> extractParameters(final Annotation[] annotations, final Class<?> cls, final boolean isArray,
                                          Set<Class<?>> classesToSkip, final Iterator<SwaggerExtension> chain) {

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/params/BaseBean.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/params/BaseBean.java
@@ -29,4 +29,8 @@ public class BaseBean {
     this.formParam = formParam;
   }
 
+  public Integer getValueWithNoProperty() {
+    return 32;
+  }
+
 }

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/params/BaseBean.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/params/BaseBean.java
@@ -29,8 +29,8 @@ public class BaseBean {
     this.formParam = formParam;
   }
 
-  public Integer getValueWithNoProperty() {
-    return 32;
+  public Integer getValueWithNoField() {
+    return 1;
   }
 
 }


### PR DESCRIPTION
Thank you so much for all the amazing work on swagger-core!

When using swagger-core on a recent project, I came across an NPE where ParameterUtils.isMethodArgumentAnArray was receiving a null paramClass argument. It turns out that this was because a BeanParam class declared a method with a name like getX, where X did not directly correspond to a field name. Because the method name began with "get," Jackson was returning a BeanPropertyDefinition corresponding to it whose field and setter were null.

After looking at the JAX-RS documentation for BeanParam, I wasn't able to think of a case where introspecting on the getter methods of a BeanParam would be useful, so I configured the ObjectMapper to only consider fields and setters. These seem to be the only places where JAX-RS annotations are used on BeanParam classes.

To demonstrate the issue, I modified one of the BeanParamClasses to include a method beginning with "get" that does not directly correspond to a field.