### PR TITLE
Fixed #1120: Models handling has been reworked.

### DIFF
--- a/modules/swagger-core/src/test/scala/io/swagger/jackson/EnumTest.java
+++ b/modules/swagger-core/src/test/scala/io/swagger/jackson/EnumTest.java
@@ -1,22 +1,39 @@
 package io.swagger.jackson;
 
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.Collections2;
+
 import io.swagger.converter.ModelConverterContextImpl;
 import io.swagger.models.Model;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
 
 public class EnumTest extends SwaggerTestBase {
-  public enum Currency { USA, CANADA }
+  public enum Currency {
+    USA, CANADA
+  }
 
   public void testEnum() throws Exception {
-    ModelResolver modelResolver = new ModelResolver(mapper());    
+    ModelResolver modelResolver = new ModelResolver(mapper());
     ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
- 
-	  Model model = context.resolve(Currency.class);
-    assertNotNull(model);
 
-    // Set<String> names = model.getProperties().keySet();
-    // if (names.contains("declaringClass")) {
-      // TODO how best to handle this?
-      // fail("Enum model should not contain property 'declaringClass', does; properties = " + names);
-    // }
+    Model model = context.resolve(Currency.class);
+    assertNull(model);
+    Property property = context.resolveProperty(Currency.class, new Annotation[] {});
+    assertNotNull(property);
+    Assert.assertThat(property, CoreMatchers.instanceOf(StringProperty.class));
+    final StringProperty strProperty = (StringProperty) property;
+    assertNotNull(strProperty.getEnum());
+    final Collection<String> values =
+        new ArrayList<String>(Collections2.transform(Arrays.asList(Currency.values()), Functions.toStringFunction()));
+    assertEquals(values, strProperty.getEnum());
   }
 }

--- a/modules/swagger-core/src/test/scala/models/ModelWithTuple2.java
+++ b/modules/swagger-core/src/test/scala/models/ModelWithTuple2.java
@@ -8,9 +8,8 @@ import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
-import io.swagger.models.properties.StringProperty;
-import io.swagger.util.Json;
 
