### PR TITLE
Switch to Java 8 compatible HTML markup in JavaDoc 

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/Api.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/Api.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a class as a Swagger resource.
- * <p/>
+ * <p>
  * By default, Swagger-Core will only include and introspect only classes that are annotated
  * with {@code @Api} and will ignore other resources (JAX-RS endpoints, Servlets and
  * so on).
@@ -35,13 +35,13 @@ import java.lang.annotation.Target;
 public @interface Api {
     /**
      * Implicitly sets a tag for the operations, legacy support (read description).
-     * <p/>
+     * <p>
      * In swagger-core 1.3.X, this was used as the 'path' that is to host the API Declaration of the
      * resource. This is no longer relevant in swagger-core 1.5.X.
-     * <p/>
+     * <p>
      * If {@link #tags()} is <i>not</i> used, this value will be used to set the tag for the operations described by this
      * resource. Otherwise, the value will be ignored.
-     * <p/>
+     * <p>
      * The leading / (if exists) will be removed.
      *
      * @return tag name for operations under this resource, unless {@link #tags()} is defined.
@@ -51,7 +51,7 @@ public @interface Api {
     /**
      * A list of tags for API documentation control.
      * Tags can be used for logical grouping of operations by resources or any other qualifier.
-     * <p/>
+     * <p>
      * A non-empty value will override the value provided in {@link #value()}.
      *
      * @return a string array of tag values
@@ -82,11 +82,11 @@ public @interface Api {
 
     /**
      * Corresponds to the `produces` field of the operations under this resource.
-     * <p/>
+     * <p>
      * Takes in comma-separated values of content types.
      * For example, "application/json, application/xml" would suggest the operations
      * generate JSON and XML output.
-     * <p/>
+     * <p>
      * For JAX-RS resources, this would automatically take the value of the {@code @Produces}
      * annotation if such exists. It can also be used to override the {@code @Produces} values
      * for the Swagger documentation.
@@ -97,11 +97,11 @@ public @interface Api {
 
     /**
      * Corresponds to the `consumes` field of the operations under this resource.
-     * <p/>
+     * <p>
      * Takes in comma-separated values of content types.
      * For example, "application/json, application/xml" would suggest the operations
      * accept JSON and XML input.
-     * <p/>
+     * <p>
      * For JAX-RS resources, this would automatically take the value of the {@code @Consumes}
      * annotation if such exists. It can also be used to override the {@code @Consumes} values
      * for the Swagger documentation.
@@ -112,7 +112,7 @@ public @interface Api {
 
     /**
      * Sets specific protocols (schemes) for the operations under this resource.
-     * <p/>
+     * <p>
      * Comma-separated values of the available protocols. Possible values: http, https, ws, wss.
      *
      * @return the protocols supported by the operations under the resource.
@@ -121,7 +121,7 @@ public @interface Api {
 
     /**
      * Corresponds to the `security` field of the Operation Object.
-     * <p/>
+     * <p>
      * Takes in a list of the authorizations (security requirements) for the operations under this resource.
      * This may be overridden by specific operations.
      *

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParam.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParam.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,12 +23,12 @@ import java.lang.annotation.Target;
 
 /**
  * Represents a single parameter in an API Operation.
- * <p/>
+ * <p>
  * While {@link ApiParam} is bound to a JAX-RS parameter,
  * method or field, this allows you to manually define a parameter in a fine-tuned manner.
  * This is the only way to define parameters when using Servlets or other non-JAX-RS
  * environments.
- * <p/>
+ * <p>
  * This annotation must be used as a value of {@link ApiImplicitParams}
  * in order to be parsed.
  *
@@ -39,7 +39,7 @@ import java.lang.annotation.Target;
 public @interface ApiImplicitParam {
     /**
      * Name of the parameter.
-     * <p/>
+     * <p>
      * For proper Swagger functionality, follow these rules when naming your parameters based on {@link #paramType()}:
      * <ol>
      * <li>If {@code paramType} is "path", the name should be the associated section in the path.</li>
@@ -62,7 +62,7 @@ public @interface ApiImplicitParam {
 
     /**
      * Limits the acceptable values for this parameter.
-     * <p/>
+     * <p>
      * There are three ways to describe the allowable values:
      * <ol>
      * <li>To set a list of values, provide a comma-separated list.
@@ -79,14 +79,14 @@ public @interface ApiImplicitParam {
 
     /**
      * Specifies if the parameter is required or not.
-     * <p/>
+     * <p>
      * Path parameters should always be set as required.
      */
     boolean required() default false;
 
     /**
      * Allows for filtering a parameter from the API documentation.
-     * <p/>
+     * <p>
      * See io.swagger.core.filter.SwaggerSpecFilter for further details.
      */
     String access() default "";
@@ -98,14 +98,14 @@ public @interface ApiImplicitParam {
 
     /**
      * The data type of the parameter.
-     * <p/>
+     * <p>
      * This can be the class name or a primitive.
      */
     String dataType() default "";
 
     /**
      * The parameter type of the parameter.
-     * <p/>
+     * <p>
      * Valid values are {@code path}, {@code query}, {@code body}, {@code header} or {@code form}.
      */
     String paramType() default "";

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParams.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParams.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModel.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModel.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * Provides additional information about Swagger models.
- * <p/>
+ * <p>
  * Classes will be introspected automatically as they are used as types in operations,
  * but you may want to manipulate the structure of the models.
  */
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
 public @interface ApiModel {
     /**
      * Provide an alternative name for the model.
-     * <p/>
+     * <p>
      * By default, the class name is used.
      */
     String value() default "";
@@ -51,7 +51,7 @@ public @interface ApiModel {
 
     /**
      * Supports model inheritance and polymorphism.
-     * <p/>
+     * <p>
      * This is the name of the field used as a discriminator. Based on this field,
      * it would be possible to assert which sub type needs to be used.
      */

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModelProperty.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModelProperty.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,7 @@ public @interface ApiModelProperty {
 
     /**
      * Limits the acceptable values for this parameter.
-     * <p/>
+     * <p>
      * There are three ways to describe the allowable values:
      * <ol>
      * <li>To set a list of values, provide a comma-separated list.
@@ -68,7 +68,7 @@ public @interface ApiModelProperty {
 
     /**
      * The data type of the parameter.
-     * <p/>
+     * <p>
      * This can be the class name or a primitive. The value will override the data type as read from the class
      * property.
      */

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiOperation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiOperation.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
 
 /**
  * Describes an operation or typically a HTTP method against a specific path.
- * <p/>
+ * <p>
  * Operations with equivalent paths are grouped in a single Operation Object.
  * A combination of a HTTP method and a path creates a unique operation.
  */
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
 public @interface ApiOperation {
     /**
      * Corresponds to the `summary` field of the operation.
-     * <p/>
+     * <p>
      * Provides a brief description of this operation. Should be 120 characters or less
      * for proper visibility in Swagger-UI.
      */
@@ -40,14 +40,14 @@ public @interface ApiOperation {
 
     /**
      * Corresponds to the 'notes' field of the operation.
-     * <p/>
+     * <p>
      * A verbose description of the operation.
      */
     String notes() default "";
 
     /**
      * A list of tags for API documentation control.
-     * <p/>
+     * <p>
      * Tags can be used for logical grouping of operations by resources or any other qualifier.
      * A non-empty value will override the value received from {@link Api#value()} or {@link Api#tags()}
      * for this operation.
@@ -58,13 +58,13 @@ public @interface ApiOperation {
 
     /**
      * The response type of the operation.
-     * <p/>
+     * <p>
      * In JAX-RS applications, the return type of the method would automatically be used, unless it is
      * {@code javax.ws.rs.core.Response}. In that case, the operation return type would default to `void`
      * as the actual response type cannot be known.
-     * <p/>
+     * <p>
      * Setting this property would override any automatically-derived data type.
-     * <p/>
+     * <p>
      * If the value used is a class representing a primitive ({@code Integer}, {@code Long}, ...)
      * the corresponding primitive type will be used.
      */
@@ -72,7 +72,7 @@ public @interface ApiOperation {
 
     /**
      * Declares a container wrapping the response.
-     * <p/>
+     * <p>
      * Valid values are "List", "Set" or "Map". Any other value will be ignored.
      */
     String responseContainer() default "";
@@ -86,14 +86,14 @@ public @interface ApiOperation {
 
     /**
      * Corresponds to the `method` field as the HTTP method used.
-     * <p/>
+     * <p>
      * If not stated, in JAX-RS applications, the following JAX-RS annotations would be scanned
      * and used: {@code @GET}, {@code @HEAD}, {@code @POST}, {@code @PUT}, {@code @DELETE} and {@code @OPTIONS}.
      * Note that even though not part of the JAX-RS specification, if you create and use the {@code @PATCH} annotation,
      * it will also be parsed and used. If the httpMethod property is set, it will override the JAX-RS annotation.
-     * <p/>
+     * <p>
      * For Servlets, you must specify the HTTP method manually.
-     * <p/>
+     * <p>
      * Acceptable values are "GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS" and "PATCH".
      */
     String httpMethod() default "";
@@ -105,7 +105,7 @@ public @interface ApiOperation {
 
     /**
      * Corresponds to the `operationId` field.
-     * <p/>
+     * <p>
      * The operationId is used by third-party tools to uniquely identify this operation. In Swagger 2.0, this is
      * no longer mandatory and if not provided will remain empty.
      */
@@ -113,11 +113,11 @@ public @interface ApiOperation {
 
     /**
      * Corresponds to the `produces` field of the operation.
-     * <p/>
+     * <p>
      * Takes in comma-separated values of content types.
      * For example, "application/json, application/xml" would suggest this operation
      * generates JSON and XML output.
-     * <p/>
+     * <p>
      * For JAX-RS resources, this would automatically take the value of the {@code @Produces}
      * annotation if such exists. It can also be used to override the {@code @Produces} values
      * for the Swagger documentation.
@@ -126,11 +126,11 @@ public @interface ApiOperation {
 
     /**
      * Corresponds to the `consumes` field of the operation.
-     * <p/>
+     * <p>
      * Takes in comma-separated values of content types.
      * For example, "application/json, application/xml" would suggest this API Resource
      * accepts JSON and XML input.
-     * <p/>
+     * <p>
      * For JAX-RS resources, this would automatically take the value of the {@code @Consumes}
      * annotation if such exists. It can also be used to override the {@code @Consumes} values
      * for the Swagger documentation.
@@ -139,7 +139,7 @@ public @interface ApiOperation {
 
     /**
      * Sets specific protocols (schemes) for this operation.
-     * <p/>
+     * <p>
      * Comma-separated values of the available protocols. Possible values: http, https, ws, wss.
      *
      * @return the protocols supported by the operations under the resource.
@@ -148,7 +148,7 @@ public @interface ApiOperation {
 
     /**
      * Corresponds to the `security` field of the Operation Object.
-     * <p/>
+     * <p>
      * Takes in a list of the authorizations (security requirements) for this operation.
      *
      * @return an array of authorizations required by the server, or a single, empty authorization value if not set.
@@ -170,7 +170,7 @@ public @interface ApiOperation {
 
     /**
      * The HTTP status code of the response.
-     * <p/>
+     * <p>
      * The value should be one of the formal <a target="_blank" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html">HTTP Status Code Definitions</a>.
      */
     int code() default 200;

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiParam.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiParam.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
 
 /**
  * Adds additional meta-data for operation parameters.
- * <p/>
+ * <p>
  * This annotation can be used only in combination of JAX-RS 1.x/2.x annotations.
  */
 @Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
@@ -31,10 +31,10 @@ import java.lang.annotation.Target;
 public @interface ApiParam {
     /**
      * The parameter name.
-     * <p/>
+     * <p>
      * The name of the parameter will be derived from the field/method/parameter name,
      * however you can override it.
-     * <p/>
+     * <p>
      * Path parameters must always be named as the path section they represent.
      */
     String name() default "";
@@ -46,7 +46,7 @@ public @interface ApiParam {
 
     /**
      * Describes the default value for the parameter.
-     * <p/>
+     * <p>
      * If the parameter is annotated with JAX-RS's {@code @DefaultValue}, that value would
      * be used, but can be overridden by setting this property.
      */
@@ -54,7 +54,7 @@ public @interface ApiParam {
 
     /**
      * Limits the acceptable values for this parameter.
-     * <p/>
+     * <p>
      * There are three ways to describe the allowable values:
      * <ol>
      * <li>To set a list of values, provide a comma-separated list.
@@ -71,14 +71,14 @@ public @interface ApiParam {
 
     /**
      * Specifies if the parameter is required or not.
-     * <p/>
+     * <p>
      * Path parameters will always be set as required, whether you set this property or not.
      */
     boolean required() default false;
 
     /**
      * Allows for filtering a parameter from the API documentation.
-     * <p/>
+     * <p>
      * See io.swagger.core.filter.SwaggerSpecFilter for further details.
      */
     String access() default "";

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponse.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponse.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,16 +23,16 @@ import java.lang.annotation.Target;
 
 /**
  * Describes a possible response of an operation.
- * <p/>
+ * <p>
  * This can be used to describe possible success and error codes from your REST API call.
  * You may or may not use this to describe the return type of the operation (normally a
  * successful code), but the successful response should be described as well using the
  * {@link ApiOperation}.
- * <p/>
+ * <p>
  * If your API has uses a different response class for these responses, you can describe them
  * here by associating a response class with a response code.
  * Note, Swagger does not allow multiple response types for a single response code.
- * <p/>
+ * <p>
  * This annotation is not used directly and will not be parsed by Swagger. It should be used
  * within the {@link ApiResponses}.
  *
@@ -44,7 +44,7 @@ import java.lang.annotation.Target;
 public @interface ApiResponse {
     /**
      * The HTTP status code of the response.
-     * <p/>
+     * <p>
      * The value should be one of the formal <a target="_blank" href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html">HTTP Status Code Definitions</a>.
      */
     int code();
@@ -56,7 +56,7 @@ public @interface ApiResponse {
 
     /**
      * Optional response class to describe the payload of the message.
-     * <p/>
+     * <p>
      * Corresponds to the `schema` field of the response message object.
      */
     Class<?> response() default Void.class;
@@ -77,7 +77,7 @@ public @interface ApiResponse {
 
     /**
      * Declares a container wrapping the response.
-     * <p/>
+     * <p>
      * Valid values are "List", "Set" or "Map". Any other value will be ignored.
      */
     String responseContainer() default "";

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponses.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponses.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ import java.lang.annotation.Target;
 
 /**
  * A wrapper to allow a list of multiple {@link ApiResponse} objects.
- * <p/>
+ * <p>
  * If you need to describe a single {@link ApiResponse}, you still
  * must use this annotation and wrap the {@code @ApiResponse} in an array.
  *

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/Authorization.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/Authorization.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,9 +23,9 @@ import java.lang.annotation.Target;
 
 /**
  * Defines an authorization scheme to be used on a resource or an operation.
- * <p/>
+ * <p>
  * The authorization scheme used needs to be declared at the Swagger root level first.
- * <p/>
+ * <p>
  * This annotation is not used directly and will not be parsed by Swagger. It should be used
  * within either {@link Api} or {@link ApiOperation}.
  *
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
 public @interface Authorization {
     /**
      * The name of the authorization scheme to be used on this resource/operation.
-     * <p/>
+     * <p>
      * The name must be defined in the Resource Listing's authorization section,
      */
     String value();

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/AuthorizationScope.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/AuthorizationScope.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,10 +23,10 @@ import java.lang.annotation.Target;
 
 /**
  * Describes an OAuth2 authorization scope.
- * <p/>
+ * <p>
  * Used to define an authorization scope that is used by an operation for
  * a defined authorization scheme.
- * <p/>
+ * <p>
  * This annotation is not used directly and will not be parsed by Swagger. It should be used
  * within the {@link Authorization}.
  *
@@ -39,7 +39,7 @@ import java.lang.annotation.Target;
 public @interface AuthorizationScope {
     /**
      * The scope of the OAuth2 Authorization scheme to be used.
-     * <p/>
+     * <p>
      * The scope should be previously declared in the Swagger Object's securityDefinition section.
      */
     String scope();

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/Contact.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/Contact.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/Extension.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/Extension.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ExtensionProperty.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ExtensionProperty.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ExternalDocs.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ExternalDocs.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/Info.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/Info.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/License.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/License.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ResponseHeader.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ResponseHeader.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,7 +44,7 @@ public @interface ResponseHeader {
 
     /**
      * Declares a container wrapping the response header.
-     * <p/>
+     * <p>
      * Valid values are "List" or "Set". Any other value will be ignored.
      */
     String responseContainer() default "";

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/SwaggerDefinition.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/SwaggerDefinition.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -52,7 +52,7 @@ public @interface SwaggerDefinition {
 
     /**
      * Global level consumes for this swagger definition.
-     * <p/>
+     * <p>
      * These will be added to all api definitions that don't have local overrides - see
      * https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#swagger-object
      *
@@ -62,7 +62,7 @@ public @interface SwaggerDefinition {
 
     /**
      * Global level produces for this swagger definition.
-     * <p/>
+     * <p>
      * These will be added to all api definitions that don't have local overrides - see
      * https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#swagger-object
      *
@@ -72,7 +72,7 @@ public @interface SwaggerDefinition {
 
     /**
      * The transfer protocol of the API.
-     * <p/>
+     * <p>
      * Setting this to Scheme.DEFAULT will result in the result being generated from the hosting container.
      *
      * @return list of supported transfer protocols, keep empty for default
@@ -81,7 +81,7 @@ public @interface SwaggerDefinition {
 
     /**
      * Global tags that can be used to tag individual Apis and ApiOperations.
-     * <p/>
+     * <p>
      * See https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#tagObject
      *
      * @return list of globally defined tags
@@ -92,7 +92,7 @@ public @interface SwaggerDefinition {
 
     /**
      * General metadata for this Swagger definition.
-     * <p/>
+     * <p>
      * See https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#infoObject
      *
      * @return general metadata for this Swagger definition

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/Tag.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/Tag.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/ReaderListener.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/ReaderListener.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/json/JacksonJsonProvider.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/json/JacksonJsonProvider.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2015 SmartBear Software
- * <p/>
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p/>
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
This fixes #1366 by replacing all JavaDoc uses of `<p/>` with `<p>`

[Here's some Oracle documentation indicating the correct usage of `<p>` instead of `<p/>`](http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#format)

After applying this fix, builds using Java 8 can complete successfully