### PR TITLE
Additional Vendor Extensions upgrades

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -64,6 +64,27 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
         return result.isEmpty() ? null : result;
     }
 
+    //because of the complexity of deserializing properties we must handle vendor extensions by hand
+    private static Map<String, Object> getVendorExtensions(JsonNode node) {
+
+        Map result = new HashMap<String, Object>();
+
+        Iterator<String> fieldNameIter = node.fieldNames();
+        while (fieldNameIter.hasNext()) {
+            String fieldName = fieldNameIter.next();
+
+            if(fieldName.startsWith("x-")) {
+                JsonNode extensionField = node.get(fieldName);
+
+                Object extensionObject = Json.mapper().convertValue(extensionField, Object.class);
+                result.put(fieldName, extensionObject);
+            }
+
+        }
+
+        return result;
+    }
+
     private static JsonNode getDetailNode(JsonNode node, PropertyBuilder.PropertyId type) {
         return node.get(type.getPropertyName());
     }
@@ -169,6 +190,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
         args.put(PropertyBuilder.PropertyId.EXCLUSIVE_MINIMUM, getBoolean(node, PropertyBuilder.PropertyId.EXCLUSIVE_MINIMUM));
         args.put(PropertyBuilder.PropertyId.EXCLUSIVE_MAXIMUM, getBoolean(node, PropertyBuilder.PropertyId.EXCLUSIVE_MAXIMUM));
         args.put(PropertyBuilder.PropertyId.UNIQUE_ITEMS, getBoolean(node, PropertyBuilder.PropertyId.UNIQUE_ITEMS));
+        args.put(PropertyBuilder.PropertyId.VENDOR_EXTENSIONS, getVendorExtensions(node));
 
         Property output = PropertyBuilder.build(type, format, args);
         if (output == null) {

--- a/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
@@ -86,7 +86,7 @@ public class JsonDeserializationTest {
         }
     }
 
-    @Test
+    @Test (description = "should deserialize a property with vendor extensions of different types")
     public void testDeserializePropertyWithVendorExtensions() throws Exception {
 
         Swagger swagger = TestUtils.deserializeJsonFileFromClasspath("specFiles/propertyWithVendorExtensions.json", Swagger.class);

--- a/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
@@ -85,4 +85,42 @@ public class JsonDeserializationTest {
             assertEquals(oauth2.get(1), "world");
         }
     }
+
+    @Test
+    public void testDeserializePropertyWithVendorExtensions() throws Exception {
+
+        Swagger swagger = TestUtils.deserializeJsonFileFromClasspath("specFiles/propertyWithVendorExtensions.json", Swagger.class);
+
+        Map<String, Object> vendorExtensions = swagger.getDefinitions().get("Health").getProperties().get("status").getVendorExtensions();
+
+        assertNotNull(vendorExtensions);
+        assertEquals(6, vendorExtensions.size());
+
+        String xStringValue = (String) vendorExtensions.get("x-string-value");
+        assertNotNull(xStringValue);
+        assertEquals(xStringValue, "Hello World");
+
+        assertTrue(vendorExtensions.containsKey("x-null-value"));
+        assertNull(vendorExtensions.get("x-null-value"));
+
+        Map<String, String> xMapValue = (Map) vendorExtensions.get("x-map-value");
+        assertNotNull(xMapValue);
+        assertEquals(xMapValue.get("hello"), "world");
+        assertEquals(xMapValue.get("foo"), "bar");
+
+        List<String> xListValue = (List) vendorExtensions.get("x-list-value");
+        assertNotNull(xListValue);
+        assertEquals(xListValue.get(0), "Hello");
+        assertEquals(xListValue.get(1), "World");
+
+        Integer xNumberValue = (Integer) vendorExtensions.get("x-number-value");
+        assertNotNull(xNumberValue);
+        assertEquals(xNumberValue.intValue(), 123);
+
+        Boolean xBooleanValue = (Boolean) vendorExtensions.get("x-boolean-value");
+        assertNotNull(xBooleanValue);
+        assertTrue(xBooleanValue);
+
+        assertFalse(vendorExtensions.containsKey("not-an-extension"));
+    }
 }

--- a/modules/swagger-core/src/test/resources/specFiles/propertyWithVendorExtensions.json
+++ b/modules/swagger-core/src/test/resources/specFiles/propertyWithVendorExtensions.json
@@ -1,0 +1,38 @@
+{
+    "swagger": "2.0",
+    "paths": {
+        "/health": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/Health"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Health": {
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "x-string-value": "Hello World",
+                    "x-null-value": null,
+                    "x-map-value": {
+                        "hello": "world",
+                        "foo": "bar"
+                    },
+                    "x-list-value": [
+                        "Hello", "World"
+                    ],
+                    "x-number-value": 123,
+                    "x-boolean-value": true,
+                    "not-an-extension": "foobar"
+                }
+            }
+        }
+    }
+}

--- a/modules/swagger-models/src/main/java/io/swagger/models/Model.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Model.java
@@ -24,4 +24,6 @@ public interface Model {
     void setReference(String reference);
 
     Object clone();
+
+    Map<String, Object> getVendorExtensions();
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/RefModel.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/RefModel.java
@@ -94,6 +94,12 @@ public class RefModel implements Model {
     }
 
     @Override
+    @JsonIgnore
+    public Map<String, Object> getVendorExtensions() {
+        return null;
+    }
+
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractProperty.java
@@ -146,6 +146,10 @@ public abstract class AbstractProperty implements Property {
         }
     }
 
+    public void setVendorExtensionMap(Map<String, Object> vendorExtensionMap) {
+        this.vendorExtensions.putAll(vendorExtensionMap);
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/Property.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/Property.java
@@ -3,6 +3,8 @@ package io.swagger.models.properties;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.models.Xml;
 
+import java.util.Map;
+
 public interface Property {
     Property title(String title);
 
@@ -53,4 +55,6 @@ public interface Property {
 
     @JsonIgnore
     void setAccess(String access);
+
+    Map<String, Object> getVendorExtensions();
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -93,7 +93,8 @@ public class PropertyBuilder {
         UNIQUE_ITEMS("uniqueItems"),
         EXAMPLE("example"),
         TYPE("type"),
-        FORMAT("format");
+        FORMAT("format"),
+        VENDOR_EXTENSIONS("vendorExtensions");
 
         private String propertyName;
 
@@ -711,6 +712,10 @@ public class PropertyBuilder {
                 if (args.containsKey(PropertyId.EXAMPLE)) {
                     final String value = PropertyId.EXAMPLE.findValue(args);
                     resolved.setExample(value);
+                }
+                if(args.containsKey(PropertyId.VENDOR_EXTENSIONS)) {
+                    final Map<String, Object> value = PropertyId.VENDOR_EXTENSIONS.findValue(args);
+                    resolved.setVendorExtensionMap(value);
                 }
             }
             return property;


### PR DESCRIPTION
I forgot to add a vendor extension getter to the Model and Property interfaces. Without these it makes it annoying to write code that deals with vendor extensions because you must first cast to a AbstractModel/AbstractProperty to access the vendor extensions map.

Additionally, I did not account for the complexity of deserializing Properties (i.e. PropertyDeserializer and PropertyBuilder). As such, I had to add some logic to both classes to support deserializing vendor extensions. Please let me know if you know of a cleaner way of supporting this. 

Finally, I added deserialization test for a Property with vendor extensions. 

As always feedback on my code is appreciated.