### PR TITLE
Fixes #1331: StringProperty.equals(Object) has been fixed

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/ArrayProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/ArrayProperty.java
@@ -59,22 +59,18 @@ public class ArrayProperty extends AbstractProperty implements Property {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((items == null) ? 0 : items.hashCode());
-        result = prime * result
-                + ((uniqueItems == null) ? 0 : uniqueItems.hashCode());
+        result = prime * result + ((uniqueItems == null) ? 0 : uniqueItems.hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof ArrayProperty)) {
             return false;
         }
         ArrayProperty other = (ArrayProperty) obj;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/BooleanProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/BooleanProperty.java
@@ -53,20 +53,17 @@ public class BooleanProperty extends AbstractProperty implements Property {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((_default == null) ? 0 : _default.hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof BooleanProperty)) {
             return false;
         }
         BooleanProperty other = (BooleanProperty) obj;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/DoubleProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/DoubleProperty.java
@@ -55,20 +55,17 @@ public class DoubleProperty extends DecimalProperty {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((_default == null) ? 0 : _default.hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof DoubleProperty)) {
             return false;
         }
         DoubleProperty other = (DoubleProperty) obj;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/FloatProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/FloatProperty.java
@@ -56,20 +56,17 @@ public class FloatProperty extends DecimalProperty {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((_default == null) ? 0 : _default.hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof FloatProperty)) {
             return false;
         }
         FloatProperty other = (FloatProperty) obj;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/IntegerProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/IntegerProperty.java
@@ -55,20 +55,17 @@ public class IntegerProperty extends BaseIntegerProperty {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((_default == null) ? 0 : _default.hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof IntegerProperty)) {
             return false;
         }
         IntegerProperty other = (IntegerProperty) obj;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/LongProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/LongProperty.java
@@ -55,20 +55,17 @@ public class LongProperty extends BaseIntegerProperty {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((_default == null) ? 0 : _default.hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof LongProperty)) {
             return false;
         }
         LongProperty other = (LongProperty) obj;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/MapProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/MapProperty.java
@@ -47,20 +47,17 @@ public class MapProperty extends AbstractProperty implements Property {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((property == null) ? 0 : property.hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof MapProperty)) {
             return false;
         }
         MapProperty other = (MapProperty) obj;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
@@ -70,20 +70,17 @@ public class RefProperty extends AbstractProperty implements Property {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((genericRef == null) ? 0 : genericRef.hashCode());
         return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof RefProperty)) {
             return false;
         }
         RefProperty other = (RefProperty) obj;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
@@ -142,7 +142,7 @@ public class StringProperty extends AbstractProperty implements Property {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((_default == null) ? 0 : _default.hashCode());
         result = prime * result + ((_enum == null) ? 0 : _enum.hashCode());
         result = prime * result + ((maxLength == null) ? 0 : maxLength.hashCode());
@@ -153,13 +153,10 @@ public class StringProperty extends AbstractProperty implements Property {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof StringProperty)) {
             return false;
         }
         StringProperty other = (StringProperty) obj;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/UUIDProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/UUIDProperty.java
@@ -83,7 +83,7 @@ public class UUIDProperty extends AbstractProperty implements Property {
     @Override
     public int hashCode() {
         final int prime = 31;
-        int result = 1;
+        int result = super.hashCode();
         result = prime * result + ((_default == null) ? 0 : _default.hashCode());
         result = prime * result + ((_enum == null) ? 0 : _enum.hashCode());
         result = prime * result + ((maxLength == null) ? 0 : maxLength.hashCode());
@@ -94,13 +94,10 @@ public class UUIDProperty extends AbstractProperty implements Property {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
+        if (!super.equals(obj)) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(obj instanceof UUIDProperty)) {
             return false;
         }
         UUIDProperty other = (UUIDProperty) obj;

--- a/modules/swagger-models/src/test/java/io/swagger/ArrayPropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/ArrayPropertyTest.java
@@ -1,0 +1,28 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import io.swagger.models.properties.ArrayProperty;
+
+import org.testng.annotations.Test;
+
+public class ArrayPropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
+    @Test
+    public void testEquals() {
+        final ArrayProperty prop1 = new ArrayProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final ArrayProperty prop2 = new ArrayProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
+    }
+}

--- a/modules/swagger-models/src/test/java/io/swagger/BooleanPropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/BooleanPropertyTest.java
@@ -1,0 +1,28 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import io.swagger.models.properties.BooleanProperty;
+
+import org.testng.annotations.Test;
+
+public class BooleanPropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
+    @Test
+    public void testEquals() {
+        final BooleanProperty prop1 = new BooleanProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final BooleanProperty prop2 = new BooleanProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
+    }
+}

