### PR TITLE
Array and set support

### DIFF
--- a/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiOperation.java
+++ b/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiOperation.java
@@ -79,4 +79,7 @@ public @interface ApiOperation {
   boolean hidden() default false;
 
   ResponseHeader[] responseHeaders() default @ResponseHeader(name = "", response = Void.class);
+
+  /** HTTP status code */
+  int code() default 200;
 }

--- a/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiResponse.java
+++ b/modules/swagger-annotations/src/main/java/com/wordnik/swagger/annotations/ApiResponse.java
@@ -42,4 +42,7 @@ public @interface ApiResponse {
   Class<?> response() default Void.class;
 
   ResponseHeader[] responseHeaders() default @ResponseHeader(name = "", response = Void.class);
+
+  /** if the response class is within a container, specify it here */
+  String responseContainer() default "";
 }

--- a/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/Reader.java
@@ -50,6 +50,7 @@ import com.wordnik.swagger.models.properties.RefProperty;
 import com.wordnik.swagger.util.Json;
 
 public class Reader {
+  private static final String SUCCESSFUL_OPERATION = "successful operation";
   private static Logger LOGGER = LoggerFactory.getLogger(Reader.class);
 
   Swagger swagger;
@@ -454,18 +455,16 @@ public class Reader {
       && !responseClass.equals(java.lang.Void.class)
       && !responseClass.equals(javax.ws.rs.core.Response.class)
       && responseClass.getAnnotation(Api.class) == null) {
+      int responseCode = 200;
+      if (apiOperation != null) {
+        responseCode = apiOperation.code();
+      }
       if(isPrimitive(responseClass)) {
-        Property responseProperty = null;
         Property property = ModelConverters.getInstance().readAsProperty(responseClass);
         if(property != null) {
-          if("list".equalsIgnoreCase(responseContainer))
-            responseProperty = new ArrayProperty(property);
-          else if("map".equalsIgnoreCase(responseContainer))
-            responseProperty = new MapProperty(property);
-          else
-            responseProperty = property;
-          operation.response(200, new Response()
-            .description("successful operation")
+          Property responseProperty = wrapContainer(responseContainer, property);
+          operation.response(responseCode, new Response()
+            .description(SUCCESSFUL_OPERATION)
             .schema(responseProperty)
             .headers(defaultResponseHeaders));
         }
@@ -474,22 +473,16 @@ public class Reader {
         Map<String, Model> models = ModelConverters.getInstance().read(responseClass);
         if(models.size() == 0) {
           Property p = ModelConverters.getInstance().readAsProperty(responseClass);
-          operation.response(200, new Response()
-            .description("successful operation")
+          operation.response(responseCode, new Response()
+            .description(SUCCESSFUL_OPERATION)
             .schema(p)
             .headers(defaultResponseHeaders));
         }
         for(String key: models.keySet()) {
-          Property responseProperty = null;
-
-          if("list".equalsIgnoreCase(responseContainer))
-            responseProperty = new ArrayProperty(new RefProperty().asDefault(key));
-          else if("map".equalsIgnoreCase(responseContainer))
-            responseProperty = new MapProperty(new RefProperty().asDefault(key));
-          else
-            responseProperty = new RefProperty().asDefault(key);
-          operation.response(200, new Response()
-            .description("successful operation")
+          Property property = new RefProperty().asDefault(key);
+          Property responseProperty = wrapContainer(responseContainer, property);
+          operation.response(responseCode, new Response()
+            .description(SUCCESSFUL_OPERATION)
             .schema(responseProperty)
             .headers(defaultResponseHeaders));
           swagger.model(key, models.get(key));
@@ -540,7 +533,9 @@ public class Reader {
         if(responseClass != null && !responseClass.equals(java.lang.Void.class)) {
           Map<String, Model> models = ModelConverters.getInstance().read(responseClass);
           for(String key: models.keySet()) {
-            response.schema(new RefProperty().asDefault(key));
+            Property property =  new RefProperty().asDefault(key);
+            Property responseProperty = wrapContainer(apiResponse.responseContainer(), property);
+            response.schema(responseProperty);
             swagger.model(key, models.get(key));
           }
           models = ModelConverters.getInstance().readAll(responseClass);
@@ -575,9 +570,18 @@ public class Reader {
       }
     }
     if(operation.getResponses() == null) {
-      operation.defaultResponse(new Response().description("successful operation"));
+      operation.defaultResponse(new Response().description(SUCCESSFUL_OPERATION));
     }
     return operation;
+  }
+
+  private Property wrapContainer(String container, Property property) {
+    if ("list".equalsIgnoreCase(container)) {
+      return new ArrayProperty(property);
+    } else if ("map".equalsIgnoreCase(container)) {
+      return new MapProperty(property);
+    }
+    return property;
   }
 
   List<Parameter> getParameters(Class<?> cls, Type type, Annotation[] annotations) {

--- a/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/com/wordnik/swagger/jaxrs/Reader.java
@@ -361,18 +361,11 @@ public class Reader {
             responseHeaders = new HashMap<String, Property>();
           String description = header.description();
           Class<?> cls = header.response();
-          String container = header.responseContainer();
 
           if(!cls.equals(java.lang.Void.class) && !"void".equals(cls.toString())) {
-            Property responseProperty = null;
             Property property = ModelConverters.getInstance().readAsProperty(cls);
             if(property != null) {
-              if("list".equalsIgnoreCase(container))
-                responseProperty = new ArrayProperty(property);
-              else if("map".equalsIgnoreCase(container))
-                responseProperty = new MapProperty(property);
-              else
-                responseProperty = property;
+              Property responseProperty = wrapContainer(header.responseContainer(), property);
               responseProperty.setDescription(description);
               responseHeaders.put(name, responseProperty);
             }
@@ -576,8 +569,12 @@ public class Reader {
   }
 
   private Property wrapContainer(String container, Property property) {
-    if ("list".equalsIgnoreCase(container)) {
+    if ("list".equalsIgnoreCase(container) || "array".equalsIgnoreCase(container)) {
       return new ArrayProperty(property);
+    } else if ("set".equalsIgnoreCase(container)) {
+      ArrayProperty arrayProperty = new ArrayProperty(property);
+      arrayProperty.setUniqueItems(true);
+      return arrayProperty;
     } else if ("map".equalsIgnoreCase(container)) {
       return new MapProperty(property);
     }

--- a/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
@@ -218,6 +218,21 @@ class SimpleScannerTest extends FlatSpec with Matchers {
     val responses4 = paths.getDelete.getResponses;
     responses4.get("203").getSchema().getClass() should be (classOf[RefProperty])
     responses4.get("403").getSchema().getClass() should be (classOf[RefProperty])
+
+    val paths2 = swagger.getPaths().get("/{id}/name")
+    val responses5 = paths2.getGet.getResponses;
+    responses5.get("203").getSchema().getClass() should be (classOf[ArrayProperty])
+    responses5.get("203").getSchema().asInstanceOf[ArrayProperty].getUniqueItems() should be (null)
+    responses5.get("203").getHeaders().get("foo").getClass() should be (classOf[MapProperty])
+    responses5.get("403").getSchema().getClass() should be (classOf[ArrayProperty])
+    responses5.get("403").getSchema().asInstanceOf[ArrayProperty].getUniqueItems().booleanValue() should be (true)
+
+    val responses6 = paths2.getPut.getResponses;
+    responses6.get("203").getSchema().getClass() should be (classOf[ArrayProperty])
+    responses6.get("203").getSchema().asInstanceOf[ArrayProperty].getUniqueItems().booleanValue() should be (true)
+    responses6.get("203").getHeaders().get("foo").getClass() should be (classOf[ArrayProperty])
+    responses6.get("203").getHeaders().get("foo").asInstanceOf[ArrayProperty].getUniqueItems.booleanValue() should be (true)
+    responses6.get("403").getSchema().getClass() should be (classOf[ArrayProperty])
   }
 }
 

--- a/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
@@ -2,9 +2,9 @@ import resources._
 
 import com.wordnik.swagger.jaxrs.config._
 import com.wordnik.swagger.models.parameters._
-import com.wordnik.swagger.models.properties.MapProperty
+import com.wordnik.swagger.models.properties.{ArrayProperty, RefProperty, MapProperty}
 
-import com.wordnik.swagger.models.Swagger
+import com.wordnik.swagger.models.{Response, Swagger}
 import com.wordnik.swagger.jaxrs.Reader
 import com.wordnik.swagger.util.Json
 
@@ -183,6 +183,41 @@ class SimpleScannerTest extends FlatSpec with Matchers {
     param2.getName() should be ("limit")
     param2.getRequired() should be (false)
     param2.getDescription() should be (null)
+  }
+
+  it should "scan resource with ApiOperation.code() value" in {
+    val swagger = new Reader(new Swagger()).read(classOf[ResourceWithApiOperationCode])
+    val paths = swagger.getPaths().get("/{id}")
+    val responses1 = paths.getGet.getResponses;
+    responses1.size() should be (3);
+    responses1.containsKey("202") should be (true);
+    responses1.containsKey("200") should be (false);
+    responses1.get("202").getDescription should be("successful operation");
+
+    val responses2 = paths.getPut.getResponses;
+    responses2.size() should be (3);
+    responses2.containsKey("200") should be (true);
+    responses2.get("200").getDescription should be("successful operation");
+  }
+
+  it should "scan resource with ApiResponse.responseContainer() value" in {
+    val swagger = new Reader(new Swagger()).read(classOf[ResourceWithApiResponseResponseContainer])
+    val paths = swagger.getPaths().get("/{id}")
+    val responses1 = paths.getGet.getResponses;
+    responses1.get("200").getSchema().getClass() should be (classOf[MapProperty])
+    responses1.get("400").getSchema().getClass() should be (classOf[ArrayProperty])
+
+    val responses2 = paths.getPut.getResponses;
+    responses2.get("201").getSchema().getClass() should be (classOf[RefProperty])
+    responses2.get("401").getSchema().getClass() should be (classOf[ArrayProperty])
+
+    val responses3 = paths.getPost.getResponses;
+    responses3.get("202").getSchema().getClass() should be (classOf[RefProperty])
+    responses3.get("402").getSchema().getClass() should be (classOf[RefProperty])
+
+    val responses4 = paths.getDelete.getResponses;
+    responses4.get("203").getSchema().getClass() should be (classOf[RefProperty])
+    responses4.get("403").getSchema().getClass() should be (classOf[RefProperty])
   }
 }
 

--- a/modules/swagger-jaxrs/src/test/scala/resources/ResourceWithApiOperationCode.java
+++ b/modules/swagger-jaxrs/src/test/scala/resources/ResourceWithApiOperationCode.java
@@ -1,0 +1,47 @@
+package resources;
+
+import com.wordnik.swagger.annotations.*;
+import models.NotFoundModel;
+import models.Sample;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+public class ResourceWithApiOperationCode {
+  @GET
+  @Path("/{id}")
+  @ApiOperation(value = "Get object by ID",
+    notes = "No details provided",
+    response = Sample.class,
+    position = 0,
+    code = 202,
+    responseHeaders = {
+      @ResponseHeader(name = "foo", description = "description", response = String.class)
+    })
+  @ApiResponses({
+    @ApiResponse(code = 400, message = "Invalid ID",
+      response = NotFoundModel.class,
+      responseHeaders = @ResponseHeader(name = "X-Rack-Cache", description = "Explains whether or not a cache was used", response = Boolean.class)),
+    @ApiResponse(code = 404, message = "object not found")})
+  public Response getTest() {
+    return Response.ok().entity("out").build();
+  }
+
+  @PUT
+  @Path("/{id}")
+  @ApiOperation(value = "Get object by ID",
+    notes = "No details provided",
+    response = Sample.class,
+    position = 0,
+    responseHeaders = {
+      @ResponseHeader(name = "foo", description = "description", response = String.class)
+    })
+  @ApiResponses({
+    @ApiResponse(code = 401, message = "Unauthorized",
+      response = NotFoundModel.class,
+      responseHeaders = @ResponseHeader(name = "X-Rack-Cache", description = "Explains whether or not a cache was used", response = Boolean.class)),
+    @ApiResponse(code = 405, message = "Method Not Allowed")})
+  public Response putTest() {
+    return Response.ok().entity("out").build();
+  }
+}

--- a/modules/swagger-jaxrs/src/test/scala/resources/ResourceWithApiResponseResponseContainer.java
+++ b/modules/swagger-jaxrs/src/test/scala/resources/ResourceWithApiResponseResponseContainer.java
@@ -88,4 +88,44 @@ public class ResourceWithApiResponseResponseContainer {
   public Response deleteTest() {
     return Response.ok().entity("out").build();
   }
+
+  @GET
+  @Path("/{id}/name")
+  @ApiOperation(value = "Get object by ID",
+    notes = "No details provided",
+    response = Sample.class,
+    responseContainer = "array",
+    position = 0,
+    code = 203,
+    responseHeaders = {
+      @ResponseHeader(name = "foo", description = "description", response = String.class, responseContainer = "map")
+    })
+  @ApiResponses({
+    @ApiResponse(code = 403, message = "Forbidden",
+      response = NotFoundModel.class,
+      responseContainer = "set",
+      responseHeaders = @ResponseHeader(name = "X-Rack-Cache", description = "Explains whether or not a cache was used", response = Boolean.class))})
+  public Response getNameTest() {
+    return Response.ok().entity("out").build();
+  }
+
+  @PUT
+  @Path("/{id}/name")
+  @ApiOperation(value = "Get object by ID",
+    notes = "No details provided",
+    response = Sample.class,
+    responseContainer = "set",
+    position = 0,
+    code = 203,
+    responseHeaders = {
+      @ResponseHeader(name = "foo", description = "description", response = String.class, responseContainer = "set")
+    })
+  @ApiResponses({
+    @ApiResponse(code = 403, message = "Forbidden",
+      response = NotFoundModel.class,
+      responseContainer = "array",
+      responseHeaders = @ResponseHeader(name = "X-Rack-Cache", description = "Explains whether or not a cache was used", response = Boolean.class))})
+  public Response putNameTest() {
+    return Response.ok().entity("out").build();
+  }
 }

--- a/modules/swagger-jaxrs/src/test/scala/resources/ResourceWithApiResponseResponseContainer.java
+++ b/modules/swagger-jaxrs/src/test/scala/resources/ResourceWithApiResponseResponseContainer.java
@@ -1,0 +1,91 @@
+package resources;
+
+import com.wordnik.swagger.annotations.*;
+import models.NotFoundModel;
+import models.Sample;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+public class ResourceWithApiResponseResponseContainer {
+  @GET
+  @Path("/{id}")
+  @ApiOperation(value = "Get object by ID",
+    notes = "No details provided",
+    response = Sample.class,
+    responseContainer = "map",
+    code = 200,
+    position = 0,
+    responseHeaders = {
+      @ResponseHeader(name = "foo", description = "description", response = String.class, responseContainer = "list")
+    })
+  @ApiResponses({
+    @ApiResponse(code = 400, message = "Invalid ID",
+      response = NotFoundModel.class,
+      responseContainer = "list",
+      responseHeaders = @ResponseHeader(name = "X-Rack-Cache", description = "Explains whether or not a cache was used", response = Boolean.class)),
+    @ApiResponse(code = 404, message = "object not found")})
+  public Response getTest() {
+    return Response.ok().entity("out").build();
+  }
+
+  @PUT
+  @Path("/{id}")
+  @ApiOperation(value = "Get object by ID",
+    notes = "No details provided",
+    response = Sample.class,
+    position = 0,
+    code = 201,
+    responseHeaders = {
+      @ResponseHeader(name = "foo", description = "description", response = String.class, responseContainer = "list")
+    })
+  @ApiResponses({
+    @ApiResponse(code = 401, message = "Unauthorized",
+      response = NotFoundModel.class,
+      responseContainer = "list",
+      responseHeaders = @ResponseHeader(name = "X-Rack-Cache", description = "Explains whether or not a cache was used", response = Boolean.class)),
+    @ApiResponse(code = 405, message = "Method Not Allowed")})
+  public Response putTest() {
+    return Response.ok().entity("out").build();
+  }
+
+  @POST
+  @Path("/{id}")
+  @ApiOperation(value = "Get object by ID",
+    notes = "No details provided",
+    response = Sample.class,
+    position = 0,
+    code = 202,
+    responseHeaders = {
+      @ResponseHeader(name = "foo", description = "description", response = String.class, responseContainer = "list")
+    })
+  @ApiResponses({
+    @ApiResponse(code = 402, message = "Invalid ID",
+      response = NotFoundModel.class,
+      responseHeaders = @ResponseHeader(name = "X-Rack-Cache", description = "Explains whether or not a cache was used", response = Boolean.class)),
+    @ApiResponse(code = 406, message = "Method Not Allowed")})
+  public Response postTest() {
+    return Response.ok().entity("out").build();
+  }
+
+  @DELETE
+  @Path("/{id}")
+  @ApiOperation(value = "Get object by ID",
+    notes = "No details provided",
+    response = Sample.class,
+    responseContainer = "other",
+    position = 0,
+    code = 203,
+    responseHeaders = {
+      @ResponseHeader(name = "foo", description = "description", response = String.class, responseContainer = "list")
+    })
+  @ApiResponses({
+    @ApiResponse(code = 403, message = "Forbidden",
+      response = NotFoundModel.class,
+      responseContainer = "wrongValue",
+      responseHeaders = @ResponseHeader(name = "X-Rack-Cache", description = "Explains whether or not a cache was used", response = Boolean.class)),
+    @ApiResponse(code = 407, message = "Proxy Authentication Required")})
+  public Response deleteTest() {
+    return Response.ok().entity("out").build();
+  }
+}


### PR DESCRIPTION
Based on [#1017](https://github.com/swagger-api/swagger-core/pull/1017)
Fixes #954 Support "array" and "set" as @ApiOperation#responseContainer value