### PR TITLE
Fixes #1187: FormDataBodyPart is set as ignored during generating the Swagger

### DIFF
--- a/modules/swagger-jersey-jaxrs/pom.xml
+++ b/modules/swagger-jersey-jaxrs/pom.xml
@@ -101,5 +101,10 @@
             <version>${jersey-version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/swagger-jersey-jaxrs/src/main/java/io/swagger/jersey/SwaggerJerseyJaxrs.java
+++ b/modules/swagger-jersey-jaxrs/src/main/java/io/swagger/jersey/SwaggerJerseyJaxrs.java
@@ -11,6 +11,7 @@ import io.swagger.models.properties.Property;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -48,6 +49,11 @@ public class SwaggerJerseyJaxrs extends AbstractSwaggerExtension {
 
     @Override
     protected boolean shouldIgnoreClass(Class<?> cls) {
-        return com.sun.jersey.core.header.FormDataContentDisposition.class.isAssignableFrom(cls);
+        for (Class<?> item : Arrays.asList(com.sun.jersey.core.header.FormDataContentDisposition.class, com.sun.jersey.multipart.FormDataBodyPart.class)) {
+            if (item.isAssignableFrom(cls)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/modules/swagger-jersey-jaxrs/src/test/java/io/swagger/FormDataBodyPartTest.java
+++ b/modules/swagger-jersey-jaxrs/src/test/java/io/swagger/FormDataBodyPartTest.java
@@ -1,0 +1,25 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+
+import io.swagger.jaxrs.Reader;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.resources.ResourceWithFormData;
+
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+public class FormDataBodyPartTest {
+
+    @Test(description = "FormDataBodyPart should be ignored when generating the Swagger document")
+    public void testFormDataBodyPart(){
+        final Swagger swagger = new Reader(new Swagger()).read(ResourceWithFormData.class);
+        final List<Parameter> parameters = swagger.getPath("/test/document/{documentName}.json").getPost().getParameters();
+        assertEquals(parameters.size(), 3);
+        assertEquals(parameters.get(0).getName(), "documentName");
+        assertEquals(parameters.get(1).getName(), "input");
+        assertEquals(parameters.get(2).getName(), "id");
+    }
+}

--- a/modules/swagger-jersey-jaxrs/src/test/java/io/swagger/resources/ResourceWithFormData.java
+++ b/modules/swagger-jersey-jaxrs/src/test/java/io/swagger/resources/ResourceWithFormData.java
@@ -1,0 +1,30 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+import com.sun.jersey.core.header.FormDataContentDisposition;
+import com.sun.jersey.multipart.FormDataBodyPart;
+import com.sun.jersey.multipart.FormDataParam;
+
+import java.io.InputStream;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@Path("test")
+@Api(value = "test", description = "test routes", produces = "application/json")
+public class ResourceWithFormData {
+
+    @POST
+    @Path("/document/{documentName}.json")
+    @ApiOperation(value = "uploadAttachAndParseUserDocument", notes = "Uploads, parses, and attaches the document to the user's job application.", position = 509)
+    public String uploadAttachAndParseUserDocument(@PathParam("documentName") final String documentName,
+                                                   @FormDataParam("document") final FormDataContentDisposition detail,
+                                                   @FormDataParam("document2") final FormDataBodyPart bodyPart,
+                                                   @FormDataParam("input") final InputStream input,
+                                                   @FormDataParam("id") final Integer id) throws Exception {
+        return "";
+    }
+}


### PR DESCRIPTION
Fixes #1187: FormDataBodyPart is set as ignored during generating the Swagger