### PR TITLE
 #1361 Making swagger-core and swagger-jaxrs OSGi-enabled

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>swagger-core</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>swagger-core</name>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -37,10 +37,12 @@
                         <Export-Package>
                             io.swagger.converter,
                             io.swagger.core,
+                            io.swagger.core.filter,
                             io.swagger.core.util,
                             io.swagger.reader,
                             io.swagger.config,
-                            io.swagger.models
+                            io.swagger.models,
+                            io.swagger.util
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/modules/swagger-jaxrs/pom.xml
+++ b/modules/swagger-jaxrs/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>swagger-jaxrs</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>swagger-jaxrs</name>
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>
@@ -37,18 +37,21 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>2.4</version>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>${felix-version}</version>
+                <extensions>true</extensions>
                 <configuration>
-                    <archive>
-                        <manifestEntries>
-                            <mode>development</mode>
-                            <url>${project.url}</url>
-                            <implementation-version>${project.version}</implementation-version>
-                            <package>io.swagger</package>
-                        </manifestEntries>
-                    </archive>
+                    <instructions>
+                        <Export-Package>
+                            io.swagger.jaxrs.config,
+                            io.swagger.jaxrs.listing
+                        </Export-Package>
+                        <Import-Package>
+                            javax.ws.rs*;version="[1.1,3)",
+                            *
+                        </Import-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This is a PR for making the above jars into OSGI-bundles.

The next steps are:
- adding an integration test to somewhere (in another test specific component)
- adding a separate artifact that generates its karaf feature definition so that we don't need to install individual depending bundles.

Any suggestion appreciated.

regards, aki