### PR TITLE
'format' handling has been fixed.

### DIFF
--- a/modules/swagger-models/pom.xml
+++ b/modules/swagger-models/pom.xml
@@ -72,6 +72,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
     </dependencies>
     <properties>
         <!-- TODO increase coverage -->

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -4,10 +4,12 @@ import io.swagger.models.ArrayModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.RefModel;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,10 +29,16 @@ public class PropertyBuilder {
         if (processor == null) {
             return null;
         }
-        if (args == null) {
-            args = Collections.emptyMap();
+        final Map<PropertyId, Object> safeArgs = args == null ? Collections.<PropertyId, Object>emptyMap() : args;
+        final Map<PropertyId, Object> fixedArgs;
+        if (format != null) {
+            fixedArgs = new EnumMap<PropertyId, Object>(PropertyId.class);
+            fixedArgs.putAll(safeArgs);
+            fixedArgs.put(PropertyId.FORMAT, format);
+        } else {
+            fixedArgs = safeArgs;
         }
-        return processor.build(args);
+        return processor.build(fixedArgs);
     }
 
     /**
@@ -678,6 +686,9 @@ public class PropertyBuilder {
         public Property merge(Property property, Map<PropertyId, Object> args) {
             if (property instanceof AbstractProperty) {
                 final AbstractProperty resolved = (AbstractProperty) property;
+                if (resolved.getFormat() == null) {
+                    resolved.setFormat(PropertyId.FORMAT.<String>findValue(args));
+                }
                 if (args.containsKey(PropertyId.TITLE)) {
                     final String value = PropertyId.TITLE.findValue(args);
                     resolved.setTitle(value);

--- a/modules/swagger-models/src/test/java/io/swagger/models/properties/PropertyBuilderTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/properties/PropertyBuilderTest.java
@@ -1,0 +1,26 @@
+package io.swagger.models.properties;
+
+import io.swagger.models.properties.Property;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.PropertyBuilder;
+
+
+public class PropertyBuilderTest {
+
+    @Test
+    public void testStringFormat() {
+        for (StringProperty.Format format : StringProperty.Format.values()) {
+            final String name = format.getName();
+            final Property property = PropertyBuilder.build(StringProperty.TYPE, name, null);
+            Assert.assertEquals(property.getType(), StringProperty.TYPE);
+            Assert.assertEquals(property.getFormat(), name);
+        }
+        final Property noFormat = PropertyBuilder.build(StringProperty.TYPE, null, null);
+        Assert.assertEquals(noFormat.getType(), StringProperty.TYPE);
+        Assert.assertNull(noFormat.getFormat());
+    }
+}


### PR DESCRIPTION
The [`PropertyBuilder.build(String, String, Map<PropertyId, Object>`)](https://github.com/swagger-api/swagger-core/blob/bbca9a657704d32348852b4c9a658a4923e48d82/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java#L25) call doesn't set format value for string properties. So, when we parse JSON with the following property definition:
```
"someProperty" : {
  "type" : "string",
  "format" : "url"
}
```
we get this output:
```
"someProperty" : {
  "type" : "string"
}
```
Proposed PR fixes this issue.