### PR TITLE
Fix Java 8 Javadoc 'error: self-closing element not allowed'

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/ReflectionUtils.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/ReflectionUtils.java
@@ -101,7 +101,7 @@ public class ReflectionUtils {
 
     /**
      * Searches for constructor suitable for resource instantiation.
-     * <p/>
+     * <p>
      * If more constructors exists the one with the most injectable parameters will be selected.
      *
      * @param cls is the class where to search


### PR DESCRIPTION
Replace `&lt;p/&gt;` with `&lt;p&gt`; so that `mvn javadoc:javadoc` or `mvn install` runs cleanly with JDK 1.8