### PR TITLE
Fixed #1154: Handling of BigDecimal and BigInteger classed has been improved.

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/AbstractModelConverter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/AbstractModelConverter.java
@@ -13,17 +13,7 @@ import io.swagger.annotations.ApiModelProperty;
 import io.swagger.converter.ModelConverter;
 import io.swagger.converter.ModelConverterContext;
 import io.swagger.models.Model;
-import io.swagger.models.properties.BooleanProperty;
-import io.swagger.models.properties.DateProperty;
-import io.swagger.models.properties.DateTimeProperty;
-import io.swagger.models.properties.DoubleProperty;
-import io.swagger.models.properties.FloatProperty;
-import io.swagger.models.properties.IntegerProperty;
-import io.swagger.models.properties.LongProperty;
-import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
-import io.swagger.models.properties.StringProperty;
-import io.swagger.models.properties.UUIDProperty;
 
 import javax.xml.bind.annotation.XmlElement;
 import java.lang.annotation.Annotation;
@@ -86,38 +76,6 @@ public abstract class AbstractModelConverter implements ModelConverter {
         } else {
             return null;
         }
-    }
-
-    protected Property getPrimitiveProperty(String typeName) {
-        Property property = null;
-        if ("boolean".equalsIgnoreCase(typeName)) {
-            property = new BooleanProperty();
-        } else if ("string".equalsIgnoreCase(typeName)) {
-            property = new StringProperty();
-        } else if ("integer".equalsIgnoreCase(typeName) || "int".toLowerCase().equalsIgnoreCase(typeName)) {
-            property = new IntegerProperty();
-        } else if ("long".equalsIgnoreCase(typeName)) {
-            property = new LongProperty();
-        } else if ("float".equalsIgnoreCase(typeName)) {
-            property = new FloatProperty();
-        } else if ("double".equalsIgnoreCase(typeName)) {
-            property = new DoubleProperty();
-        } else if ("dateTime".equalsIgnoreCase(typeName)) {
-            property = new DateTimeProperty();
-        } else if ("date".equalsIgnoreCase(typeName)) {
-            property = new DateProperty();
-        } else if ("byte".equalsIgnoreCase(typeName)) {
-            property = new StringProperty("byte");
-        } else if ("object".equalsIgnoreCase(typeName)) {
-            property = new ObjectProperty();
-        } else if ("uuid".equalsIgnoreCase(typeName)) {
-            property = new UUIDProperty();
-        } else if ("url".equalsIgnoreCase(typeName)) {
-            property = new StringProperty("url");
-        } else if ("uri".equalsIgnoreCase(typeName)) {
-            property = new StringProperty("uri");
-        }
-        return property;
     }
 
     protected String _description(Annotated ann) {

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/TypeNameResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/TypeNameResolver.java
@@ -1,19 +1,12 @@
 package io.swagger.jackson;
 
 import com.fasterxml.jackson.databind.JavaType;
+
 import io.swagger.annotations.ApiModel;
+import io.swagger.util.PrimitiveType;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.text.WordUtils;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.net.URI;
-import java.net.URL;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
 
 /**
  * Helper class used for converting well-known (property) types into
@@ -22,67 +15,7 @@ import java.util.UUID;
 public class TypeNameResolver {
     public final static TypeNameResolver std = new TypeNameResolver();
 
-    /**
-     * Not quite sure if it should be "dateTime" or "date-time";
-     * spec and code seem to disagree
-     */
-    public final static String TYPE_DATE_TIME = "dateTime";
-
-    /**
-     * Not quite sure if it should be "date" or "Date";
-     * spec and code seem to disagree
-     */
-    public final static String TYPE_DATE = "date";
-
-    protected final static Map<Class<?>, String> JDK_TYPES = jdkTypes();
-
-    /**
-     * We also support handling of a small number of "well-known" types,
-     * specifically for Joda lib.
-     */
-    protected final static Map<String, String> EXTERNAL_TYPES = externalTypes();
-
     protected TypeNameResolver() {
-    }
-
-    private static Map<Class<?>, String> jdkTypes() {
-        Map<Class<?>, String> map = new HashMap<Class<?>, String>();
-        _add(map, "boolean", Boolean.class, Boolean.TYPE);
-        _add(map, "byte", Byte.class, Byte.TYPE);
-        _add(map, "integer", Integer.class, Integer.TYPE,
-                Short.class, Short.TYPE);
-        _add(map, "long", Long.class, Long.TYPE,
-                BigInteger.class);
-        _add(map, "float", Float.class, Float.TYPE);
-        _add(map, "double", Double.class, Double.TYPE,
-                BigDecimal.class);
-        _add(map, "string", String.class,
-                Character.class, Character.TYPE);
-
-        // Date, Calendar types are not exact matches (but sub-types), not added here
-
-        _add(map, "uuid", UUID.class);
-        _add(map, "url", URL.class);
-        _add(map, "uri", URI.class);
-
-        return map;
-    }
-
-    private static Map<String, String> externalTypes() {
-        Map<String, String> map = new HashMap<String, String>();
-        map.put("org.joda.time.DateTime", TYPE_DATE_TIME);
-        map.put("org.joda.time.LocalDate", TYPE_DATE);
-        map.put("org.joda.time.ReadableDateTime", TYPE_DATE_TIME);
-        map.put("javax.xml.datatype.XMLGregorianCalendar", TYPE_DATE_TIME);
-        return map;
-    }
-
-    private static Map<Class<?>, String> _add(Map<Class<?>, String> map, String name,
-                                              Class<?>... types) {
-        for (Class<?> type : types) {
-            map.put(type, name);
-        }
-        return map;
     }
 
     public String nameForType(JavaType type) {
@@ -91,10 +24,6 @@ public class TypeNameResolver {
         }
         final String name = findStdName(type);
         return (name == null) ? nameForClass(type) : name;
-    }
-
-    public boolean isStdType(JavaType type) {
-        return findStdName(type) != null;
     }
 
     protected String nameForClass(JavaType type) {
@@ -112,28 +41,13 @@ public class TypeNameResolver {
         final int count = type.containedTypeCount();
         for (int i = 0; i < count; ++i) {
             final JavaType arg = type.containedType(i);
-            final String argName = findStdName(arg) != null ? nameForClass(arg) : nameForType(arg);
+            final String argName = PrimitiveType.fromType(arg) != null ? nameForClass(arg) : nameForType(arg);
             generic.append(WordUtils.capitalize(argName));
         }
         return generic.toString();
     }
 
     protected String findStdName(JavaType type) {
-        final Class<?> raw = type.getRawClass();
-        String name = JDK_TYPES.get(raw);
-        if (name == null) {
-            name = EXTERNAL_TYPES.get(raw.getName());
-            if (name == null) {
-                // these are implemented by concrete types, so:
-                if (Date.class.isAssignableFrom(raw)) {
-                    return TYPE_DATE_TIME;
-                }
-                if (Calendar.class.isAssignableFrom(raw)) {
-                    return TYPE_DATE_TIME;
-                }
-            }
-            return name;
-        }
-        return name;
+        return PrimitiveType.getCommonName(type);
     }
 }

--- a/modules/swagger-core/src/main/java/io/swagger/util/PrimitiveType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PrimitiveType.java
@@ -1,0 +1,303 @@
+package io.swagger.util;
+
+import io.swagger.models.properties.BaseIntegerProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.DecimalProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.LongProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.UUIDProperty;
+
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * The <code>PrimitiveType</code> enumeration defines a mapping of limited set
+ * of classes into Swagger primitive types.
+ */
+public enum PrimitiveType {
+    /**
+     * Boolean.
+     */
+    BOOLEAN(Boolean.class, BooleanProperty.TYPE) {
+
+        @Override
+        public BooleanProperty createProperty() {
+            return new BooleanProperty();
+        }
+    },
+    /**
+     * String.
+     */
+    STRING(String.class, StringProperty.TYPE) {
+
+        @Override
+        public StringProperty createProperty() {
+            return new StringProperty();
+        }
+    },
+    /**
+     * Byte.
+     */
+    BYTE(Byte.class, "byte") {
+
+        @Override
+        public StringProperty createProperty() {
+            return new StringProperty(StringProperty.Format.BYTE);
+        }
+    },
+    /**
+     * URI string.
+     */
+    URI(java.net.URI.class) {
+
+        @Override
+        public StringProperty createProperty() {
+            return new StringProperty(StringProperty.Format.URI);
+        }
+    },
+    /**
+     * URL string.
+     */
+    URL(java.net.URL.class) {
+
+        @Override
+        public StringProperty createProperty() {
+            return new StringProperty(StringProperty.Format.URL);
+        }
+    },
+    /**
+     * UUID string.
+     */
+    UUID(java.util.UUID.class) {
+
+        @Override
+        public UUIDProperty createProperty() {
+            return new UUIDProperty();
+        }
+    },
+    /**
+     * 32-bit integer.
+     */
+    INT(Integer.class, IntegerProperty.TYPE) {
+
+        @Override
+        public IntegerProperty createProperty() {
+            return new IntegerProperty();
+        }
+    },
+    /**
+     * 64-bit integer.
+     */
+    LONG(Long.class, "long") {
+
+        @Override
+        public LongProperty createProperty() {
+            return new LongProperty();
+        }
+    },
+    /**
+     * 32-bit decimal.
+     */
+    FLOAT(Float.class, "float") {
+
+        @Override
+        public FloatProperty createProperty() {
+            return new FloatProperty();
+        }
+    },
+    /**
+     * 64-bit decimal.
+     */
+    DOUBLE(Double.class, "double") {
+
+        @Override
+        public DoubleProperty createProperty() {
+            return new DoubleProperty();
+        }
+    },
+    /**
+     * Generic integer number without specific format.
+     */
+    INTEGER(java.math.BigInteger.class) {
+
+        @Override
+        public BaseIntegerProperty createProperty() {
+            return new BaseIntegerProperty();
+        }
+    },
+    /**
+     * Generic decimal number without specific format.
+     */
+    DECIMAL(java.math.BigDecimal.class) {
+
+        @Override
+        public DecimalProperty createProperty() {
+            return new DecimalProperty();
+        }
+    },
+    /**
+     * Date.
+     */
+    DATE(DateStub.class, "date") {
+
+        @Override
+        public DateProperty createProperty() {
+            return new DateProperty();
+        }
+    },
+    /**
+     * Date and time.
+     */
+    DATE_TIME(java.util.Date.class, "dateTime") {
+
+        @Override
+        public DateTimeProperty createProperty() {
+            return new DateTimeProperty();
+        }
+    },
+    /**
+     * Generic object.
+     */
+    OBJECT(Object.class) {
+
+        @Override
+        public ObjectProperty createProperty() {
+            return new ObjectProperty();
+        }
+    };
+
+    private static final Map<Class<?>, PrimitiveType> KEY_CLASSES;
+    private static final Map<Class<?>, PrimitiveType> BASE_CLASSES;
+    /**
+     * Adds support of a small number of "well-known" types, specifically for
+     * Joda lib.
+     */
+    private static final Map<String, PrimitiveType> EXTERNAL_CLASSES;
+    /**
+     * Alternative names for primitive types that have to be supported for
+     * backward compatibility.
+     */
+    private static final Map<String, PrimitiveType> NAMES;
+    private final Class<?> keyClass;
+    private final String commonName;
+
+    static {
+        final Map<Class<?>, PrimitiveType> keyClasses = new HashMap<Class<?>, PrimitiveType>();
+        addKeys(keyClasses, BOOLEAN, Boolean.class, Boolean.TYPE);
+        addKeys(keyClasses, STRING, String.class, Character.class, Character.TYPE);
+        addKeys(keyClasses, BYTE, Byte.class, Byte.TYPE);
+        addKeys(keyClasses, URL, java.net.URL.class);
+        addKeys(keyClasses, URI, java.net.URI.class);
+        addKeys(keyClasses, UUID, java.util.UUID.class);
+        addKeys(keyClasses, INT, Integer.class, Integer.TYPE, Short.class, Short.TYPE);
+        addKeys(keyClasses, LONG, Long.class, Long.TYPE);
+        addKeys(keyClasses, FLOAT, Float.class, Float.TYPE);
+        addKeys(keyClasses, DOUBLE, Double.class, Double.TYPE);
+        addKeys(keyClasses, INTEGER, java.math.BigInteger.class);
+        addKeys(keyClasses, DECIMAL, java.math.BigDecimal.class);
+        addKeys(keyClasses, DATE, DateStub.class);
+        addKeys(keyClasses, DATE_TIME, java.util.Date.class);
+        addKeys(keyClasses, OBJECT, Object.class);
+        KEY_CLASSES = Collections.unmodifiableMap(keyClasses);
+
+        final Map<Class<?>, PrimitiveType> baseClasses = new HashMap<Class<?>, PrimitiveType>();
+        addKeys(baseClasses, DATE_TIME, java.util.Date.class, java.util.Calendar.class);
+        BASE_CLASSES = Collections.unmodifiableMap(baseClasses);
+
+        final Map<String, PrimitiveType> externalClasses = new HashMap<String, PrimitiveType>();
+        addKeys(externalClasses, DATE, "org.joda.time.LocalDate");
+        addKeys(externalClasses, DATE_TIME, "org.joda.time.DateTime", "org.joda.time.ReadableDateTime",
+                "javax.xml.datatype.XMLGregorianCalendar");
+        EXTERNAL_CLASSES = Collections.unmodifiableMap(externalClasses);
+
+        final Map<String, PrimitiveType> names = new TreeMap<String, PrimitiveType>(String.CASE_INSENSITIVE_ORDER);
+        for (PrimitiveType item : values()) {
+            final String name = item.getCommonName();
+            if (name != null) {
+                addKeys(names, item, name);
+            }
+        }
+        addKeys(names, INT, "int");
+        addKeys(names, OBJECT, ObjectProperty.TYPE);
+        NAMES = Collections.unmodifiableMap(names);
+    }
+
+    private PrimitiveType(Class<?> keyClass) {
+        this(keyClass, null);
+    }
+
+    private PrimitiveType(Class<?> keyClass, String commonName) {
+        this.keyClass = keyClass;
+        this.commonName = commonName;
+    }
+
+    public static PrimitiveType fromType(Type type) {
+        final Class<?> raw = TypeFactory.defaultInstance().constructType(type).getRawClass();
+        final PrimitiveType key = KEY_CLASSES.get(raw);
+        if (key != null) {
+            return key;
+        }
+        final PrimitiveType external = EXTERNAL_CLASSES.get(raw.getName());
+        if (external != null) {
+            return external;
+        }
+        for (Map.Entry<Class<?>, PrimitiveType> entry : BASE_CLASSES.entrySet()) {
+            if (entry.getKey().isAssignableFrom(raw)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    public static PrimitiveType fromName(String name) {
+        return name == null ? null : NAMES.get(name);
+    }
+
+    public static Property createProperty(Type type) {
+        final PrimitiveType item = fromType(type);
+        return item == null ? null : item.createProperty();
+    }
+
+    public static Property createProperty(String name) {
+        final PrimitiveType item = fromName(name);
+        return item == null ? null : item.createProperty();
+    }
+
+    public static String getCommonName(Type type) {
+        final PrimitiveType item = fromType(type);
+        return item == null ? null : item.getCommonName();
+    }
+
+    public Class<?> getKeyClass() {
+        return keyClass;
+    }
+
+    public String getCommonName() {
+        return commonName;
+    }
+
+    public abstract Property createProperty();
+
+    private static <K> void addKeys(Map<K, PrimitiveType> map, PrimitiveType type, K... keys) {
+        for (K key : keys) {
+            map.put(key, type);
+        }
+    }
+
+    private static class DateStub {
+        private DateStub() {
+        }
+    }
+}

--- a/modules/swagger-core/src/test/scala/models/ModelWithNumbers.java
+++ b/modules/swagger-core/src/test/scala/models/ModelWithNumbers.java
@@ -1,0 +1,19 @@
+package models;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class ModelWithNumbers {
+    public short shortPrimitive;
+    public Short shortObject;
+    public int intPrimitive;
+    public Integer intObject;
+    public long longPrimitive;
+    public Long longObject;
+    public float floatPrimitive;
+    public Float floatObject;
+    public double doublePrimitive;
+    public Double doubleObject;
+    public BigInteger bigInteger;
+    public BigDecimal bigDecimal;
+}

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/BaseIntegerProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/BaseIntegerProperty.java
@@ -1,0 +1,22 @@
+package io.swagger.models.properties;
+
+/**
+ * The <code>BaseIntegerProperty</code> class defines property for integers
+ * without specific format.
+ */
+public class BaseIntegerProperty extends AbstractNumericProperty {
+    public static final String TYPE = "integer";
+
+    public BaseIntegerProperty() {
+        this(null);
+    }
+
+    public BaseIntegerProperty(String format) {
+        super.type = TYPE;
+        super.format = format;
+    }
+
+    public static boolean isType(String type, String format) {
+        return TYPE.equals(type) && format == null;
+    }
+}

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/BooleanProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/BooleanProperty.java
@@ -3,18 +3,15 @@ package io.swagger.models.properties;
 import io.swagger.models.Xml;
 
 public class BooleanProperty extends AbstractProperty implements Property {
+    public static final String TYPE = "boolean";
     protected Boolean _default;
 
     public BooleanProperty() {
-        super.type = "boolean";
+        super.type = TYPE;
     }
 
     public static boolean isType(String type, String format) {
-        if ("boolean".equals(type)) {
-            return true;
-        } else {
-            return false;
-        }
+        return TYPE.equals(type);
     }
 
     public BooleanProperty xml(Xml xml) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/DecimalProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/DecimalProperty.java
@@ -2,17 +2,20 @@ package io.swagger.models.properties;
 
 import io.swagger.models.Xml;
 
-public class DecimalProperty extends AbstractNumericProperty implements Property {
+public class DecimalProperty extends AbstractNumericProperty {
+    public static final String TYPE = "number";
+
     public DecimalProperty() {
-        super.type = "number";
+        this(null);
+    }
+
+    public DecimalProperty(String format) {
+        super.type = TYPE;
+        super.format = format;
     }
 
     public static boolean isType(String type, String format) {
-        if ("number".equals(type) && format == null) {
-            return true;
-        } else {
-            return false;
-        }
+        return TYPE.equals(type) && format == null;
     }
 
     public DecimalProperty xml(Xml xml) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/DoubleProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/DoubleProperty.java
@@ -2,20 +2,16 @@ package io.swagger.models.properties;
 
 import io.swagger.models.Xml;
 
-public class DoubleProperty extends AbstractNumericProperty implements Property {
+public class DoubleProperty extends DecimalProperty {
+    private static final String FORMAT = "double";
     protected Double _default;
 
     public DoubleProperty() {
-        super.type = "number";
-        super.format = "double";
+        super(FORMAT);
     }
 
     public static boolean isType(String type, String format) {
-        if ("number".equals(type) && "double".equals(format)) {
-            return true;
-        } else {
-            return false;
-        }
+        return TYPE.equals(type) && FORMAT.equals(format);
     }
 
     public DoubleProperty xml(Xml xml) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/FloatProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/FloatProperty.java
@@ -2,20 +2,17 @@ package io.swagger.models.properties;
 
 import io.swagger.models.Xml;
 
-public class FloatProperty extends AbstractNumericProperty implements Property {
+public class FloatProperty extends DecimalProperty {
+    private static final String FORMAT = "float";
+
     protected Float _default;
 
     public FloatProperty() {
-        super.type = "number";
-        super.format = "float";
+        super(FORMAT);
     }
 
     public static boolean isType(String type, String format) {
-        if ("number".equals(type) && "float".equals(format)) {
-            return true;
-        } else {
-            return false;
-        }
+        return TYPE.equals(type) && FORMAT.equals(format);
     }
 
     public FloatProperty xml(Xml xml) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/IntegerProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/IntegerProperty.java
@@ -2,21 +2,16 @@ package io.swagger.models.properties;
 
 import io.swagger.models.Xml;
 
-public class IntegerProperty extends AbstractNumericProperty implements Property {
-    public static final String TYPE = "integer";
+public class IntegerProperty extends BaseIntegerProperty {
+    private static final String FORMAT = "int32";
     protected Integer _default;
 
     public IntegerProperty() {
-        super.type = TYPE;
-        super.format = "int32";
+        super(FORMAT);
     }
 
     public static boolean isType(String type, String format) {
-        if (TYPE.equals(type) && "int32".equals(format)) {
-            return true;
-        } else {
-            return false;
-        }
+        return TYPE.equals(type) && FORMAT.equals(format);
     }
 
     public IntegerProperty xml(Xml xml) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/LongProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/LongProperty.java
@@ -2,20 +2,16 @@ package io.swagger.models.properties;
 
 import io.swagger.models.Xml;
 
-public class LongProperty extends AbstractNumericProperty implements Property {
+public class LongProperty extends BaseIntegerProperty {
+    private static final String FORMAT = "int64";
     protected Long _default;
 
     public LongProperty() {
-        super.type = "integer";
-        super.format = "int64";
+        super(FORMAT);
     }
 
     public static boolean isType(String type, String format) {
-        if ("integer".equals(type) && "int64".equals(format)) {
-            return true;
-        } else {
-            return false;
-        }
+        return TYPE.equals(type) && FORMAT.equals(format);
     }
 
     public LongProperty xml(Xml xml) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -184,17 +184,10 @@ public class PropertyBuilder {
                 return new DateTimeProperty();
             }
         },
-        INTEGER(IntegerProperty.class) {
+        INT(IntegerProperty.class) {
             @Override
             protected boolean isType(String type, String format) {
-                if (IntegerProperty.isType(type, format)) {
-                    return true;
-                }
-                if (IntegerProperty.TYPE.equals(type) && format == null) {
-                    LOGGER.debug("no format specified for integer type, falling back to int32");
-                    return true;
-                }
-                return false;
+                return IntegerProperty.isType(type, format);
             }
 
             @Override
@@ -361,6 +354,27 @@ public class PropertyBuilder {
                     return model;
                 }
                 return null;
+            }
+        },
+        INTEGER(BaseIntegerProperty.class) {
+            @Override
+            protected boolean isType(String type, String format) {
+                return BaseIntegerProperty.isType(type, format);
+            }
+
+            @Override
+            protected BaseIntegerProperty create() {
+                return new BaseIntegerProperty();
+            }
+
+            @Override
+            public Property merge(Property property, Map<PropertyId, Object> args) {
+                super.merge(property, args);
+                if (property instanceof BaseIntegerProperty) {
+                    final BaseIntegerProperty resolved = (BaseIntegerProperty) property;
+                    mergeNumeric(resolved, args);
+                }
+                return property;
             }
         },
         DECIMAL(DecimalProperty.class) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
@@ -6,28 +6,51 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class StringProperty extends AbstractProperty implements Property {
+    public static final String TYPE = "string";
     protected List<String> _enum;
     protected Integer minLength = null, maxLength = null;
     protected String pattern = null;
     protected String _default;
 
+    public enum Format {
+        BYTE("byte"),
+        URI("uri"),
+        URL("url");
+
+        private final String name;
+
+        private Format(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public static Format fromName(String name) {
+            for (Format item : values()) {
+                if (item.getName().equals(name)) {
+                    return item;
+                }
+            }
+            return null;
+        }
+    }
     public StringProperty() {
-        this(null);
+        this((String) null);
+    }
+
+    public StringProperty(Format format) {
+        this(format.getName());
     }
 
     public StringProperty(String format) {
-        super.type = "string";
+        super.type = TYPE;
         super.format = format;
     }
 
-    //TODO: implement additional formats
     public static boolean isType(String type, String format) {
-        boolean formatMatchStringType = "uri".equals(format) || "byte".equals(format) || "url".equals(format);
-        if ("string".equals(type) && (format == null || formatMatchStringType)) {
-            return true;
-        } else {
-            return false;
-        }
+        return TYPE.equals(type) && (format == null || Format.fromName(format) != null);
     }
 
     public StringProperty xml(Xml xml) {


### PR DESCRIPTION
Fixed #1154: Handling of BigDecimal and BigInteger classed has been improved.
Mapping of a small set of "well-known" classes into Swagger properties is implemented via hard-coded string identifiers of supported types. These string identifiers are defined in two classes: [TypeNameResolver](https://github.com/swagger-api/swagger-core/blob/cfd8eda836da8bd49b117259099d914b6ad4b19b/modules/swagger-core/src/main/java/io/swagger/jackson/TypeNameResolver.java#L48-78) and [AbstractModelConverter](https://github.com/swagger-api/swagger-core/blob/cfd8eda836da8bd49b117259099d914b6ad4b19b/modules/swagger-core/src/main/java/io/swagger/jackson/AbstractModelConverter.java#L91-121). This approach has two main drawbacks:
1. String identifiers have to be synchronized between two classes;
2. String identifiers are visible via `@ApiModelProperty.dataType()` and `@ApiImplicitParam.dataType()` annotations, so some internal type identifiers like `uri`, `url` and `uuid` are published indirectly as standard primitive types.
To overcome mentioned drawbacks and fix handling of BigDecimal and BigInteger types I added the `io.swagger.util.PrimitiveType` enumeration.