### PR TITLE
Fixes #942: Path validation has been fixed.

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/Reader.java
@@ -18,6 +18,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Produces;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -316,7 +317,7 @@ public class Reader {
   }
 
   String getPath(javax.ws.rs.Path classLevelPath, javax.ws.rs.Path methodLevelPath, String parentPath) {
-    if (classLevelPath == null && methodLevelPath == null && parentPath == null) {
+    if (classLevelPath == null && methodLevelPath == null && StringUtils.isEmpty(parentPath)) {
       return null;
     }
     StringBuilder b = new StringBuilder();


### PR DESCRIPTION
Fixes #942: Path validation has been fixed.
Initial fix [#1008](https://github.com/swagger-api/swagger-core/pull/1008) was incorrect as `parentPath` never gets null value.
