### PR TITLE
Fix Issue #1388: allow path and response refs, too.

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/RefModel.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/RefModel.java
@@ -3,7 +3,6 @@ package io.swagger.models;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.models.properties.Property;
 import io.swagger.models.refs.GenericRef;
-import io.swagger.models.refs.RefConstants;
 import io.swagger.models.refs.RefFormat;
 import io.swagger.models.refs.RefType;
 
@@ -24,7 +23,7 @@ public class RefModel implements Model {
     }
 
     public RefModel asDefault(String ref) {
-        this.set$ref(RefConstants.INTERNAL_DEFINITION_PREFIX + ref);
+        this.set$ref(RefType.DEFINITION.getInternalPrefix() + ref);
         return this;
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/RefParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/RefParameter.java
@@ -2,7 +2,6 @@ package io.swagger.models.parameters;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.models.refs.GenericRef;
-import io.swagger.models.refs.RefConstants;
 import io.swagger.models.refs.RefFormat;
 import io.swagger.models.refs.RefType;
 
@@ -22,7 +21,7 @@ public class RefParameter extends AbstractParameter implements Parameter {
     }
 
     public RefParameter asDefault(String ref) {
-        this.set$ref(RefConstants.INTERNAL_PARAMETER_PREFIX + ref);
+        this.set$ref(RefType.PARAMETER.getInternalPrefix() + ref);
         return this;
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
@@ -2,7 +2,6 @@ package io.swagger.models.properties;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.models.refs.GenericRef;
-import io.swagger.models.refs.RefConstants;
 import io.swagger.models.refs.RefFormat;
 import io.swagger.models.refs.RefType;
 
@@ -28,7 +27,7 @@ public class RefProperty extends AbstractProperty implements Property {
     }
 
     public RefProperty asDefault(String ref) {
-        this.set$ref(RefConstants.INTERNAL_DEFINITION_PREFIX + ref);
+        this.set$ref(RefType.DEFINITION.getInternalPrefix() + ref);
         return this;
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/models/refs/GenericRef.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/refs/GenericRef.java
@@ -1,7 +1,7 @@
 package io.swagger.models.refs;
 
 /**
- * A class the encapsulates logic that is common to RefModel, RefParameter, and RefProperty
+ * A class the encapsulates logic that is common to RefModel, RefParameter, and RefProperty.
  */
 public class GenericRef {
 
@@ -14,29 +14,18 @@ public class GenericRef {
         this.format = computeRefFormat(ref);
         this.type = type;
 
-        validateFormatAndType(format, type);
-
         if (format == RefFormat.INTERNAL && !ref.startsWith("#/")) {
             /* this is an internal path that did not start with a #/, we must be in some of ModelResolver code
             while currently relies on the ability to create RefModel/RefProperty objects via a constructor call like
             1) new RefModel("Animal")..and expects get$ref to return #/definitions/Animal
             2) new RefModel("http://blah.com/something/file.json")..and expects get$ref to turn the URL
              */
-            this.ref = getPrefixForType(type) + ref;
+            this.ref = type.getInternalPrefix() + ref;
         } else {
             this.ref = ref;
         }
 
         this.simpleRef = computeSimpleRef(this.ref, format, type);
-    }
-
-    private void validateFormatAndType(RefFormat format, RefType type) {
-        if(type == RefType.PATH || type == RefType.RESPONSE) {
-            if(format == RefFormat.INTERNAL) {
-                //PATH AND RESPONSE refs  can only be URL or RELATIVE
-                throw new RuntimeException(type + " refs can not be internal references");
-            }
-        }
     }
 
     public RefFormat getFormat() {
@@ -92,24 +81,8 @@ public class GenericRef {
         String result = ref;
         //simple refs really only apply to internal refs
         if (format == RefFormat.INTERNAL) {
-            String prefix = getPrefixForType(type);
+            String prefix = type.getInternalPrefix();
             result = ref.substring(prefix.length());
-        }
-        return result;
-    }
-
-    private static String getPrefixForType(RefType refType) {
-        String result;
-
-        switch (refType) {
-            case DEFINITION:
-                result = RefConstants.INTERNAL_DEFINITION_PREFIX;
-                break;
-            case PARAMETER:
-                result = RefConstants.INTERNAL_PARAMETER_PREFIX;
-                break;
-            default:
-                throw new RuntimeException("No logic implemented for RefType of " + refType);
         }
 
         return result;

--- a/modules/swagger-models/src/main/java/io/swagger/models/refs/RefConstants.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/refs/RefConstants.java
@@ -1,9 +1,0 @@
-package io.swagger.models.refs;
-
-/**
- * Created by russellb337 on 7/1/15.
- */
-public class RefConstants {
-    public static final String INTERNAL_PARAMETER_PREFIX = "#/parameters/";
-    public static final String INTERNAL_DEFINITION_PREFIX = "#/definitions/";
-}

--- a/modules/swagger-models/src/main/java/io/swagger/models/refs/RefType.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/refs/RefType.java
@@ -4,8 +4,21 @@ package io.swagger.models.refs;
  * Created by russellb337 on 7/1/15.
  */
 public enum RefType {
-    DEFINITION,
-    PARAMETER,
-    PATH,
-    RESPONSE
+    DEFINITION("#/definitions/"),
+    PARAMETER("#/parameters/"),
+    PATH("#/paths/"),
+    RESPONSE("#/responses/");
+
+    private final String internalPrefix;
+
+    private RefType(final String prefix) {
+        this.internalPrefix = prefix;
+    }
+
+    /**
+     * The prefix in an internal reference of this type.
+     */
+    public String getInternalPrefix() {
+        return internalPrefix;
+    }
 }

--- a/modules/swagger-models/src/test/java/io/swagger/GenericRefTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/GenericRefTest.java
@@ -20,14 +20,23 @@ public class GenericRefTest {
         assertRefFormat(new GenericRef(RefType.DEFINITION, "http://my.company.com/models/model.json#/thing"), RefFormat.URL);
         assertRefFormat(new GenericRef(RefType.PARAMETER, "http://my.company.com/models/model.json"), RefFormat.URL);
         assertRefFormat(new GenericRef(RefType.PARAMETER, "http://my.company.com/models/model.json#/thing"), RefFormat.URL);
+        assertRefFormat(new GenericRef(RefType.RESPONSE, "http://my.company.com/models/model.json"), RefFormat.URL);
+        assertRefFormat(new GenericRef(RefType.RESPONSE, "http://my.company.com/models/model.json#/thing"), RefFormat.URL);
+        assertRefFormat(new GenericRef(RefType.PATH, "http://my.company.com/models/model.json"), RefFormat.URL);
+        assertRefFormat(new GenericRef(RefType.PATH, "http://my.company.com/models/model.json#/thing"), RefFormat.URL);
     }
 
     @Test(description = "it should correctly identify internal refs")
     public void identifyInternalRefs() {
         assertRefFormat(new GenericRef(RefType.DEFINITION, "#/definitions/foo"), RefFormat.INTERNAL);
         assertRefFormat(new GenericRef(RefType.PARAMETER, "#/parameters/foo"), RefFormat.INTERNAL);
+        assertRefFormat(new GenericRef(RefType.RESPONSE, "#/responses/foo"), RefFormat.INTERNAL);
+        assertRefFormat(new GenericRef(RefType.PATH, "#/paths/foo"), RefFormat.INTERNAL);
+
         assertRefFormat(new GenericRef(RefType.PARAMETER, "Foo"), RefFormat.INTERNAL);
         assertRefFormat(new GenericRef(RefType.DEFINITION, "Foo"), RefFormat.INTERNAL);
+        assertRefFormat(new GenericRef(RefType.RESPONSE, "Foo"), RefFormat.INTERNAL);
+        assertRefFormat(new GenericRef(RefType.PATH, "Foo"), RefFormat.INTERNAL);
     }
 
     @Test(description = "it should correctly identify relative refs")
@@ -40,6 +49,14 @@ public class GenericRefTest {
         assertRefFormat(new GenericRef(RefType.PARAMETER, "./path/to/model.json#/thing"), RefFormat.RELATIVE);
         assertRefFormat(new GenericRef(RefType.PARAMETER, "../path/to/model.json"), RefFormat.RELATIVE);
         assertRefFormat(new GenericRef(RefType.PARAMETER, "../path/to/model.json#/thing"), RefFormat.RELATIVE);
+        assertRefFormat(new GenericRef(RefType.RESPONSE, "./path/to/model.json"), RefFormat.RELATIVE);
+        assertRefFormat(new GenericRef(RefType.RESPONSE, "./path/to/model.json#/thing"), RefFormat.RELATIVE);
+        assertRefFormat(new GenericRef(RefType.RESPONSE, "../path/to/model.json"), RefFormat.RELATIVE);
+        assertRefFormat(new GenericRef(RefType.RESPONSE, "../path/to/model.json#/thing"), RefFormat.RELATIVE);
+        assertRefFormat(new GenericRef(RefType.PATH, "./path/to/model.json"), RefFormat.RELATIVE);
+        assertRefFormat(new GenericRef(RefType.PATH, "./path/to/model.json#/thing"), RefFormat.RELATIVE);
+        assertRefFormat(new GenericRef(RefType.PATH, "../path/to/model.json"), RefFormat.RELATIVE);
+        assertRefFormat(new GenericRef(RefType.PATH, "../path/to/model.json#/thing"), RefFormat.RELATIVE);
     }
 
     private void assertRefStringIsUnchanged(RefType refType, String refStr) {
@@ -64,17 +81,31 @@ public class GenericRefTest {
     public void giveBackRightRefString() {
         assertRefStringIsUnchanged(RefType.DEFINITION, "./path/to/model.json");
         assertRefStringIsUnchanged(RefType.DEFINITION, "./path/to/model.json#/thing");
-        assertRefStringIsUnchanged(RefType.PARAMETER, "./path/to/parameters.json#/param");
-        assertRefStringIsUnchanged(RefType.PARAMETER, "./path/to/parameters.json#/param");
+        assertRefStringIsUnchanged(RefType.PARAMETER, "./path/to/parameters.json");
+        assertRefStringIsUnchanged(RefType.PARAMETER, "./path/to/parameters.json#/thing");
+        assertRefStringIsUnchanged(RefType.PATH, "./path/to/parameters.json");
+        assertRefStringIsUnchanged(RefType.PATH, "./path/to/parameters.json#/thing");
+        assertRefStringIsUnchanged(RefType.RESPONSE, "./path/to/parameters.json");
+        assertRefStringIsUnchanged(RefType.RESPONSE, "./path/to/parameters.json#/thing");
+
         assertRefStringIsUnchanged(RefType.DEFINITION, "#/definitions/foo");
         assertRefStringIsUnchanged(RefType.PARAMETER, "#/parameters/foo");
+        assertRefStringIsUnchanged(RefType.PATH, "#/paths/foo");
+        assertRefStringIsUnchanged(RefType.RESPONSE, "#/responses/foo");
+
         assertRefStringIsUnchanged(RefType.DEFINITION, "http://my.company.com/models/model.json");
         assertRefStringIsUnchanged(RefType.DEFINITION, "http://my.company.com/models/model.json#/thing");
         assertRefStringIsUnchanged(RefType.PARAMETER, "http://my.company.com/models/model.json");
         assertRefStringIsUnchanged(RefType.PARAMETER, "http://my.company.com/models/model.json#/thing");
+        assertRefStringIsUnchanged(RefType.RESPONSE, "http://my.company.com/models/model.json");
+        assertRefStringIsUnchanged(RefType.RESPONSE, "http://my.company.com/models/model.json#/thing");
+        assertRefStringIsUnchanged(RefType.PATH, "http://my.company.com/models/model.json");
+        assertRefStringIsUnchanged(RefType.PATH, "http://my.company.com/models/model.json#/thing");
 
         assertRefString(RefType.DEFINITION, "foo", "#/definitions/foo");
         assertRefString(RefType.PARAMETER, "foo", "#/parameters/foo");
+        assertRefString(RefType.RESPONSE, "foo", "#/responses/foo");
+        assertRefString(RefType.PATH, "foo", "#/paths/foo");
     }
 
     @Test(description = "it should give back the right simple ref")
@@ -83,15 +114,28 @@ public class GenericRefTest {
         assertSimpleRefMatchesRef(RefType.DEFINITION, "./path/to/model.json#/thing");
         assertSimpleRefMatchesRef(RefType.PARAMETER, "./path/to/parameters.json#/param");
         assertSimpleRefMatchesRef(RefType.PARAMETER, "./path/to/parameters.json#/param");
+        assertSimpleRefMatchesRef(RefType.RESPONSE, "./path/to/parameters.json#/param");
+        assertSimpleRefMatchesRef(RefType.RESPONSE, "./path/to/parameters.json#/param");
+        assertSimpleRefMatchesRef(RefType.PATH, "./path/to/parameters.json#/param");
+        assertSimpleRefMatchesRef(RefType.PATH, "./path/to/parameters.json#/param");
 
         assertSimpleRefMatchesRef(RefType.DEFINITION, "http://my.company.com/models/model.json");
         assertSimpleRefMatchesRef(RefType.DEFINITION, "http://my.company.com/models/model.json#/thing");
         assertSimpleRefMatchesRef(RefType.PARAMETER, "http://my.company.com/models/model.json");
         assertSimpleRefMatchesRef(RefType.PARAMETER, "http://my.company.com/models/model.json#/thing");
+        assertSimpleRefMatchesRef(RefType.PATH, "http://my.company.com/models/model.json");
+        assertSimpleRefMatchesRef(RefType.PATH, "http://my.company.com/models/model.json#/thing");
+        assertSimpleRefMatchesRef(RefType.RESPONSE, "http://my.company.com/models/model.json");
+        assertSimpleRefMatchesRef(RefType.RESPONSE, "http://my.company.com/models/model.json#/thing");
 
         assertSimpleRef(RefType.DEFINITION, "#/definitions/foo", "foo");
         assertSimpleRef(RefType.PARAMETER, "#/parameters/foo", "foo");
+        assertSimpleRef(RefType.RESPONSE, "#/responses/foo", "foo");
+        assertSimpleRef(RefType.PATH, "#/paths/foo", "foo");
+
         assertSimpleRef(RefType.DEFINITION, "foo", "foo");
         assertSimpleRef(RefType.PARAMETER, "foo", "foo");
+        assertSimpleRef(RefType.RESPONSE, "foo", "foo");
+        assertSimpleRef(RefType.PATH, "foo", "foo");
     }
 }


### PR DESCRIPTION
Assuming the discussion in #1388 doesn't result in there being a valid reason not to allow PATH and RESPONSE as internal refs, this is a solution which simply allows those.

This commit does those things:

* move the internal prefixes into the RefType enum (→ RefConstants class is not needed anymore)
* add prefixes for RESPONSE and PATH
* get rid of the exception when trying to use an internal reference of type RESPONSE or PATH
* add test cases in GenericRefTest for PATH and RESPONSE.