### PR TITLE
Fix IndexOutOfBoundsException in ReflectionUtils

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/ReflectionUtils.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/ReflectionUtils.java
@@ -83,7 +83,11 @@ public class ReflectionUtils {
         Type[] gpTypes = methodToFind.getGenericParameterTypes();
         methodLoop:
         for (Method method : cls.getMethods()) {
-            if (!method.getName().equals(methodToSearch) || !method.getReturnType().isAssignableFrom(methodToFind.getReturnType())) {
+            if (
+            	!method.getName().equals(methodToSearch) || 
+            	!method.getReturnType().isAssignableFrom(methodToFind.getReturnType()) ||
+            	method.getParameterTypes().length != pTypes.length
+            	) {
                 continue;
             }
             Class<?>[] pt = method.getParameterTypes();


### PR DESCRIPTION
When looking for overridden methods, if the superclass or interface that is being used has overloaded methods with the same name, an IndexOutOfBoundsException will be generated (on line 93 in old code), because the code  is not checking for the array lengths and using the length of the methodToFind.getParameterTypes to iterate arrays of different length.