### PR TITLE
Fixed #992. Fixed references processing with ApiModel.

### DIFF
--- a/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/ModelResolver.java
@@ -163,8 +163,8 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         // complex type
         String propertyTypeName = _typeName(propType);
         Model innerModel =  context.resolve(propType);      
-        if(innerModel != null) {      
-          property = new RefProperty(propertyTypeName);
+        if(innerModel instanceof ModelImpl) {
+          property = new RefProperty(((ModelImpl)innerModel).getName());
         }
       }
     }

--- a/modules/swagger-jaxrs/src/test/scala/ReferenceTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/ReferenceTest.scala
@@ -1,0 +1,34 @@
+import com.wordnik.swagger.converter.ModelConverters
+import models.Pet
+import resources._
+
+import com.wordnik.swagger.jaxrs.config._
+import com.wordnik.swagger.models.parameters._
+import com.wordnik.swagger.models.properties.{RefProperty, MapProperty}
+
+import com.wordnik.swagger.models.Swagger
+import com.wordnik.swagger.jaxrs.Reader
+import com.wordnik.swagger.util.Json
+
+import scala.collection.JavaConverters._
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+@RunWith(classOf[JUnitRunner])
+class ReferenceTest extends FlatSpec with Matchers {
+
+  it should "Scan a model with common reference and reference with ApiModel" in {
+    val props = ModelConverters.getInstance().readAll(classOf[Pet]).get("Pet").getProperties()
+    val category = props.get("category").asInstanceOf[RefProperty]
+    category.getType() should be ("ref")
+    category.get$ref() should be ("#/definitions/Category")
+
+    val categoryWithApiModel = props.get("categoryWithApiModel").asInstanceOf[RefProperty]
+    categoryWithApiModel.getType() should be ("ref")
+    categoryWithApiModel.get$ref() should be ("#/definitions/MyCategory")
+  }
+
+}

--- a/modules/swagger-jaxrs/src/test/scala/models/CategoryWithApiModel.java
+++ b/modules/swagger-jaxrs/src/test/scala/models/CategoryWithApiModel.java
@@ -1,0 +1,9 @@
+package models;
+
+import javax.xml.bind.annotation.*;
+import com.wordnik.swagger.annotations.ApiModel;
+
+@com.wordnik.swagger.annotations.ApiModel("MyCategory")
+@XmlRootElement(name = "CategoryWithApiModel")
+public class CategoryWithApiModel {
+}

--- a/modules/swagger-jaxrs/src/test/scala/models/Pet.java
+++ b/modules/swagger-jaxrs/src/test/scala/models/Pet.java
@@ -11,6 +11,7 @@ import javax.xml.bind.annotation.*;
 public class Pet {
 	private long id;
 	private Category category;
+	private CategoryWithApiModel categoryWithApiModel;
 	private String name;
 	private List<String> photoUrls = new ArrayList<String>();
 	private List<Tag> tags = new ArrayList<Tag>();
@@ -32,6 +33,15 @@ public class Pet {
 
 	public void setCategory(Category category) {
 		this.category = category;
+	}
+
+	@XmlElement(name = "categoryWithApiModel")
+	public CategoryWithApiModel getCategoryWithApiModel() {
+		return categoryWithApiModel;
+	}
+
+	public void setCategoryWithApiModel(CategoryWithApiModel category) {
+		this.categoryWithApiModel = categoryWithApiModel;
 	}
 
 	@XmlElement(name = "name")


### PR DESCRIPTION
References names have been set wrong if referenced classes are annotated by ApiModel with different names. Fixed.