### PR TITLE
'expected' and 'actual' wrong way around

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/model/override/OverrideTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/model/override/OverrideTest.java
@@ -27,8 +27,8 @@ public class OverrideTest {
 
         final Model model = read.get(GenericModel.class.getSimpleName());
         assertTrue(model.getProperties().containsKey(NAME));
-        assertEquals(model.getProperties().get(NAME).getType(), "string");
+        assertEquals("string", model.getProperties().get(NAME).getType());
         assertTrue(model.getProperties().containsKey(COUNT));
-        assertEquals(model.getProperties().get(COUNT).getType(), "integer");
+        assertEquals("integer", model.getProperties().get(COUNT).getType());
     }
 }


### PR DESCRIPTION
The syntax for the test method is:
`assertEquals(expected, actual);`

Swapping them around make no difference to whether the test will pass of fail, it just makes understanding it clearer if it ever fails. Eg, it will say something like:
    `Expected "error" but was "string"`
when it should have been:
    `Expected "string" but was "error"`