### PR TITLE
Feature/993 fall back to no format if format is missing

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 public class PropertyBuilder {
-    static Logger LOGGER = LoggerFactory.getLogger(PropertyBuilder.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(PropertyBuilder.class);
 
     /**
      * Creates new property on the passed arguments.
@@ -601,8 +601,23 @@ public class PropertyBuilder {
                     return item;
                 }
             }
-            LOGGER.debug("no property for " + type + ", " + format);
-            return null;
+
+            if (format != null) {
+                LOGGER.debug("no property for " + type + ", " + format + ", trying again without the format.");
+
+                // if none was found, try again without the format:
+                for (final Processor item : values()) {
+                    if (item.isType(type, null)) {
+                        return item;
+                    }
+                }
+
+                LOGGER.debug("no property for " + type + ", null, either.");
+                return null;
+            } else {
+                LOGGER.debug("no property for " + type + ", " + format);
+                return null;
+            }
         }
 
         public static Processor fromProperty(Property property) {

--- a/modules/swagger-models/src/test/java/io/swagger/models/properties/PropertyBuilderTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/properties/PropertyBuilderTest.java
@@ -1,26 +1,59 @@
 package io.swagger.models.properties;
 
-import io.swagger.models.properties.Property;
-
 import org.testng.Assert;
+
 import org.testng.annotations.Test;
-
-import io.swagger.models.properties.StringProperty;
-import io.swagger.models.properties.PropertyBuilder;
-
 
 public class PropertyBuilderTest {
 
     @Test
-    public void testStringFormat() {
-        for (StringProperty.Format format : StringProperty.Format.values()) {
+    public void testStringPredefinedFormats() {
+        for (final StringProperty.Format format : StringProperty.Format.values()) {
             final String name = format.getName();
             final Property property = PropertyBuilder.build(StringProperty.TYPE, name, null);
             Assert.assertEquals(property.getType(), StringProperty.TYPE);
             Assert.assertEquals(property.getFormat(), name);
         }
+    }
+
+    @Test
+    public void testStringNoFormat() {
         final Property noFormat = PropertyBuilder.build(StringProperty.TYPE, null, null);
         Assert.assertEquals(noFormat.getType(), StringProperty.TYPE);
         Assert.assertNull(noFormat.getFormat());
     }
+
+    @Test
+    public void testStringCustomFormat() {
+        final String customFormatName = "custom";
+        final Property customFormatProperty = PropertyBuilder.build(StringProperty.TYPE, customFormatName, null);
+        Assert.assertNotNull(customFormatProperty);
+        Assert.assertEquals(customFormatProperty.getType(), StringProperty.TYPE);
+        Assert.assertEquals(customFormatProperty.getFormat(), customFormatName);
+    }
+
+    @Test
+    public void testNumberFloat() {
+        final String floatFormat = "float";
+        final Property floatProperty = PropertyBuilder.build(DecimalProperty.TYPE, floatFormat, null);
+        Assert.assertEquals(floatProperty.getType(), DecimalProperty.TYPE);
+        Assert.assertEquals(floatProperty.getFormat(), floatFormat);
+    }
+
+    @Test
+    public void testNumberNoFormat() {
+        final Property noFormat = PropertyBuilder.build(DecimalProperty.TYPE, null, null);
+        Assert.assertEquals(noFormat.getType(), DecimalProperty.TYPE);
+        Assert.assertNull(noFormat.getFormat());
+    }
+
+    @Test
+    public void testNumberCustomFormat() {
+        final String customFormatName = "custom";
+        final Property customFormatProperty = PropertyBuilder.build(DecimalProperty.TYPE, customFormatName, null);
+        Assert.assertNotNull(customFormatProperty);
+        Assert.assertEquals(customFormatProperty.getType(), DecimalProperty.TYPE);
+        Assert.assertEquals(customFormatProperty.getFormat(), customFormatName);
+    }
+
 }


### PR DESCRIPTION
This is a possible solution for Issue #993.

It is a simple fall-back solution: In `PropertyBuilder.Processor.fromType`, we first try the given (type, format) pair. If this doesn't give a match, we have a custom format without special implementation support, so we simply ignore the format name and look again for Processors for (type, null).

Only if this doesn't give a result we return null.

The first commit also adds some tests for this problem (which fail without the fix in the second commit).


This seems to also solve [Issue #1133 from swagger-codegen](https://github.com/swagger-api/swagger-codegen/issues/1133) (after using a fixed version of swagger-models in swagger-codegen).