### PR TITLE
Allow VendorExtensions to process @Context params

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/ParameterProcessor.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/ParameterProcessor.java
@@ -35,7 +35,7 @@ public class ParameterProcessor {
 
     public static Parameter applyAnnotations(Swagger swagger, Parameter parameter, Type type, List<Annotation> annotations) {
         final AnnotationsHelper helper = new AnnotationsHelper(annotations);
-        if (helper.isContext()) {
+        if (helper.isContext() && parameter.getVendorExtensions().isEmpty()) {
             return null;
         }
         final ParamWrapper<?> param = helper.getApiParam();


### PR DESCRIPTION
Currently, parameters that have @Context annotation are ignored by the Reader. This is fine for automatically processed parameters, but with Vendor Extensions, it would be nice to be able to extend the model with additional parameter information for these parameters.