+import org.apache.commons.lang3.text.WordUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import com.fasterxml.jackson.databind.JavaType;
@@ -18,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-
 import java.util.*;
 
 public class ModelWithTuple2 {
@@ -36,48 +34,49 @@ public class ModelWithTuple2 {
     public Integer age;
   }
 
-  public static class TupleModelConverter extends AbstractModelConverter implements ModelConverter {
-    public TupleModelConverter(ObjectMapper mapper) {
+  public static class TupleAsMapModelConverter extends AbstractModelConverter {
+
+    public TupleAsMapModelConverter(ObjectMapper mapper) {
       super(mapper);
     }
 
     @Override
-    public Property resolveProperty(Type type, ModelConverterContext context, Annotation[] annotations, Iterator<ModelConverter> chain) {
-      JavaType _type = Json.mapper().constructType(type);
-      if(_type != null){
-        Class<?> cls = _type.getRawClass();
-        if(Pair.class.isAssignableFrom(cls)) {
-          return new MapProperty()
-            .additionalProperties(new StringProperty());
-        }
+    public Model resolve(Type type, ModelConverterContext context, Iterator<ModelConverter> chain) {
+      final JavaType javaType = _mapper.constructType(type);
+      if (Pair.class.isAssignableFrom(javaType.getRawClass())) {
+        final JavaType left = javaType.containedType(0);
+        final String name = "MapOf" + WordUtils.capitalize(_typeName(left));
+
+        return new ModelImpl().name(name).additionalProperties(context.resolveProperty(left, new Annotation[] {}));
       }
-      if(chain.hasNext())
-        return chain.next().resolveProperty(type, context, annotations, chain);
-      else
-        return null;
+      return super.resolve(type, context, chain);
+    }
+  }
+
+  public static class TupleAsMapPropertyConverter extends AbstractModelConverter {
+
+    public TupleAsMapPropertyConverter(ObjectMapper mapper) {
+      super(mapper);
+    }
+
+    @Override
+    public Property resolveProperty(Type type, ModelConverterContext context, Annotation[] annotations,
+        Iterator<ModelConverter> chain) {
+      final JavaType javaType = _mapper.constructType(type);
+      if (Pair.class.isAssignableFrom(javaType.getRawClass())) {
+        final JavaType left = javaType.containedType(0);
+        return new MapProperty(context.resolveProperty(left, new Annotation[] {}));
+      }
+      return super.resolveProperty(type, context, annotations, chain);
     }
 
     @Override
     public Model resolve(Type type, ModelConverterContext context, Iterator<ModelConverter> chain) {
-      JavaType _type = Json.mapper().constructType(type);
-      if(_type != null){
-        Class<?> cls = _type.getRawClass();
-        if(Pair.class.isAssignableFrom(cls)) {
-          String name = _typeName(_type); // use name from type?
-          name = "MyPair";
-
-          ModelImpl model = new ModelImpl()
-            .name(name)
-            .additionalProperties(new StringProperty());
-
-          return model;
-        }
-      }
-
-      if(chain.hasNext())
-        return chain.next().resolve(type, context, chain);
-      else
+      final JavaType javaType = _mapper.constructType(type);
+      if (Pair.class.isAssignableFrom(javaType.getRawClass())) {
         return null;
+      }
+      return super.resolve(type, context, chain);
     }
   }
 }

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
@@ -97,16 +97,20 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
   }
 
   private Property createProperty(Type type) {
-    return enforcePrimitive(ModelConverters.getInstance().readAsProperty(type));
+    return enforcePrimitive(ModelConverters.getInstance().readAsProperty(type), 0);
   }
 
-  private Property enforcePrimitive(Property in) {
+  private Property enforcePrimitive(Property in, int level) {
     if (in instanceof RefProperty) {
       return new StringProperty();
     }
     if (in instanceof ArrayProperty) {
-      final ArrayProperty array = (ArrayProperty) in;
-      array.setItems(enforcePrimitive(array.getItems()));
+      if (level == 0) {
+        final ArrayProperty array = (ArrayProperty) in;
+        array.setItems(enforcePrimitive(array.getItems(), level + 1));
+      } else {
+        return new StringProperty();
+      }
     }
     return in;
   }

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -641,7 +641,7 @@ public class Reader {
       return output;
   }
 
-  public Map<String, Property> parseResponseHeaders(ResponseHeader[] headers) {
+  private Map<String, Property> parseResponseHeaders(ResponseHeader[] headers) {
     Map<String,Property> responseHeaders = null;
     if(headers != null && headers.length > 0) {
       for(ResponseHeader header : headers) {
@@ -652,13 +652,14 @@ public class Reader {
           String description = header.description();
           Class<?> cls = header.response();
 
-          if(!cls.equals(java.lang.Void.class) && !"void".equals(cls.toString())) {
-            Property property = ModelConverters.getInstance().readAsProperty(cls);
+          if(!isVoid(cls)) {
+            final Property property = ModelConverters.getInstance().readAsProperty(cls);
             if(property != null) {
               Property responseProperty = ContainerWrapper.wrapContainer(header.responseContainer(), property,
                       ContainerWrapper.ARRAY, ContainerWrapper.LIST, ContainerWrapper.SET);
               responseProperty.setDescription(description);
               responseHeaders.put(name, responseProperty);
+              appendModels(cls);
             }
           }
         }
@@ -734,45 +735,13 @@ public class Reader {
       responseType = method.getGenericReturnType();
     }
     if(isValidResponse(responseType)) {
-      int responseCode = 200;
-      if (apiOperation != null) {
-        responseCode = apiOperation.code();
-      }
-      if(isPrimitive(responseType)) {
-        Property property = ModelConverters.getInstance().readAsProperty(responseType);
-        if(property != null) {
-          Property responseProperty = ContainerWrapper.wrapContainer(responseContainer, property);
-          operation.response(responseCode, new Response()
-            .description(SUCCESSFUL_OPERATION)
-            .schema(responseProperty)
+      final Property property = ModelConverters.getInstance().readAsProperty(responseType);
+      if (property != null) {
+        final Property responseProperty = ContainerWrapper.wrapContainer(responseContainer, property);
+        final int responseCode = apiOperation == null ? 200 : apiOperation.code();
+        operation.response(responseCode, new Response().description(SUCCESSFUL_OPERATION).schema(responseProperty)
             .headers(defaultResponseHeaders));
-        }
-      } else {
-        Map<String, Model> models = ModelConverters.getInstance().read(responseType);
-        if(models.size() == 0) {
-          Property p = ModelConverters.getInstance().readAsProperty(responseType);
-          operation.response(responseCode, new Response()
-            .description(SUCCESSFUL_OPERATION)
-            .schema(p)
-            .headers(defaultResponseHeaders));
-        }
-        for(String key: models.keySet()) {
-          Model model = models.get( key );
-          Property property = StringUtils.isNotEmpty( model.getReference() ) ?
-                  new RefProperty( model.getReference() ) :
-                  new RefProperty().asDefault(key);
-
-          Property responseProperty = ContainerWrapper.wrapContainer(responseContainer, property);
-          operation.response(responseCode, new Response()
-            .description(SUCCESSFUL_OPERATION)
-            .schema(responseProperty)
-            .headers(defaultResponseHeaders));
-          swagger.model(key, models.get(key));
-        }
-        models = ModelConverters.getInstance().readAll(responseType);
-        for(String key: models.keySet()) {
-          swagger.model(key, models.get(key));
-        }
+        appendModels(responseType);
       }
     }
 
@@ -811,32 +780,14 @@ public class Reader {
         else
           operation.response(apiResponse.code(), response);
 
-        responseType = apiResponse.response();
-
         if( StringUtils.isNotEmpty( apiResponse.reference() )){
           response.schema( new RefProperty( apiResponse.reference() ));
-        }
-        else if(responseType != null && !isVoid(responseType)) {
-          Map<String, Model> models = ModelConverters.getInstance().read(responseType);
-          for(String key: models.keySet()) {
-            Model model = models.get( key );
-            Property property = StringUtils.isNotEmpty( model.getReference() ) ?
-                    new RefProperty( model.getReference() ) :
-                    new RefProperty().asDefault(key);
-
-            Property responseProperty = ContainerWrapper.wrapContainer(apiResponse.responseContainer(), property);
-            response.schema(responseProperty);
-
-            if( StringUtils.isEmpty(model.getReference())) {
-              swagger.model(key, models.get(key));
-            }
-          }
-          models = ModelConverters.getInstance().readAll(responseType);
-          for(String key: models.keySet()) {
-            Model model = models.get(key);
-            if( StringUtils.isEmpty(model.getReference())) {
-              swagger.model(key, model);
-            }
+        } else if (!isVoid(apiResponse.response())) {
+          responseType = apiResponse.response();
+          final Property property = ModelConverters.getInstance().readAsProperty(responseType);
+          if (property != null) {
+            response.schema(ContainerWrapper.wrapContainer(apiResponse.responseContainer(), property));
+            appendModels(responseType);
           }
         }
       }
@@ -942,25 +893,11 @@ public class Reader {
       return null;
   }
 
-  boolean isPrimitive(Type type) {
-    boolean out = false;
-
-    Property property = ModelConverters.getInstance().readAsProperty(type);
-    if(property == null)
-      out = false;
-    else if("integer".equals(property.getType()))
-      out = true;
-    else if("string".equals(property.getType()))
-      out = true;
-    else if("number".equals(property.getType()))
-      out = true;
-    else if("boolean".equals(property.getType()))
-      out = true;
-    else if("array".equals(property.getType()))
-      out = true;
-    else if("file".equals(property.getType()))
-      out = true;
-    return out;
+  private void appendModels(Type type) {
+    final Map<String, Model> models = ModelConverters.getInstance().readAll(type);
+    for(Map.Entry<String, Model> entry : models.entrySet()) {
+      swagger.model(entry.getKey(), entry.getValue());
+    }
   }
 
   private static Set<Scheme> parseSchemes(String schemes) {

--- a/modules/swagger-jaxrs/src/test/scala/resources/ResourceWithTypedResponses.java
+++ b/modules/swagger-jaxrs/src/test/scala/resources/ResourceWithTypedResponses.java
@@ -1,0 +1,61 @@
+package resources;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import models.Tag;
+
+@Api(value = "/root")
+public class ResourceWithTypedResponses {
+
+  @GET
+  @Path("testPrimitiveResponses")
+  @ApiResponses({ @ApiResponse(code = 400, message = "Message for URI", response = URI.class),
+      @ApiResponse(code = 401, message = "Message for URL", response = URL.class),
+      @ApiResponse(code = 402, message = "Message for UUID", response = UUID.class),
+      @ApiResponse(code = 403, message = "Message for Long", response = Long.class),
+      @ApiResponse(code = 404, message = "Message for String", response = String.class) })
+  public Response testPrimitiveResponses() {
+    return null;
+  }
+
+  @GET
+  @Path("testObjectResponse")
+  public Tag testObjectResponse(Tag body) {
+    return body;
+  }
+
+  @GET
+  @Path("testObjectsResponse")
+  public List<Tag> testObjectsResponse(List<Tag> body) {
+    return body;
+  }
+
+  @GET
+  @Path("testStringResponse")
+  public String testStringResponse(String body) {
+    return body;
+  }
+
+  @GET
+  @Path("testStringsResponse")
+  public List<String> testStringsResponse(List<String> body) {
+    return body;
+  }
+
+  @GET
+  @Path("testMapResponse")
+  public Map<Integer, Tag> testMapResponse(Map<Integer, Tag> body) {
+    return body;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,7 @@
     <jackson-guava-version>2.4.2</jackson-guava-version>
     <logback-version>1.0.1</logback-version>
 
-    <junit-version>4.8.1</junit-version>
+    <junit-version>4.8.2</junit-version>
     <maven-plugin-version>1.0.0</maven-plugin-version>
     <commons-lang-version>3.2.1</commons-lang-version>
     <slf4j-version>1.6.3</slf4j-version>


### PR DESCRIPTION
Fixed #1120: Models handling has been reworked.

Actually the #1120 has to separate issues. The first one that swagger doesn't fill the [Response.schema](https://github.com/swagger-api/swagger-core/blob/6875dfe0cc5e7f3ec08e49f4d0eb9c5e6832bfd3/modules/swagger-models/src/main/java/io/swagger/models/Response.java#L11) property for primitive types and the second that `URL` class is treated as complex type `"$ref" : "#/definitions/string"` (https://github.com/swagger-api/swagger-core/issues/1120#issue-83516910) while it should be reported as a primitive `string` with the `url` format.

The first issue rises here https://github.com/swagger-api/swagger-core/blob/6875dfe0cc5e7f3ec08e49f4d0eb9c5e6832bfd3/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java#L820-840 - primitive types are not processed at all.
There are 6 similar places where we instantiate implementation of the `Property` interface to reference a type:
1. https://github.com/swagger-api/swagger-core/blob/6875dfe0cc5e7f3ec08e49f4d0eb9c5e6832bfd3/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java#L97-118
2. https://github.com/swagger-api/swagger-core/blob/6875dfe0cc5e7f3ec08e49f4d0eb9c5e6832bfd3/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java#L122-173
3. https://github.com/swagger-api/swagger-core/blob/6875dfe0cc5e7f3ec08e49f4d0eb9c5e6832bfd3/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java#L656-662
4. https://github.com/swagger-api/swagger-core/blob/6875dfe0cc5e7f3ec08e49f4d0eb9c5e6832bfd3/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java#L741-776
5. https://github.com/swagger-api/swagger-core/blob/6875dfe0cc5e7f3ec08e49f4d0eb9c5e6832bfd3/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/ParameterProcessor.java#L128-159
6. https://github.com/swagger-api/swagger-core/blob/6875dfe0cc5e7f3ec08e49f4d0eb9c5e6832bfd3/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/ParameterProcessor.java#L162-187
All these pieces of code do the same thing but differently. It would be nice to extract this functionality into some utility class and re-use from everywhere. But it appeared that it's enough to call `ModelConverters.getInstance().readAsProperty(...)` to instantiate  implementation of the `Property` interface and `ModelConverters.getInstance().readAll(...)` to collect all referenced models.
The only difference for `ParameterProcessor` is that `Property` has to be converted into `Model`, that is why the `io.swagger.models.properties.PropertyBuilder.toModel(...)` method has been added.

The second issue arises here https://github.com/swagger-api/swagger-core/blob/6875dfe0cc5e7f3ec08e49f4d0eb9c5e6832bfd3/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverters.java#L101, so `ModelConverters.read(...)` and `ModelConverters.readAll(...)` calls return empty maps for `java.lang.String` and non-empty maps for `java.net.URL` and `java.net.URI` but should not.
So, added the `io.swagger.jackson.TypeNameResolver.isStdType(JavaType)` method and used it in `io.swagger.jackson.ModelResolver` to force null models for primitive types.

After all these changes two old tests failed:
* EnumTest was expecting non null model for enum class but enums are treated as strings and no models should be created for them
* ModelWithTuple2 was incorrect as it merged `Pair<String, String>` and `Pair<ComplexLeft, String>` into a single model

So, both tests were reworked.

