### PR TITLE
Properly resolve a inner model with a self/cyclic reference.

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContext.java
+++ b/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContext.java
@@ -25,8 +25,9 @@ public interface ModelConverterContext {
      * @param name  the name of the model
      * @param model the Model
      * @param type the Type
+     * @param prevName the (optional) previous name
      */
-    public void defineModel(String name, Model model, Type type);
+    public void defineModel(String name, Model model, Type type, String prevName);
 
     /**
      * @param type the property Class

--- a/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContext.java
+++ b/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContext.java
@@ -19,6 +19,16 @@ public interface ModelConverterContext {
     public void defineModel(String name, Model model);
 
     /**
+     * needs to be called whenever a Model is defined which can be referenced from another
+     * Model or Property
+     *
+     * @param name  the name of the model
+     * @param model the Model
+     * @param type the Type
+     */
+    public void defineModel(String name, Model model, Type type);
+
+    /**
      * @param type the property Class
      * @return a property representation of the Class. Any referenced models will be defined already.
      */

--- a/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContextImpl.java
+++ b/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContextImpl.java
@@ -3,6 +3,7 @@ package io.swagger.converter;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.Property;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,15 +45,19 @@ public class ModelConverterContextImpl implements ModelConverterContext {
 
     @Override
     public void defineModel(String name, Model model) {
-        defineModel(name,model,null);
+        defineModel(name,model,null,null);
     }
 
     @Override
-    public void defineModel(String name, Model model, Type type) {
+    public void defineModel(String name, Model model, Type type, String oldName) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("defineModel %s %s", name, model));
         }
         modelByName.put(name, model);
+
+        if(StringUtils.isNotBlank(oldName)) {
+            modelByName.remove(oldName);
+        }
 
         if(type != null) {
             modelByType.put(type,model);

--- a/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContextImpl.java
+++ b/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContextImpl.java
@@ -49,14 +49,14 @@ public class ModelConverterContextImpl implements ModelConverterContext {
     }
 
     @Override
-    public void defineModel(String name, Model model, Type type, String oldName) {
+    public void defineModel(String name, Model model, Type type, String prevName) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("defineModel %s %s", name, model));
         }
         modelByName.put(name, model);
 
-        if(StringUtils.isNotBlank(oldName)) {
-            modelByName.remove(oldName);
+        if(StringUtils.isNotBlank(prevName)) {
+            modelByName.remove(prevName);
         }
 
         if(type != null) {

--- a/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContextImpl.java
+++ b/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContextImpl.java
@@ -44,10 +44,19 @@ public class ModelConverterContextImpl implements ModelConverterContext {
 
     @Override
     public void defineModel(String name, Model model) {
+        defineModel(name,model,null);
+    }
+
+    @Override
+    public void defineModel(String name, Model model, Type type) {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(String.format("defineModel %s %s", name, model));
         }
         modelByName.put(name, model);
+
+        if(type != null) {
+            modelByType.put(type,model);
+        }
     }
 
     public Map<String, Model> getDefinedModels() {

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -179,11 +179,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             // We don't build models for primitive types
             return null;
         }
-        if (type.isContainerType()) {
-            // We treat collections as primitive types, just need to add models for values (if any)
-            context.resolve(type.getContentType());
-            return null;
-        }
+
         final BeanDescription beanDesc = _mapper.getSerializationConfig().introspect(type);
         // Couple of possibilities for defining
         String name = _typeName(type, beanDesc);
@@ -194,7 +190,13 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
         final ModelImpl model = new ModelImpl().type(ModelImpl.OBJECT).name(name)
                 .description(_description(beanDesc.getClassInfo()));
+        context.defineModel(name,model,type);
 
+        if (type.isContainerType()) {
+            // We treat collections as primitive types, just need to add models for values (if any)
+            context.resolve(type.getContentType());
+            return null;
+        }
         // if XmlRootElement annotation, construct an Xml object and attach it to the model
         XmlRootElement rootAnnotation = beanDesc.getClassAnnotations().get(XmlRootElement.class);
         if (rootAnnotation != null && !"".equals(rootAnnotation.name()) && !"##default".equals(rootAnnotation.name())) {

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -190,7 +190,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
         final ModelImpl model = new ModelImpl().type(ModelImpl.OBJECT).name(name)
                 .description(_description(beanDesc.getClassInfo()));
-        context.defineModel(name,model,type,null);
+
+        if(!type.isContainerType()) {
+            // define the model here to support self/cyclic referencing of models
+            context.defineModel(name, model, type, null);
+        }
 
         if (type.isContainerType()) {
             // We treat collections as primitive types, just need to add models for values (if any)

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -190,7 +190,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
         final ModelImpl model = new ModelImpl().type(ModelImpl.OBJECT).name(name)
                 .description(_description(beanDesc.getClassInfo()));
-        context.defineModel(name,model,type);
+        context.defineModel(name,model,type,null);
 
         if (type.isContainerType()) {
             // We treat collections as primitive types, just need to add models for values (if any)

--- a/modules/swagger-core/src/test/scala/1_3/converter/SnakeCaseConverterTest.scala
+++ b/modules/swagger-core/src/test/scala/1_3/converter/SnakeCaseConverterTest.scala
@@ -95,7 +95,9 @@ class SnakeCaseConverter extends ModelConverter {
         val name = (model.asInstanceOf[ModelImpl]).getName
         if (model.isInstanceOf[ModelImpl]) {
           val impl = model.asInstanceOf[ModelImpl]
+          val prevName = impl.getName()
           impl.setName(toSnakeCase(impl.getName()))
+          context.defineModel(impl.getName,impl,`type`,prevName)
         }
         return model
       }

--- a/modules/swagger-jaxrs/src/test/scala/ReferenceTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/ReferenceTest.scala
@@ -28,135 +28,141 @@ class ReferenceTest extends FlatSpec with Matchers {
     val swagger = reader.read(classOf[ResourceWithReferences])
 
     swagger should serializeToJson(
-      """{
-  "swagger": "2.0",
-  "tags": [
-    {
-      "name": "basic"
+    """{"swagger": "2.0", "tags": [
+      {
+        "name": "basic"
+      }
+      ], "paths": {
+      "/anotherModel": {
+      "get": {
+      "tags": ["basic"],
+      "summary": "Get Another Model",
+      "description": "",
+      "operationId": "getAnotherModel",
+      "parameters": [],
+      "responses": {
+      "200": {
+      "description": "successful operation",
+      "schema": {
+      "$ref": "http://swagger.io/schemas.json#/Models"
     }
-  ],
-  "paths": {
-    "/anotherModel": {
-      "get": {
-        "tags": [
-          "basic"
-        ],
-        "summary": "Get Another Model",
-        "description": "",
-        "operationId": "getAnotherModel",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "schema": {
-              "$ref": "http://swagger.io/schemas.json#/Models"
-            }
-          }
-        }
-      }
-    },
-    "/model": {
-      "get": {
-        "tags": [
-          "basic"
-        ],
-        "summary": "Get Model",
-        "description": "",
-        "operationId": "getModel",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "schema": {
-              "$ref": "#/definitions/ModelContainingModelWithReference"
-            }
-          }
-        }
-      }
-    },
-    "/some": {
-      "get": {
-        "tags": [
-          "basic"
-        ],
-        "summary": "Get Some",
-        "description": "",
-        "operationId": "getSome",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "schema": {
-              "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
-            }
-          }
-        }
-      }
-    },
-    "/test": {
-      "get": {
-        "tags": [
-          "basic"
-        ],
-        "operationId": "getTest",
-        "parameters": [],
-        "responses": {
-          "500": {
-            "description": "Error",
-            "schema": {
-              "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
-            }
-          }
-        }
-      }
-    },
-    "/testSome": {
-      "get": {
-        "tags": [
-          "basic"
-        ],
-        "summary": "Get Some",
-        "description": "",
-        "operationId": "getTestSome",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "schema": {
-              "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
-            }
-          },
-          "500": {
-            "description": "Error",
-            "schema": {
-              "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
-            }
-          }
-        }
-      }
     }
-  },
-  "definitions": {
-    "ModelWithReference": {
+    }
+    }
+    },
+      "/model": {
+      "get": {
+      "tags": ["basic"],
+      "summary": "Get Model",
+      "description": "",
+      "operationId": "getModel",
+      "parameters": [],
+      "responses": {
+      "200": {
+      "description": "successful operation",
+      "schema": {
+      "$ref": "#/definitions/ModelContainingModelWithReference"
+    }
+    }
+    }
+    }
+    },
+      "/some": {
+      "get": {
+      "tags": ["basic"],
+      "summary": "Get Some",
+      "description": "",
+      "operationId": "getSome",
+      "parameters": [],
+      "responses": {
+      "200": {
+      "description": "successful operation",
+      "schema": {
+      "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
+    }
+    }
+    }
+    }
+    },
+      "/test": {
+      "get": {
+      "tags": ["basic"],
+      "operationId": "getTest",
+      "parameters": [],
+      "responses": {
+      "500": {
+      "description": "Error",
+      "schema": {
+      "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
+    }
+    }
+    }
+    }
+    },
+      "/testSome": {
+      "get": {
+      "tags": ["basic"],
+      "summary": "Get Some",
+      "description": "",
+      "operationId": "getTestSome",
+      "parameters": [],
+      "responses": {
+      "200": {
+      "description": "successful operation",
+      "schema": {
+      "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
+    }
+    },
+      "500": {
+      "description": "Error",
+      "schema": {
+      "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
+    }
+    }
+    }
+    }
+    }
+    }, "definitions": {
+      "ModelWithReference": {
       "type": "object",
       "properties": {
-        "description": {
-          "$ref": "http://swagger.io/schemas.json#/Models/Description"
-        }
-      }
+      "nested": {
+      "type": "array",
+      "description": "SubModelWithSelfReference",
+      "items": {
+      "$ref": "#/definitions/SubModelWithSelfReference"
+    }
     },
-    "ModelContainingModelWithReference": {
+      "description": {
+      "$ref": "http://swagger.io/schemas.json#/Models/Description"
+    }
+    }
+    },
+      "ModelContainingModelWithReference": {
       "type": "object",
       "properties": {
-        "model": {
-          "$ref": "http://swagger.io/schemas.json#/Models"
-        },
-        "anotherModel": {
-          "$ref": "http://swagger.io/schemas.json#/Models/AnotherModel"
-        }
-      }
+      "model": {
+      "$ref": "http://swagger.io/schemas.json#/Models"
+    },
+      "anotherModel": {
+      "$ref": "http://swagger.io/schemas.json#/Models/AnotherModel"
     }
-  }
-}""")
+    }
+    },
+      "SubModelWithSelfReference": {
+      "type": "object",
+      "properties": {
+      "references": {
+      "type": "array",
+      "description": "References",
+      "items": {
+      "$ref": "#/definitions/SubModelWithSelfReference"
+    }
+    }
+    }
+    }
+    }}
+"""
+    )
   }
 }

