### PR TITLE
Parameters in DefaultReaderConfig

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -247,7 +247,12 @@ public class Reader {
                 }
                 javax.ws.rs.Path methodPath = getAnnotation(method, javax.ws.rs.Path.class);
 
-                String operationPath = getPath(apiPath, methodPath, parentPath);
+                String classLevelPath = apiPath != null ? apiPath.value() : null;
+                if (config.isPathFromDeclaration() && api != null && api.value() != null) {
+                    classLevelPath = api.value();
+                }
+
+                String operationPath = getPath(classLevelPath, methodPath, parentPath);
                 Map<String, String> regexMap = new HashMap<String, String>();
                 operationPath = PathUtils.parsePath(operationPath, regexMap);
                 if (operationPath != null) {
@@ -617,7 +622,7 @@ public class Reader {
         return output;
     }
 
-    String getPath(javax.ws.rs.Path classLevelPath, javax.ws.rs.Path methodLevelPath, String parentPath) {
+    String getPath(String classLevelPath, javax.ws.rs.Path methodLevelPath, String parentPath) {
         if (classLevelPath == null && methodLevelPath == null && StringUtils.isEmpty(parentPath)) {
             return null;
         }
@@ -633,7 +638,7 @@ public class Reader {
             b.append(parentPath);
         }
         if (classLevelPath != null) {
-            b.append(classLevelPath.value());
+            b.append(classLevelPath);
         }
         if (methodLevelPath != null && !"/".equals(methodLevelPath.value())) {
             String methodPath = methodLevelPath.value();

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/DefaultReaderConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/DefaultReaderConfig.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 public class DefaultReaderConfig implements ReaderConfig {
     private boolean scanAllResources;
     private Collection<String> ignoredRoutes = Collections.emptySet();
+    private boolean pathFromDeclaration;
 
     /**
      * Creates default configuration.
@@ -27,6 +28,7 @@ public class DefaultReaderConfig implements ReaderConfig {
         }
         setScanAllResources(src.isScanAllResources());
         setIgnoredRoutes(src.getIgnoredRoutes());
+        setPathFromDeclaration(src.isPathFromDeclaration());
     }
 
     @Override
@@ -46,5 +48,14 @@ public class DefaultReaderConfig implements ReaderConfig {
     public void setIgnoredRoutes(Collection<String> ignoredRoutes) {
         this.ignoredRoutes = ignoredRoutes == null || ignoredRoutes.isEmpty() ? Collections.<String>emptySet()
                 : Collections.unmodifiableCollection(new HashSet<String>(ignoredRoutes));
+    }
+
+    @Override
+    public boolean isPathFromDeclaration() {
+        return pathFromDeclaration;
+    }
+
+    public void setPathFromDeclaration(boolean pathFromDeclaration) {
+        this.pathFromDeclaration = pathFromDeclaration;
     }
 }

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/ReaderConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/ReaderConfig.java
@@ -24,4 +24,12 @@ public interface ReaderConfig {
      * @return collection of paths
      */
     Collection<String> getIgnoredRoutes();
+
+    /**
+     * The 'path' will be scanned from @API declaration instead of @Path
+     * {@link Api} value will be used
+     * @return <code>true</code> use 'path' that is to host the API Declaration of the
+     * resource
+     */
+    boolean isPathFromDeclaration();
 }

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/ReaderConfigUtils.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/ReaderConfigUtils.java
@@ -17,9 +17,12 @@ public class ReaderConfigUtils {
     }
 
     public static void initReaderConfig(ServletConfig config) {
-        if ("true".equals(config.getInitParameter("scan.all.resources")) || config.getInitParameter("ignore.routes") != null) {
+        if ("true".equals(config.getInitParameter("scan.all.resources"))
+                || config.getInitParameter("ignore.routes") != null
+                || "true".equals(config.getInitParameter("path.from.declaration"))) {
             final DefaultReaderConfig rc = new DefaultReaderConfig();
             rc.setScanAllResources("true".equals(config.getInitParameter("scan.all.resources")));
+            rc.setPathFromDeclaration("true".equals(config.getInitParameter("path.from.declaration")));
             final Set<String> ignoredRoutes = new LinkedHashSet<String>();
             for (String item : StringUtils.trimToEmpty(config.getInitParameter("ignore.routes")).split(",")) {
                 final String route = StringUtils.trimToNull(item);

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/ReaderConfigUtils.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/ReaderConfigUtils.java
@@ -17,9 +17,9 @@ public class ReaderConfigUtils {
     }
 
     public static void initReaderConfig(ServletConfig config) {
-        if ("true".equals(config.getInitParameter("scan.all.resources"))) {
+        if ("true".equals(config.getInitParameter("scan.all.resources")) || config.getInitParameter("ignore.routes") != null) {
             final DefaultReaderConfig rc = new DefaultReaderConfig();
-            rc.setScanAllResources(true);
+            rc.setScanAllResources("true".equals(config.getInitParameter("scan.all.resources")));
             final Set<String> ignoredRoutes = new LinkedHashSet<String>();
             for (String item : StringUtils.trimToEmpty(config.getInitParameter("ignore.routes")).split(",")) {
                 final String route = StringUtils.trimToNull(item);


### PR DESCRIPTION
Hi,
We should do improvements:
**ignore.routes should not depend on scan.all.resources parameter**
We want to use this parameter to ignore some routes. However, it depends on scan.all.resources. We should not have this dependency.

**Support new param path.from.declaration**
We wouldn't like to use value in @Path - javax.ws.rs.Path because we have nice URLs with rewrite engine. So we want to use value from @Api - io.swagger.annotations.Api. For flexibility, we should support new parameter to indicate this.