### PR TITLE
Fixes swagger-api/swagger-codegen#980 : Allowing inheritance without additonal properties

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/ModelDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ModelDeserializer.java
@@ -33,19 +33,20 @@ public class ModelDeserializer extends JsonDeserializer<Model> {
             List<Model> allComponents = model.getAllOf();
             if (allComponents.size() >= 1) {
                 model.setParent(allComponents.get(0));
-                model.setChild(new ModelImpl());
-            }
-            if (allComponents.size() >= 2) {
-            	model.setChild(allComponents.get(allComponents.size() - 1));
-                List<RefModel> interfaces = new ArrayList<RefModel>();
-                int size = allComponents.size();
-                for (Model m : allComponents.subList(1, size - 1)) {
-                    if (m instanceof RefModel) {
-                        RefModel ref = (RefModel) m;
-                        interfaces.add(ref);
-                    }
-                }
-                model.setInterfaces(interfaces);
+                if (allComponents.size() >= 2) {
+	            	model.setChild(allComponents.get(allComponents.size() - 1));
+	                List<RefModel> interfaces = new ArrayList<RefModel>();
+	                int size = allComponents.size();
+	                for (Model m : allComponents.subList(1, size - 1)) {
+	                    if (m instanceof RefModel) {
+	                        RefModel ref = (RefModel) m;
+	                        interfaces.add(ref);
+	                    }
+	                }
+	                model.setInterfaces(interfaces);
+	            } else {
+	            	model.setChild(new ModelImpl());
+	            }
             }
             return model;
         } else {

--- a/modules/swagger-core/src/main/java/io/swagger/util/ModelDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ModelDeserializer.java
@@ -31,11 +31,12 @@ public class ModelDeserializer extends JsonDeserializer<Model> {
             // we only support one parent, no multiple inheritance or composition
             model = Json.mapper().convertValue(node, ComposedModel.class);
             List<Model> allComponents = model.getAllOf();
-            if (allComponents.size() >= 2) {
+            if (allComponents.size() >= 1) {
                 model.setParent(allComponents.get(0));
-                model.setChild(allComponents.get(allComponents.size() - 1));
+                model.setChild(new ModelImpl());
             }
             if (allComponents.size() >= 2) {
+            	model.setChild(allComponents.get(allComponents.size() - 1));
                 List<RefModel> interfaces = new ArrayList<RefModel>();
                 int size = allComponents.size();
                 for (Model m : allComponents.subList(1, size - 1)) {


### PR DESCRIPTION
Fixes swagger-api/swagger-codegen#980

In swagger-codegen, a model which inherit from an other without defining its own properties will result in a NullPointerException. The error is caused by the ModelDeserializer which create a CompoundModel without any parent.
This fix would allow such a case.