### PR TITLE
Collection<Enum<?>> as a field on a transfer object yields spec with ClassLoader et al.

### DIFF
--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Path.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/Path.java
@@ -3,6 +3,8 @@ package com.wordnik.swagger.models;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.wordnik.swagger.models.parameters.Parameter;
 
@@ -12,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 @JsonPropertyOrder({ "get", "post", "put", "delete", "options", "patch"})
+@JsonInclude(Include.NON_NULL)
 public class Path {
   private Operation get;
   private Operation put;


### PR DESCRIPTION
Specs that are returned when accessing swagger.json are not valid as per https://github.com/swagger-api/swagger-js/issues/268