### PR TITLE
Improved accept header for swagger request.

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
@@ -12,6 +12,8 @@ import io.swagger.jaxrs.config.JaxrsScanner;
 import io.swagger.jaxrs.config.ReaderConfigUtils;
 import io.swagger.models.Swagger;
 import io.swagger.util.Yaml;
+
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +21,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.Context;
@@ -28,6 +31,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;


### PR DESCRIPTION
1. Outsourced code for swagger creation, so that duplicate code is
reduced.
2. Changed path annotations of getListingJson and getListingYaml and a
new methods that supports swagger with .yaml or .json at the end.
Through this swagger now supports 3 ways to request the documentation.
/swagger , /swagger.json & /swagger.yaml
This way URL-based negotiation (http://docs.jboss.org/resteasy/docs/2.3.7.Final/userguide/html/JAX-RS_Content_Negotiation.html#media_mappings) of RESTeasy works, if a media type mapping from .json to application/json is configured.