### PR TITLE
upgrade jackson version

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -148,6 +148,12 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io-version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <!-- TODO increase coverage -->

--- a/modules/swagger-core/src/test/java/io/swagger/util/YamlTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/YamlTest.java
@@ -1,0 +1,31 @@
+package io.swagger.util;
+
+import io.swagger.models.*;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.RefProperty;
+import org.apache.commons.io.IOUtils;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class YamlTest {
+
+    @Test
+    public void testSerializeYaml() throws Exception {
+        Swagger swagger = new Swagger();
+        swagger.addConsumes("application/json");
+        swagger.addProduces("application/json");
+        swagger.path("/health", new Path().get(new Operation().response(200, new Response().schema(new RefProperty("health")))));
+        swagger.addDefinition("health", new ModelImpl().property("isHealthy", new BooleanProperty()));
+
+        final String actual = Yaml.pretty().writeValueAsString(swagger);
+
+        final InputStream stream = YamlTest.class.getResourceAsStream("/expectedSerializedYaml.yaml");
+        final String expected = IOUtils.toString(stream);
+
+        assertEquals(actual, expected);
+    }
+}

--- a/modules/swagger-core/src/test/resources/expectedSerializedYaml.yaml
+++ b/modules/swagger-core/src/test/resources/expectedSerializedYaml.yaml
@@ -1,0 +1,19 @@
+---
+swagger: "2.0"
+consumes:
+- "application/json"
+produces:
+- "application/json"
+paths:
+  /health:
+    get:
+      parameters: []
+      responses:
+        200:
+          schema:
+            $ref: "#/definitions/health"
+definitions:
+  health:
+    properties:
+      isHealthy:
+        type: "boolean"

--- a/pom.xml
+++ b/pom.xml
@@ -539,7 +539,7 @@
         <jersey-version>1.13</jersey-version>
         <jersey2-version>2.1</jersey2-version>
         <jackson-version>2.4.5</jackson-version>
-        <jackson-guava-version>2.4.2</jackson-guava-version>
+        <jackson-guava-version>2.4.5</jackson-guava-version>
         <logback-version>1.0.1</logback-version>
 
         <junit-version>4.8.2</junit-version>

--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@
         <servlet-api-version>2.5</servlet-api-version>
         <jersey-version>1.13</jersey-version>
         <jersey2-version>2.1</jersey2-version>
-        <jackson-version>2.4.2</jackson-version>
+        <jackson-version>2.4.5</jackson-version>
         <jackson-guava-version>2.4.2</jackson-guava-version>
         <logback-version>1.0.1</logback-version>
 
@@ -547,6 +547,7 @@
         <surefire-version>2.18.1</surefire-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <commons-lang-version>3.2.1</commons-lang-version>
+        <commons-io-version>2.4</commons-io-version>
         <slf4j-version>1.6.3</slf4j-version>
         <scala-test-version>2.1.3</scala-test-version>
         <jetty-version>8.1.11.v20130520</jetty-version>


### PR DESCRIPTION
version 2.4.2 of jackson-dataformat-yaml has a bug that prevents
successful serialization of an object to yaml (i.e. when you try and serialize an object to YAML it actually gets serialized as JSON).

I upgraded all of swagger core's Jackson libraries to 2.4.5 to pull in the fixed version. 

I also added a unit test that tests YAML is getting serialized correctly.