### PR TITLE
Fixed #970: DefaultValue missing in post body of swagger.json in 1.5.3-M1

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
@@ -1,8 +1,8 @@
 package io.swagger.jaxrs;
 
-import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.models.parameters.CookieParameter;
 import io.swagger.models.parameters.FormParameter;
 import io.swagger.models.parameters.HeaderParameter;
@@ -14,41 +14,34 @@ import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 
-import java.util.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.FormParam;
-import javax.ws.rs.DefaultValue;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 public class DefaultParameterExtension extends AbstractSwaggerExtension {
 
   @Override
   public List<Parameter> extractParameters(List<Annotation> annotations, Type type, Set<Type> typesToSkip, Iterator<SwaggerExtension> chain) {
-    String defaultValue = "";
-
     if(shouldIgnoreType(type, typesToSkip))
       return new ArrayList<Parameter>();
 
     List<Parameter> parameters = new ArrayList<Parameter>();
     Parameter parameter = null;
     for(Annotation annotation : annotations) {
-      if(annotation instanceof DefaultValue) {
-        DefaultValue defaultValueAnnotation = (DefaultValue) annotation;
-        defaultValue = defaultValueAnnotation.value();
-      }
       if(annotation instanceof QueryParam) {
         QueryParam param = (QueryParam) annotation;
         QueryParameter qp = new QueryParameter()
           .name(param.value());
 
-        if(!defaultValue.isEmpty()) {
-          qp.setDefaultValue(defaultValue);
-        }
         Property schema = createProperty(type);
         if(schema != null)
           qp.setProperty(schema);
@@ -58,8 +51,6 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
         PathParam param = (PathParam) annotation;
         PathParameter pp = new PathParameter()
           .name(param.value());
-        if(!defaultValue.isEmpty())
-          pp.setDefaultValue(defaultValue);
         Property schema = createProperty(type);
         if(schema != null)
           pp.setProperty(schema);
@@ -69,7 +60,6 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
         HeaderParam param = (HeaderParam) annotation;
         HeaderParameter hp = new HeaderParameter()
           .name(param.value());
-        hp.setDefaultValue(defaultValue);
         Property schema = createProperty(type);
         if(schema != null)
           hp.setProperty(schema);
@@ -79,8 +69,6 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
         CookieParam param = (CookieParam) annotation;
         CookieParameter cp = new CookieParameter()
           .name(param.value());
-        if(!defaultValue.isEmpty())
-          cp.setDefaultValue(defaultValue);
         Property schema = createProperty(type);
         if(schema != null)
           cp.setProperty(schema);
@@ -90,8 +78,6 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
         FormParam param = (FormParam) annotation;
         FormParameter fp = new FormParameter()
           .name(param.value());
-        if(!defaultValue.isEmpty())
-          fp.setDefaultValue(defaultValue);
         Property schema = createProperty(type);
         if(schema != null)
           fp.setProperty(schema);

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/ScannerTest.scala
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/ScannerTest.scala
@@ -1,14 +1,11 @@
 import io.swagger.jaxrs.Reader
-import io.swagger.models.Swagger
+import io.swagger.models.{ModelImpl, Swagger}
 import io.swagger.models.properties.MapProperty
 import io.swagger.util.Json
 import resources._
 
 import io.swagger.jaxrs.config._
 import io.swagger.models.parameters._
-
-
-import scala.collection.JavaConverters._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -41,5 +38,31 @@ class ScannerTest extends FlatSpec with Matchers {
 
     swagger.getDefinitions() should not be (null)
     swagger.getDefinitions().get( "ClassWithString" ) should not be (null)
+  }
+
+  it should "scan a bean param resource" in {
+    val swagger = new Reader(new Swagger()).read(classOf[ResourceWithBeanParams])
+
+    val get = swagger.getPaths().get("/bean/{id}").getGet()
+    val params = get.getParameters()
+
+    val headerParam1 = params.get(0).asInstanceOf[HeaderParameter]
+    headerParam1.getDefaultValue() should be("1")
+    headerParam1.getName() should be("test order annotation 1")
+
+    val headerParam2 = params.get(1).asInstanceOf[HeaderParameter]
+    headerParam2.getDefaultValue() should be("2")
+    headerParam2.getName() should be("test order annotation 2")
+
+    val priority1 = params.get(2).asInstanceOf[QueryParameter]
+    priority1.getDefaultValue() should be("overridden")
+    priority1.getName() should be("test priority 1")
+
+    val priority2 = params.get(3).asInstanceOf[QueryParameter]
+    priority2.getDefaultValue() should be("overridden")
+    priority2.getName() should be("test priority 2")
+
+    val bodyParam1 = params.get(4).asInstanceOf[BodyParameter].getSchema().asInstanceOf[ModelImpl]
+    bodyParam1.getDefaultValue() should be ("bodyParam")
   }
 }

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/models/TestBeanParam.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/models/TestBeanParam.java
@@ -1,0 +1,61 @@
+package models;
+
+import io.swagger.annotations.ApiParam;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.QueryParam;
+
+
+public class TestBeanParam {
+
+  @HeaderParam("test order annotation 1")
+  @DefaultValue("1")
+  private Integer order1;
+
+  @DefaultValue("2")
+  @HeaderParam("test order annotation 2")
+  private Integer order2;
+
+  @QueryParam("priority1")
+  @DefaultValue("default")
+  @ApiParam(name = "test priority 1", defaultValue = "overridden")
+  private Integer priority1;
+
+  @QueryParam("priority2")
+  @ApiParam(name = "test priority 2", defaultValue = "overridden")
+  @DefaultValue("default")
+  private Integer priority2;
+
+  public Integer getOrder1() {
+    return order1;
+  }
+
+  public void setOrder1(Integer order1) {
+    this.order1 = order1;
+  }
+
+  public Integer getOrder2() {
+    return order2;
+  }
+
+  public void setOrder2(Integer order2) {
+    this.order2 = order2;
+  }
+
+  public Integer getPriority1() {
+    return priority1;
+  }
+
+  public void setPriority1(Integer priority1) {
+    this.priority1 = priority1;
+  }
+
+  public Integer getPriority2() {
+    return priority2;
+  }
+
+  public void setPriority2(Integer priority2) {
+    this.priority2 = priority2;
+  }
+}

--- a/modules/swagger-jersey2-jaxrs/src/test/scala/resources/ResourceWithBeanParams.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/scala/resources/ResourceWithBeanParams.java
@@ -4,11 +4,18 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import models.*;
+import models.NotFoundModel;
+import models.Pagination;
+import models.TestBeanParam;
 
-import javax.ws.rs.*;
+import java.util.HashMap;
+import java.util.Map;
 
-import java.util.*;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
 
 @Api(value = "/basic", description = "Basic resource")
 public class ResourceWithBeanParams {
@@ -24,6 +31,19 @@ public class ResourceWithBeanParams {
   public Map<String, Integer> getTest(
       @BeanParam Pagination pagination
       ) throws WebApplicationException {
+    return new HashMap<String, Integer>();
+  }
+
+  @GET
+  @Path("/bean/{id}")
+  @ApiOperation(value = "Get test object by ID",
+    notes = "No details provided")
+  @ApiResponses({
+    @ApiResponse(code = 400, message = "Invalid ID", response = NotFoundModel.class),
+    @ApiResponse(code = 404, message = "object not found")})
+  public Map<String, Integer> getTestBeanParams(@BeanParam TestBeanParam params, @DefaultValue("bodyParam") String
+    testBody) throws
+    WebApplicationException {
     return new HashMap<String, Integer>();
   }
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/ModelImpl.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/ModelImpl.java
@@ -1,11 +1,18 @@
 package io.swagger.models;
 
-import com.fasterxml.jackson.annotation.*;
 import io.swagger.models.properties.Property;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlType;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @XmlType(propOrder = {"type", "required", "discriminator", "properties"})
 @JsonPropertyOrder({"type", "required", "discriminator", "properties"})
@@ -22,6 +29,8 @@ public class ModelImpl extends AbstractModel {
   private Property additionalProperties;
   private String discriminator;
   private Xml xml;
+  @JsonProperty("default")
+  private String defaultValue;
 
   public ModelImpl discriminator(String discriminator) {
     this.setDiscriminator(discriminator);
@@ -163,7 +172,7 @@ public class ModelImpl extends AbstractModel {
           property.setRequired(true);
       }
     }
-    properties.put(key, property);    
+    properties.put(key, property);
   }
 
   public Map<String, Property> getProperties() {
@@ -195,6 +204,14 @@ public class ModelImpl extends AbstractModel {
     this.xml = xml;
   }
 
+  public String getDefaultValue() {
+    return defaultValue;
+  }
+
+  public void setDefaultValue(String defaultValue) {
+    this.defaultValue = defaultValue;
+  }
+
   public Object clone() {
     ModelImpl cloned = new ModelImpl();
     super.cloneTo(cloned);
@@ -208,6 +225,7 @@ public class ModelImpl extends AbstractModel {
     cloned.additionalProperties = this.additionalProperties;
     cloned.discriminator = this.discriminator;
     cloned.xml = this.xml;
+    cloned.defaultValue = this.defaultValue;
 
     return cloned;
   }
@@ -233,6 +251,7 @@ public class ModelImpl extends AbstractModel {
   	result = prime * result + ((required == null) ? 0 : required.hashCode());
   	result = prime * result + ((type == null) ? 0 : type.hashCode());
   	result = prime * result + ((xml == null) ? 0 : xml.hashCode());
+    result = prime * result + ((defaultValue == null) ? 0 : defaultValue.hashCode());
   	return result;
   }
 
@@ -297,6 +316,11 @@ public class ModelImpl extends AbstractModel {
   			return false;
   	} else if (!xml.equals(other.xml))
   		return false;
+    if (defaultValue == null) {
+      if (other.defaultValue != null)
+        return false;
+    } else if (!defaultValue.equals(other.defaultValue))
+      return false;
   	return true;
   }
 }


### PR DESCRIPTION
Fixed #970: DefaultValue missing in post body of swagger.json in 1.5.3-M1

* Supports `@DefaultValue` annotation for `BodyParameter`
* Annotations handling was made order insensitive