### PR TITLE
link to last setup jaxrs page: 1.5.X instead of legacy 1.3.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following methods are available to obtain support for Swagger:
 
 
 ## Get started with Swagger!
-See the guide on [getting started with swagger](https://github.com/swagger-api/swagger-core/wiki/Swagger-Core-JAX-RS-Project-Setup) to get started with adding swagger to your API.
+See the guide on [getting started with swagger](https://github.com/swagger-api/swagger-core/wiki/Swagger-Core-JAX-RS-Project-Setup-1.5.X) to get started with adding swagger to your API.
 
 ## Compatibility
 The Swagger Specification has undergone 3 revisions since initial creation in 2010.  The swagger-core project has the following compatibilities with the swagger specification:


### PR DESCRIPTION
I was disappointed when I finally discover after some time that an up to date but not linked documentation exists to [setup swagger 1.5.x](https://github.com/swagger-api/swagger-core/wiki/Swagger-Core-JAX-RS-Project-Setup-1.5.X).
This pull request only does one thing: update link url to last version of the documentation.

This defect can also be seen on the [getting started > overview page of swagger.io](http://swagger.io/getting-started).