### PR TITLE
Fixes #1387: FormDataContentDisposition and FormDataBodyPart are set ignored for jersey2

### DIFF
--- a/modules/swagger-jersey2-jaxrs/src/main/java/io/swagger/jersey/SwaggerJersey2Jaxrs.java
+++ b/modules/swagger-jersey2-jaxrs/src/main/java/io/swagger/jersey/SwaggerJersey2Jaxrs.java
@@ -5,12 +5,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+
+import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ParameterProcessor;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtensions;
 import io.swagger.models.parameters.FormParameter;
 import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.Property;
 import io.swagger.util.Json;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
@@ -18,6 +21,7 @@ import javax.ws.rs.BeanParam;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -89,6 +93,13 @@ public class SwaggerJersey2Jaxrs extends AbstractSwaggerExtension {
                 if (java.io.InputStream.class.isAssignableFrom(constructType(type).getRawClass())) {
                     final Parameter param = new FormParameter().type("file").name(fd.value());
                     parameters.add(param);
+                } else {
+                    final FormParameter fp = new FormParameter().name(fd.value());
+                    final Property schema = ModelConverters.getInstance().readAsProperty(type);
+                    if (schema != null) {
+                        fp.setProperty(schema);
+                    }
+                    parameters.add(fp);
                 }
             }
         }
@@ -99,5 +110,16 @@ public class SwaggerJersey2Jaxrs extends AbstractSwaggerExtension {
         }
 
         return parameters;
+    }
+
+    @Override
+    protected boolean shouldIgnoreClass(Class<?> cls) {
+        for (Class<?> item : Arrays.asList(org.glassfish.jersey.media.multipart.FormDataContentDisposition.class,
+                org.glassfish.jersey.media.multipart.FormDataBodyPart.class)) {
+            if (item.isAssignableFrom(cls)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/SwaggerJersey2JaxrsTest.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/SwaggerJersey2JaxrsTest.java
@@ -15,6 +15,7 @@ import io.swagger.params.BaseBean;
 import io.swagger.params.ChildBean;
 import io.swagger.params.EnumBean;
 import io.swagger.params.RefBean;
+import io.swagger.resources.ResourceWithFormData;
 import io.swagger.resources.ResourceWithKnownInjections;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
@@ -130,6 +131,16 @@ public class SwaggerJersey2JaxrsTest {
         assertEquals(getName(resourceParameters, 1), "skip");
         assertEquals(getName(resourceParameters, 2), "limit");
         assertEquals(getName(resourceParameters, 3), "methodParam");
+    }
+
+    @Test(description = "FormDataBodyPart should be ignored when generating the Swagger document")
+    public void testFormDataBodyPart() {
+        final Swagger swagger = new Reader(new Swagger()).read(ResourceWithFormData.class);
+        final List<Parameter> parameters = swagger.getPath("/test/document/{documentName}.json").getPost().getParameters();
+        assertEquals(parameters.size(), 3);
+        assertEquals(parameters.get(0).getName(), "documentName");
+        assertEquals(parameters.get(1).getName(), "input");
+        assertEquals(parameters.get(2).getName(), "id");
     }
 
     private String getName(List<Parameter> resourceParameters, int i) {

--- a/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/resources/ResourceWithFormData.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/resources/ResourceWithFormData.java
@@ -1,0 +1,30 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+
+import java.io.InputStream;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@Path("test")
+@Api(value = "test", description = "test routes", produces = "application/json")
+public class ResourceWithFormData {
+
+    @POST
+    @Path("/document/{documentName}.json")
+    @ApiOperation(value = "uploadAttachAndParseUserDocument", notes = "Uploads, parses, and attaches the document to the user's job application.", position = 509)
+    public String uploadAttachAndParseUserDocument(@PathParam("documentName") final String documentName,
+                                                   @FormDataParam("document") final FormDataContentDisposition detail,
+                                                   @FormDataParam("document2") final FormDataBodyPart bodyPart,
+                                                   @FormDataParam("input") final InputStream input,
+                                                   @FormDataParam("id") final Integer id) throws Exception {
+        return "";
+    }
+}


### PR DESCRIPTION
Fixes #1387: FormDataContentDisposition and FormDataBodyPart are set ignored for jersey2. Also 'else' branch was added to process FormDataParam, so now all FormDataParam will be processed  as FormParameter (not only InputStream type)