--- a/modules/swagger-models/src/test/java/io/swagger/DoublePropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/DoublePropertyTest.java
@@ -1,0 +1,28 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import io.swagger.models.properties.DoubleProperty;
+
+import org.testng.annotations.Test;
+
+public class DoublePropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
+    @Test
+    public void testEquals() {
+        final DoubleProperty prop1 = new DoubleProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final DoubleProperty prop2 = new DoubleProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
+    }
+}

--- a/modules/swagger-models/src/test/java/io/swagger/FloatPropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/FloatPropertyTest.java
@@ -1,0 +1,28 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import io.swagger.models.properties.FloatProperty;
+
+import org.testng.annotations.Test;
+
+public class FloatPropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
+    @Test
+    public void testEquals() {
+        final FloatProperty prop1 = new FloatProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final FloatProperty prop2 = new FloatProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
+    }
+}

--- a/modules/swagger-models/src/test/java/io/swagger/IntegerPropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/IntegerPropertyTest.java
@@ -1,0 +1,28 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import io.swagger.models.properties.IntegerProperty;
+
+import org.testng.annotations.Test;
+
+public class IntegerPropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
+    @Test
+    public void testEquals() {
+        final IntegerProperty prop1 = new IntegerProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final IntegerProperty prop2 = new IntegerProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
+    }
+}

--- a/modules/swagger-models/src/test/java/io/swagger/LongPropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/LongPropertyTest.java
@@ -1,0 +1,28 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import io.swagger.models.properties.LongProperty;
+
+import org.testng.annotations.Test;
+
+public class LongPropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
+    @Test
+    public void testEquals() {
+        final LongProperty prop1 = new LongProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final LongProperty prop2 = new LongProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
+    }
+}

--- a/modules/swagger-models/src/test/java/io/swagger/MapPropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/MapPropertyTest.java
@@ -1,0 +1,28 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import io.swagger.models.properties.MapProperty;
+
+import org.testng.annotations.Test;
+
+public class MapPropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
+    @Test
+    public void testEquals() {
+        final MapProperty prop1 = new MapProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final MapProperty prop2 = new MapProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
+    }
+}

--- a/modules/swagger-models/src/test/java/io/swagger/RefPropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/RefPropertyTest.java
@@ -1,13 +1,19 @@
 package io.swagger;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.refs.RefFormat;
 
 import org.testng.annotations.Test;
 
 public class RefPropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
     private void assertRefFormat(RefProperty ref, RefFormat expectedFormat) {
         assertEquals(ref.getRefFormat(), expectedFormat);
     }
@@ -20,5 +26,20 @@ public class RefPropertyTest {
         assertRefFormat(new RefProperty("./models/model.json#/thing"), RefFormat.RELATIVE);
         assertRefFormat(new RefProperty("#/definitions/foo"), RefFormat.INTERNAL);
         assertRefFormat(new RefProperty("foo"), RefFormat.INTERNAL);
+    }
+
+    @Test
+    public void testEquals() {
+        final RefProperty prop1 = new RefProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final RefProperty prop2 = new RefProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
     }
 }

--- a/modules/swagger-models/src/test/java/io/swagger/StringPropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/StringPropertyTest.java
@@ -1,0 +1,31 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import io.swagger.models.properties.StringProperty;
+
+import org.testng.annotations.Test;
+
+public class StringPropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
+    @Test
+    public void testEquals() {
+        assertNotEquals(new StringProperty(StringProperty.Format.BYTE), new StringProperty(StringProperty.Format.URL));
+        assertEquals(new StringProperty(StringProperty.Format.BYTE), new StringProperty(StringProperty.Format.BYTE));
+
+        final StringProperty prop1 = new StringProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final StringProperty prop2 = new StringProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
+    }
+}

--- a/modules/swagger-models/src/test/java/io/swagger/UUIDPropertyTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/UUIDPropertyTest.java
@@ -1,0 +1,28 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+import io.swagger.models.properties.UUIDProperty;
+
+import org.testng.annotations.Test;
+
+public class UUIDPropertyTest {
+    private static final String PROP_1 = "prop1";
+    private static final String PROP_2 = "prop2";
+
+    @Test
+    public void testEquals() {
+        final UUIDProperty prop1 = new UUIDProperty();
+        prop1.setName(PROP_1);
+        prop1.setRequired(true);
+
+        final UUIDProperty prop2 = new UUIDProperty();
+        prop2.setName(PROP_2);
+        assertNotEquals(prop1, prop2);
+
+        prop2.setName(PROP_1);
+        prop2.setRequired(true);
+        assertEquals(prop1, prop2);
+    }
+}


### PR DESCRIPTION
Fixes #1331: StringProperty.equals(Object) has been fixed. Also equals() method was fixed for all AbstractProperty's descendants, which overrides it.