### PR TITLE
Fixes #1057: 'type' property was set to 'object' for model schema.

### DIFF
--- a/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/com/wordnik/swagger/jackson/ModelResolver.java
@@ -231,9 +231,8 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
       return null;
     }
 
-    ModelImpl model = new ModelImpl()
-      .name(name)
-      .description(_description(beanDesc.getClassInfo()));
+    final ModelImpl model = new ModelImpl().type(ModelImpl.OBJECT).name(name)
+        .description(_description(beanDesc.getClassInfo()));
 
     // if XmlRootElement annotation, construct an Xml object and attach it to the model
     XmlRootElement rootAnnotation = beanDesc.getClassAnnotations().get(XmlRootElement.class);
@@ -499,8 +498,6 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     for (Property prop : props) {
       modelProps.put(prop.getName(), prop);
     }
-    if(modelProps.size() == 0)
-      model.setType("object");
     model.setProperties(modelProps);
     return model;
   }

--- a/modules/swagger-core/src/test/scala/1_3/converter/BoxedTypesTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/BoxedTypesTest.scala
@@ -32,6 +32,7 @@ class BoxedTypesTest extends FlatSpec with Matchers {
 models should serializeToJson (
 """{
   "BoxedTypesIssue31" : {
+    "type": "object",
     "properties" : {
       "stringSeq" : {
         "type" : "array",
@@ -82,6 +83,7 @@ models should serializeToJson (
     models should serializeToJson (
 """{
   "BoxedTypesIssue31WithDataType" : {
+    "type": "object",
     "properties" : {
       "stringSeq" : {
         "type" : "array",

--- a/modules/swagger-core/src/test/scala/1_3/converter/ByteConverterTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/ByteConverterTest.scala
@@ -26,6 +26,7 @@ class ByteConverterTest extends FlatSpec with Matchers {
   models should serializeToJson (
 """{
   "ByteConverterModel" : {
+    "type": "object",
     "properties" : {
       "myBytes" : {
         "type" : "array",

--- a/modules/swagger-core/src/test/scala/1_3/converter/CovariantGetterTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/CovariantGetterTest.scala
@@ -27,6 +27,7 @@ class CovariantGetterTest extends FlatSpec with Matchers {
     models should serializeToJson (
 """{
   "Sub" : {
+    "type":"object",
     "properties" : {
       "myProperty" : {
         "type" : "integer",

--- a/modules/swagger-core/src/test/scala/1_3/converter/EnumConversionPropertyTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/EnumConversionPropertyTest.scala
@@ -26,6 +26,7 @@ class EnumConversionPropertyTest extends FlatSpec with Matchers {
     models should serializeToJson (
 """{
   "ModelWithEnumProperty" : {
+    "type": "object",
     "properties" : {
       "enumValue" : {
         "type" : "string",
@@ -41,6 +42,7 @@ class EnumConversionPropertyTest extends FlatSpec with Matchers {
     models should serializeToJson (
 """{
   "ATM" : {
+    "type": "object",
     "properties" : {
       "currency" : {
         "type" : "string",

--- a/modules/swagger-core/src/test/scala/1_3/converter/JsonIgnoreModelTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/JsonIgnoreModelTest.scala
@@ -21,6 +21,7 @@ class JsonIgnoreModelTest extends FlatSpec with Matchers {
   models should serializeToJson (
 """{
   "ModelWithIgnoreAnnotation" : {
+    "type":"object",
     "properties" : {
       "name" : {
         "type" : "string"

--- a/modules/swagger-core/src/test/scala/1_3/converter/JsonIgnorePropertiesModelTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/JsonIgnorePropertiesModelTest.scala
@@ -22,6 +22,7 @@ class JsonIgnorePropertiesModelTest extends FlatSpec with Matchers {
     models should serializeToJson (
 """{
   "ModelWithIgnorePropertiesAnnotation" : {
+    "type": "object",
     "properties" : {
       "name" : {
         "type" : "string"

--- a/modules/swagger-core/src/test/scala/1_3/converter/JsonPropertyModelTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/JsonPropertyModelTest.scala
@@ -21,6 +21,7 @@ class JsonPropertyModelTest extends FlatSpec with Matchers {
   models should serializeToJson (
 """{
   "ModelWithJsonProperty" : {
+    "type":"object",
     "properties" : {
       "theCount" : {
         "type" : "integer",

--- a/modules/swagger-core/src/test/scala/1_3/converter/ModelConversionTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/ModelConversionTest.scala
@@ -29,6 +29,7 @@ class ModelConversionTest extends FlatSpec with Matchers {
     model.getProperties().size should be (5)
     model should serializeToJson (
 """{
+  "type": "object",
   "properties" : {
     "date" : {
       "type" : "string",
@@ -65,6 +66,7 @@ class ModelConversionTest extends FlatSpec with Matchers {
     model.getProperties().size should be (1)
     model should serializeToJson (
 """{
+  "type": "object",
   "properties" : {
     "longs" : {
       "type" : "array",

--- a/modules/swagger-core/src/test/scala/1_3/converter/ModelPropertyTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/ModelPropertyTest.scala
@@ -81,6 +81,7 @@ class ModelPropertyOverrideTest extends FlatSpec with Matchers {
     models should serializeToJson (
 """{
   "Children" : {
+    "type": "object",
     "properties" : {
       "name" : {
         "type" : "string"
@@ -88,6 +89,7 @@ class ModelPropertyOverrideTest extends FlatSpec with Matchers {
     }
   },
   "ModelWithModelPropertyOverrides" : {
+    "type": "object",
     "properties" : {
       "children" : {
         "type" : "array",

--- a/modules/swagger-core/src/test/scala/1_3/converter/PropertyAnnotationTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/PropertyAnnotationTest.scala
@@ -29,6 +29,7 @@ class PropertyAnnotationTest extends FlatSpec with Matchers {
     a should serializeToJson (
 """{
   "ModelWithAnnotationOnProperty" : {
+    "type": "object",
     "properties" : {
       "count" : {
         "type" : "integer",

--- a/modules/swagger-core/src/test/scala/1_3/converter/SnakeCaseConverterTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/SnakeCaseConverterTest.scala
@@ -39,6 +39,7 @@ class SnakeCaseConverterTest extends FlatSpec with Matchers {
     models should serializeToJson (
 """{
   "bar" : {
+    "type": "object",
     "properties" : {
       "foo" : {
         "type" : "string"
@@ -46,6 +47,7 @@ class SnakeCaseConverterTest extends FlatSpec with Matchers {
     }
   },
   "snake_case_model" : {
+    "type": "object",
     "properties" : {
       "bar" : {
         "$ref" : "#/definitions/bar"

--- a/modules/swagger-core/src/test/scala/CompositionTest.scala
+++ b/modules/swagger-core/src/test/scala/CompositionTest.scala
@@ -21,6 +21,7 @@ class CompositionTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "Human" : {
+    "type": "object",
     "properties" : {
       "name" : {
         "type" : "string"
@@ -44,6 +45,7 @@ class CompositionTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "Animal" : {
+    "type": "object",
     "properties" : {
       "name" : {
         "type" : "string"
@@ -58,6 +60,7 @@ class CompositionTest extends FlatSpec with Matchers {
     "allOf" : [ {
       "$ref" : "#/definitions/Animal"
     }, {
+      "type": "object",
       "properties" : {
         "name" : {
           "type" : "string"
@@ -78,6 +81,7 @@ class CompositionTest extends FlatSpec with Matchers {
     "allOf" : [ {
       "$ref" : "#/definitions/Animal"
     }, {
+      "type": "object",
       "required" : [ "isDomestic", "name", "type" ],
       "properties" : {
         "type" : {
@@ -113,6 +117,7 @@ class CompositionTest extends FlatSpec with Matchers {
       "allOf" : [ {
       "$ref" : "#/definitions/AbstractBaseModelWithoutFields"
       }, {
+       "type": "object",
       "properties" : {
         "a" : {
           "type" : "string",

--- a/modules/swagger-core/src/test/scala/GuavaTest.scala
+++ b/modules/swagger-core/src/test/scala/GuavaTest.scala
@@ -1,19 +1,14 @@
-import models._
-import models.composition.Pet;
-
-import com.wordnik.swagger.util.Json
-import com.wordnik.swagger.models.ModelImpl
-import com.wordnik.swagger.models.properties._
-import com.wordnik.swagger.converter._
-
-import com.fasterxml.jackson.datatype.guava.GuavaModule
-
-import scala.collection.JavaConverters._
-
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import com.fasterxml.jackson.datatype.guava.GuavaModule
+import com.wordnik.swagger.converter.ModelConverters
+import com.wordnik.swagger.util.Json
+
+import matchers.SerializationMatchers.serializeToJson
+import models.GuavaModel
 
 @RunWith(classOf[JUnitRunner])
 class GuavaTest extends FlatSpec with Matchers {
@@ -23,6 +18,6 @@ class GuavaTest extends FlatSpec with Matchers {
     m.registerModule(new GuavaModule())
 
     val schemas = ModelConverters.getInstance().read(classOf[GuavaModel])
-    m.writeValueAsString(schemas) should equal ("""{"GuavaModel":{"properties":{"name":{"type":"string"}}}}""")
+    schemas should serializeToJson ("""{"GuavaModel":{"type": "object","properties":{"name":{"type":"string"}}}}""")
   }
 }

--- a/modules/swagger-core/src/test/scala/ModelConverterTest.scala
+++ b/modules/swagger-core/src/test/scala/ModelConverterTest.scala
@@ -20,6 +20,7 @@ class ModelConverterTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "Person" : {
+    "type": "object",
     "properties" : {
       "id" : {
         "type" : "integer",
@@ -56,7 +57,7 @@ class ModelConverterTest extends FlatSpec with Matchers {
 
   it should "convert a model with Joda DateTime" in {
     val schemas = ModelConverters.getInstance().read(classOf[JodaDateTimeModel])
-    Json.mapper().writeValueAsString(schemas) should equal ("""{"JodaDateTimeModel":{"properties":{"createdAt":{"type":"string","format":"date-time"}}}}""")
+    schemas should serializeToJson ("""{"JodaDateTimeModel":{"type": "object","properties":{"createdAt":{"type":"string","format":"date-time"}}}}""")
   }
 
   it should "read an interface" in {
@@ -64,6 +65,7 @@ class ModelConverterTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "Pet" : {
+    "type": "object",
     "required" : [ "isDomestic", "name", "type" ],
     "properties" : {
       "type" : {
@@ -91,6 +93,7 @@ class ModelConverterTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "Cat" : {
+    "type": "object",
     "required" : [ "isDomestic", "name", "type" ],
     "properties" : {
       "clawCount" : {

--- a/modules/swagger-core/src/test/scala/ModelSerializerTest.scala
+++ b/modules/swagger-core/src/test/scala/ModelSerializerTest.scala
@@ -1,17 +1,29 @@
-import com.wordnik.swagger.models._
-import com.wordnik.swagger.models.properties._
-import com.wordnik.swagger.converter._
-
-import models._
-import com.wordnik.swagger.util.Json
-
+import scala.collection.JavaConverters.mutableMapAsJavaMapConverter
+import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.collection.mutable.HashMap
-import scala.collection.JavaConverters._
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
+import org.scalatest.junit.JUnitRunner
+
+import com.wordnik.swagger.converter.ModelConverters
+import com.wordnik.swagger.models.ArrayModel
+import com.wordnik.swagger.models.ExternalDocs
+import com.wordnik.swagger.models.Model
+import com.wordnik.swagger.models.ModelImpl
+import com.wordnik.swagger.models.RefModel
+import com.wordnik.swagger.models.properties.DateProperty
+import com.wordnik.swagger.models.properties.DateTimeProperty
+import com.wordnik.swagger.models.properties.IntegerProperty
+import com.wordnik.swagger.models.properties.LongProperty
+import com.wordnik.swagger.models.properties.Property
+import com.wordnik.swagger.models.properties.RefProperty
+import com.wordnik.swagger.util.Json
+
+import matchers.SerializationMatchers.serializeToJson
+import models.Car
+import models.Manufacturers
 
 @RunWith(classOf[JUnitRunner])
 class ModelSerializerTest extends FlatSpec with Matchers {
@@ -61,12 +73,12 @@ class ModelSerializerTest extends FlatSpec with Matchers {
 
   it should "make a field readOnly by annotation" in {
     val schemas = ModelConverters.getInstance().read(classOf[Car])
-    Json.mapper().writeValueAsString(schemas) should be ("""{"Car":{"properties":{"wheelCount":{"type":"integer","format":"int32","readOnly":true}}}}""")
+    schemas should serializeToJson ("""{"Car":{"type":"object","properties":{"wheelCount":{"type":"integer","format":"int32","readOnly":true}}}}""")
   }
 
   it should "serialize a model with a Set" in {
     val schemas = ModelConverters.getInstance().read(classOf[Manufacturers])
-    Json.mapper().writeValueAsString(schemas) should be ("""{"Manufacturers":{"properties":{"countries":{"type":"array","uniqueItems":true,"items":{"type":"string"}}}}}""")
+    schemas should serializeToJson ("""{"Manufacturers":{"type":"object","properties":{"countries":{"type":"array","uniqueItems":true,"items":{"type":"string"}}}}}""")
   }
 
   it should "deserialize a model with object example" in {

--- a/modules/swagger-core/src/test/scala/ScalaModelTest.scala
+++ b/modules/swagger-core/src/test/scala/ScalaModelTest.scala
@@ -25,6 +25,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "SimpleCaseClass" : {
+    "type": "object",
     "properties" : {
       "name" : {
         "type" : "string"
@@ -43,6 +44,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "CaseClassWithList" : {
+    "type": "object",
     "properties" : {
       "name" : {
         "type" : "string"
@@ -73,6 +75,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "CaseClassWithOptionLong" : {
+    "type": "object",
     "properties" : {
       "intValue" : {
         "type" : "integer",
@@ -109,6 +112,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
     schemas should serializeToJson ( 
 """{
   "ComplexModel" : {
+    "type": "object",
     "properties" : {
       "name" : {
         "type" : "string"
@@ -120,6 +124,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
     }
   },
   "NestedModel" : {
+    "type": "object",
     "properties" : {
       "complexModel" : {
         "$ref" : "#/definitions/ComplexModel"
@@ -138,6 +143,7 @@ class ScalaModelTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "Pet" : {
+    "type": "object",
     "required" : [ "isDomestic", "name", "type" ],
     "properties" : {
       "type" : {

--- a/modules/swagger-core/src/test/scala/ScalaTest.scala
+++ b/modules/swagger-core/src/test/scala/ScalaTest.scala
@@ -23,6 +23,7 @@ class ScalaTest extends FlatSpec with Matchers {
     schemas should serializeToJson (
 """{
   "ClassWithScalaField" : {
+    "type": "object",
     "properties" : {
       "id" : {
         "type" : "integer",

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ModelImpl.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ModelImpl.java
@@ -12,6 +12,7 @@ import javax.xml.bind.annotation.*;
 @XmlType(propOrder = { "required", "properties"})
 @JsonPropertyOrder({ "required", "properties"})
 public class ModelImpl extends AbstractModel {
+  public static final String OBJECT = "object";
   private String type;
   private String name;
   private List<String> required;
@@ -27,6 +28,12 @@ public class ModelImpl extends AbstractModel {
     this.setDiscriminator(discriminator);
     return this;
   }
+
+  public ModelImpl type(String type) {
+    this.setType(type);
+    return this;
+  }
+
   public ModelImpl name(String name) {
     this.setName(name);
     return this;
@@ -90,7 +97,7 @@ public class ModelImpl extends AbstractModel {
     return additionalProperties;
   }
   public void setAdditionalProperties(Property additionalProperties) {
-    this.setType("object");
+    type(OBJECT);
     this.additionalProperties = additionalProperties;
   }
 

--- a/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ModelImpl.java
+++ b/modules/swagger-models/src/main/java/com/wordnik/swagger/models/ModelImpl.java
@@ -9,8 +9,8 @@ import java.util.*;
 
 import javax.xml.bind.annotation.*;
 
-@XmlType(propOrder = { "required", "properties"})
-@JsonPropertyOrder({ "required", "properties"})
+@XmlType(propOrder = {"type", "required", "discriminator", "properties"})
+@JsonPropertyOrder({"type", "required", "discriminator", "properties"})
 public class ModelImpl extends AbstractModel {
   public static final String OBJECT = "object";
   private String type;


### PR DESCRIPTION
Fixes #1057: 'type' property was set to 'object' for model schema.