--- a/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
@@ -306,7 +306,7 @@ class SimpleScannerTest extends FlatSpec with Matchers {
     schema.getType() should be("integer")
     schema.getFormat() should be("int32")
 
-    swagger.getDefinitions().keySet().asScala should be(Set("Tag","Array"))
+    swagger.getDefinitions().keySet().asScala should be(Set("Tag"))
 
     def testParam(path: String, name: String, description: String): Model = {
       val param = swagger.getPath(path).getPost().getParameters().get(0).asInstanceOf[BodyParameter]
@@ -362,7 +362,7 @@ class SimpleScannerTest extends FlatSpec with Matchers {
 
   it should "check response models processing" in {
     val swagger = new Reader(new Swagger()).read(classOf[ResourceWithTypedResponses])
-    swagger.getDefinitions.keySet().asScala should be(Set("Map","Tag","List"))
+    swagger.getDefinitions.keySet().asScala should be(Set("Tag"))
     for ((key, path) <- swagger.getPaths.asScala) {
       key.substring(key.lastIndexOf("/") + 1) match {
         case "testPrimitiveResponses" =>

--- a/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
+++ b/modules/swagger-jaxrs/src/test/scala/SimpleScannerTest.scala
@@ -306,7 +306,7 @@ class SimpleScannerTest extends FlatSpec with Matchers {
     schema.getType() should be("integer")
     schema.getFormat() should be("int32")
 
-    swagger.getDefinitions().keySet().asScala should be(Set("Tag"))
+    swagger.getDefinitions().keySet().asScala should be(Set("Tag","Array"))
 
     def testParam(path: String, name: String, description: String): Model = {
       val param = swagger.getPath(path).getPost().getParameters().get(0).asInstanceOf[BodyParameter]
@@ -362,7 +362,7 @@ class SimpleScannerTest extends FlatSpec with Matchers {
 
   it should "check response models processing" in {
     val swagger = new Reader(new Swagger()).read(classOf[ResourceWithTypedResponses])
-    swagger.getDefinitions.keySet().asScala should be(Set("Tag"))
+    swagger.getDefinitions.keySet().asScala should be(Set("Map","Tag","List"))
     for ((key, path) <- swagger.getPaths.asScala) {
       key.substring(key.lastIndexOf("/") + 1) match {
         case "testPrimitiveResponses" =>

--- a/modules/swagger-jaxrs/src/test/scala/models/ModelWithReference.java
+++ b/modules/swagger-jaxrs/src/test/scala/models/ModelWithReference.java
@@ -3,6 +3,8 @@ package models;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.List;
+
 @ApiModel(reference = "http://swagger.io/schemas.json#/Models")
 public class ModelWithReference {
 
@@ -10,4 +12,7 @@ public class ModelWithReference {
     public String getDescription() {
         return "Swagger";
     }
+
+    @ApiModelProperty(value="SubModelWithSelfReference")
+    public List<SubModelWithSelfReference> nested;
 }

--- a/modules/swagger-jaxrs/src/test/scala/models/SubModelWithSelfReference.java
+++ b/modules/swagger-jaxrs/src/test/scala/models/SubModelWithSelfReference.java
@@ -1,0 +1,13 @@
+package models;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.List;
+
+/**
+ * Created by simon00t on 10-6-2015.
+ */
+public class SubModelWithSelfReference {
+    @ApiModelProperty(value="References")
+    public List<SubModelWithSelfReference> references;
+}


### PR DESCRIPTION
Properly resolve a inner model with a self/cyclic reference.

In the following example the implementation was lacking to generate a property reference from Model B to Model B. 

[Model A] -> [Model B] -> [Model B] 

I extented the 'ReferenceTest ' to cover this situation.