### PR TITLE
multiple swaggers on the same tomcat

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/config/ScannerSingleton.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/config/ScannerSingleton.java
@@ -1,7 +1,9 @@
 package io.swagger.config;
 
-public class ScannerFactory {
-    private static Scanner SCANNER;
+import io.swagger.jaxrs.config.DefaultJaxrsScanner;
+
+public class ScannerSingleton {
+    private static Scanner SCANNER = new DefaultJaxrsScanner();
 
     public static Scanner getScanner() {
         return SCANNER;

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/config/SwaggerConfigMap.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/config/SwaggerConfigMap.java
@@ -1,0 +1,16 @@
+package io.swagger.config;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class SwaggerConfigMap {
+    private static Map<String, SwaggerConfig> map = new HashMap<String, SwaggerConfig>();
+
+    public static SwaggerConfig getConfig(String id) {
+        return SwaggerConfigMap.map.get(id);
+    }
+    
+    public static void storeConfig(String id, SwaggerConfig config) {
+        SwaggerConfigMap.map.put(id, config);
+    }
+}

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
@@ -4,7 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.SwaggerDefinition;
 import io.swagger.config.FilterFactory;
 import io.swagger.config.Scanner;
-import io.swagger.config.ScannerFactory;
+import io.swagger.config.ScannerSingleton;
 import io.swagger.config.SwaggerConfig;
 import io.swagger.core.filter.SwaggerSpecFilter;
 import io.swagger.jaxrs.Reader;
@@ -180,7 +180,7 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
 
             updateInfoFromConfig();
         }
-        ScannerFactory.setScanner(this);
+        ScannerSingleton.setScanner(this);
     }
 
     public Set<Class<?>> classes() {

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/DefaultJaxrsConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/DefaultJaxrsConfig.java
@@ -3,13 +3,19 @@ package io.swagger.jaxrs.config;
 import javax.servlet.ServletConfig;
 import javax.servlet.http.HttpServlet;
 
+import io.swagger.config.SwaggerConfigMap;
+
 public class DefaultJaxrsConfig extends HttpServlet {
     @Override
     public void init(ServletConfig servletConfig) throws javax.servlet.ServletException {
         super.init(servletConfig);
 
-        servletConfig.getServletContext().setAttribute("reader", new WebXMLReader(servletConfig));
-        servletConfig.getServletContext().setAttribute("scanner", new DefaultJaxrsScanner());
+        String swaggerId = servletConfig.getInitParameter("swagger.id");
+        if (swaggerId == null) {
+            swaggerId = "default";
+        }
+
+        SwaggerConfigMap.storeConfig(swaggerId, new WebXMLReader(servletConfig));
         ReaderConfigUtils.initReaderConfig(servletConfig);
     }
 }

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/WebXMLReader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/WebXMLReader.java
@@ -2,7 +2,7 @@ package io.swagger.jaxrs.config;
 
 import io.swagger.config.FilterFactory;
 import io.swagger.config.Scanner;
-import io.swagger.config.ScannerFactory;
+import io.swagger.config.ScannerSingleton;
 import io.swagger.config.SwaggerConfig;
 import io.swagger.core.filter.SwaggerSpecFilter;
 import io.swagger.models.Info;
@@ -18,8 +18,7 @@ public class WebXMLReader implements SwaggerConfig {
     private Logger LOGGER = LoggerFactory.getLogger(WebXMLReader.class);
 
     public WebXMLReader(ServletConfig servletConfig) {
-        Scanner scanner = new DefaultJaxrsScanner();
-        ScannerFactory.setScanner(scanner);
+        Scanner scanner = ScannerSingleton.getScanner();
         apiVersion = servletConfig.getInitParameter("api.version");
         if (apiVersion == null) {
             apiVersion = "Swagger Server";

--- a/modules/swagger-jersey2-jaxrs/src/main/java/io/swagger/jersey/config/JerseyJaxrsConfig.java
+++ b/modules/swagger-jersey2-jaxrs/src/main/java/io/swagger/jersey/config/JerseyJaxrsConfig.java
@@ -1,19 +1,12 @@
 package io.swagger.jersey.config;
 
-import io.swagger.jaxrs.config.DefaultJaxrsScanner;
-import io.swagger.jaxrs.config.ReaderConfigUtils;
-import io.swagger.jaxrs.config.WebXMLReader;
-
 import javax.servlet.ServletConfig;
-import javax.servlet.http.HttpServlet;
 
-public class JerseyJaxrsConfig extends HttpServlet {
+import io.swagger.jaxrs.config.DefaultJaxrsConfig;
+
+public class JerseyJaxrsConfig extends DefaultJaxrsConfig {
     @Override
     public void init(ServletConfig servletConfig) throws javax.servlet.ServletException {
         super.init(servletConfig);
-
-        servletConfig.getServletContext().setAttribute("reader", new WebXMLReader(servletConfig));
-        servletConfig.getServletContext().setAttribute("scanner", new DefaultJaxrsScanner());
-        ReaderConfigUtils.initReaderConfig(servletConfig);
     }
 }

--- a/modules/swagger-mule/src/main/java/io/swagger/mule/ApiListingJSON.java
+++ b/modules/swagger-mule/src/main/java/io/swagger/mule/ApiListingJSON.java
@@ -2,7 +2,7 @@ package io.swagger.mule;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.config.Scanner;
-import io.swagger.config.ScannerFactory;
+import io.swagger.config.ScannerSingleton;
 import io.swagger.config.SwaggerConfig;
 import io.swagger.jaxrs.Reader;
 import io.swagger.jaxrs.listing.SwaggerSerializers;
@@ -34,7 +34,7 @@ public class ApiListingJSON {
     }
 
     protected synchronized void scan(Application app) {
-        Scanner scanner = ScannerFactory.getScanner();
+        Scanner scanner = ScannerSingleton.getScanner();
         LOGGER.debug("using scanner " + scanner);
         if (scanner != null) {
             SwaggerSerializers.setPrettyPrint(scanner.getPrettyPrint());


### PR DESCRIPTION
Swagger has somewhat global presence in tomcat environment. If you want to partition your api, global nature hiders you. This commit aims to alleviate the issue.

Change description:
ScannerFactory does not act in accord with its name since this factory does not produce new instances. The class is used as the holder for Scanner instance. As I understand, there exist only one instance of Scanner by design so I find accurate embedding this fact in classes' name, hence ScannerSingleton.
For each part of my api I am gonna need proper SwaggerConfig. For instance to get proper baseUrl. Each instance of SwaggerConfig has to be easily identified in global scope. I could use ServletContext but I loose controll over object type and it would not be consistent with the way global presence of Scanner is done. Added SwaggerConfigMap.
It seems that ServletContext was used to store "reader" (that is obviously instance of SwaggerConfig) and "scanner". When "reader" is used, "scanner" seems to be abbandoned in favor of ScannerFactory. Moreover the "reader" actually sets global scanner. As a result "scanner" has no merit.
Since ScannerFactory is now ScannerSingleton I moved creation of new instance of Scanner from WebXMLReader to ScannerSingleton. BeanConfig replace this instance as it have done.
JerseyJaxrsConfig is present only due to compatibility (I guess) so I modified the class to reflect that.
ApiListingResource stores instances of Swagger using swagger.id what allows partitioning. When swagger.id is absent Swagger is stored under name "swagger-default" as a result previous functionality is supported.