### PR TITLE
Feature/993 remove format checks where null

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/BaseIntegerProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/BaseIntegerProperty.java
@@ -1,8 +1,8 @@
 package io.swagger.models.properties;
 
 /**
- * The <code>BaseIntegerProperty</code> class defines property for integers
- * without specific format.
+ * The <code>BaseIntegerProperty</code> class defines property for integers without specific format, or with a custom
+ * format.
  */
 public class BaseIntegerProperty extends AbstractNumericProperty {
     public static final String TYPE = "integer";
@@ -17,6 +17,6 @@ public class BaseIntegerProperty extends AbstractNumericProperty {
     }
 
     public static boolean isType(String type, String format) {
-        return TYPE.equals(type) && format == null;
+        return TYPE.equals(type);
     }
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/DecimalProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/DecimalProperty.java
@@ -5,6 +5,10 @@ import io.swagger.models.Xml;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * The DecimalProperty class defines properties for (decimal) numbers without a specific format, or with a custom
+ * format. The two standard formats are defined in {@link DoubleProperty} and {@link FloatProperty}.
+ */
 public class DecimalProperty extends AbstractNumericProperty {
     public static final String TYPE = "number";
 
@@ -18,7 +22,7 @@ public class DecimalProperty extends AbstractNumericProperty {
     }
 
     public static boolean isType(String type, String format) {
-        return TYPE.equals(type) && format == null;
+        return TYPE.equals(type);
     }
 
     public DecimalProperty xml(Xml xml) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 public class PropertyBuilder {
-    static Logger LOGGER = LoggerFactory.getLogger(PropertyBuilder.class);
+    static final Logger LOGGER = LoggerFactory.getLogger(PropertyBuilder.class);
 
     /**
      * Creates new property on the passed arguments.
@@ -140,37 +140,9 @@ public class PropertyBuilder {
                         }
                     }
                 }
+
                 return property;
             }
-        },
-        STRING(StringProperty.class) {
-            @Override
-            protected boolean isType(String type, String format) {
-                return StringProperty.isType(type, format);
-            }
-
-            @Override
-            protected StringProperty create() {
-                return new StringProperty();
-            }
-
-            @Override
-            public Property merge(Property property, Map<PropertyId, Object> args) {
-                super.merge(property, args);
-                if (property instanceof StringProperty) {
-                    mergeString((StringProperty) property, args);
-                }
-                return property;
-            }
-
-            @Override
-            public Model toModel(Property property) {
-                if (isType(property)) {
-                    return createStringModel((StringProperty) property);
-                }
-                return null;
-            }
-
         },
         BYTE_ARRAY(ByteArrayProperty.class) {
             @Override
@@ -377,6 +349,10 @@ public class PropertyBuilder {
                 return null;
             }
         },
+
+        // note: this must be in the enum order after both INT and LONG
+        // (and any integer types added in the future), so the more specific
+        // ones will be found first.
         INTEGER(BaseIntegerProperty.class) {
             @Override
             protected boolean isType(String type, String format) {
@@ -398,6 +374,10 @@ public class PropertyBuilder {
                 return property;
             }
         },
+
+        // note: this must be in the enum order after both DOUBLE and FLOAT
+        // (and any number types added in the future), so the more specific
+        // ones will be found first.
         DECIMAL(DecimalProperty.class) {
             @Override
             protected boolean isType(String type, String format) {
@@ -530,14 +510,7 @@ public class PropertyBuilder {
         OBJECT(ObjectProperty.class) {
             @Override
             protected boolean isType(String type, String format) {
-                if (ObjectProperty.isType(type, format)) {
-                    return true;
-                }
-                if (ObjectProperty.TYPE.equals(type) && format == null) {
-                    LOGGER.debug("no format specified for object type, falling back to object");
-                    return true;
-                }
-                return false;
+                return ObjectProperty.isType(type, format);
             }
 
             @Override
@@ -587,7 +560,42 @@ public class PropertyBuilder {
                 }
                 return null;
             }
-        };
+        },
+
+        // String is intentionally last, so it is found after the more specific property
+        // types which also use the "string" type.
+        STRING(StringProperty.class) {
+            @Override
+            protected boolean isType(final String type, final String format) {
+                return StringProperty.isType(type, format);
+            }
+
+            @Override
+            protected StringProperty create() {
+                return new StringProperty();
+            }
+
+            @Override
+            public Property merge(final Property property, final Map<PropertyId, Object> args) {
+                super.merge(property, args);
+                if (property instanceof StringProperty) {
+                    mergeString((StringProperty) property, args);
+                }
+
+                return property;
+            }
+
+            @Override
+            public Model toModel(final Property property) {
+                if (isType(property)) {
+                    return createStringModel((StringProperty) property);
+                }
+
+                return null;
+            }
+
+        },
+        ;
 
         private final Class<? extends Property> type;
 

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
@@ -5,6 +5,10 @@ import io.swagger.models.Xml;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * The StringProperty class defines properties for strings without a specific format, for standard formats which don't
+ * need specific handling, or for custom formats.
+ */
 public class StringProperty extends AbstractProperty implements Property {
     public static final String TYPE = "string";
     protected List<String> _enum;
@@ -51,7 +55,7 @@ public class StringProperty extends AbstractProperty implements Property {
     }
 
     public static boolean isType(String type, String format) {
-        return TYPE.equals(type) && (format == null || Format.fromName(format) != null);
+        return TYPE.equals(type);
     }
 
     public StringProperty xml(Xml xml) {

--- a/modules/swagger-models/src/test/java/io/swagger/models/properties/PropertyBuilderTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/properties/PropertyBuilderTest.java
@@ -1,59 +1,138 @@
 package io.swagger.models.properties;
 
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.Iterator;
+import java.util.List;
+
 import org.testng.Assert;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import io.swagger.models.properties.PropertyBuilder.PropertyId;
+import io.swagger.models.properties.StringProperty.Format;
 
 public class PropertyBuilderTest {
 
-    @Test
-    public void testStringPredefinedFormats() {
-        for (final StringProperty.Format format : StringProperty.Format.values()) {
-            final String name = format.getName();
-            final Property property = PropertyBuilder.build(StringProperty.TYPE, name, null);
-            Assert.assertEquals(property.getType(), StringProperty.TYPE);
-            Assert.assertEquals(property.getFormat(), name);
+    private static final String STRING_FORMATS = "stringFormats";
+    private static final String FROM_SPEC = "fromSpec";
+    private static final String BY_IMPLEMENTATION = "predefined";
+    private static final String CUSTOM_OR_PLAIN = "customOrPlain";
+
+    @DataProvider(name = BY_IMPLEMENTATION)
+    public Iterator<Object[]> createPredefinedProperties() {
+        Property[] properties = {
+            new DecimalProperty(), new FloatProperty(), new DoubleProperty(), new BaseIntegerProperty(),
+            new IntegerProperty(), new LongProperty(), new StringProperty(), new UUIDProperty(), new BooleanProperty(),
+            new ByteArrayProperty(), new ArrayProperty(), new ObjectProperty(), new DateTimeProperty(),
+            new DateProperty(), new RefProperty(), new EmailProperty(),
+            // new MapProperty() // MapProperty can't be distinguished from ObjectProperty
+        };
+        List<Object[]> resultList = new ArrayList<Object[]>(properties.length);
+        for (Property property : properties) {
+            resultList.add(new Object[] {property.getType(), property.getFormat(), property.getClass()});
         }
+
+        return resultList.iterator();
+    }
+
+    @DataProvider(name = STRING_FORMATS)
+    public Iterator<Object[]> createPredefinedStringFormats() {
+        List<Object[]> resultList = new ArrayList<Object[]>();
+        for (Format format : StringProperty.Format.values()) {
+            resultList.add(new Object[] {StringProperty.TYPE, format.getName(), StringProperty.class});
+        }
+
+        return resultList.iterator();
+    }
+
+    @DataProvider(name = FROM_SPEC)
+    public Object[][] createDataFromSpec() {
+
+        // from the table in http://swagger.io/specification/#dataTypeType
+        return new Object[][] {
+                {"integer", "int32", IntegerProperty.class},
+                {"integer", "int64", LongProperty.class},
+                {"number", "float", FloatProperty.class},
+                {"number", "double", DoubleProperty.class},
+                {"string", null, StringProperty.class},
+                {"string", "byte", StringProperty.class}, // are this and the next one correct?
+                {"string", "binary", ByteArrayProperty.class},
+                {"boolean", null, BooleanProperty.class},
+                {"string", "date", DateProperty.class},
+                {"string", "date-time", DateTimeProperty.class},
+                {"string", "password", StringProperty.class},
+            };
+    }
+
+    @DataProvider(name = CUSTOM_OR_PLAIN)
+    public Object[][] createCustomAndPlainData() {
+
+        // these are the types without formats (as long as not already in the
+        // table in the spec), and a "custom" format for each of the types.
+        // we expect to get the same Property class back in both cases.
+        return new Object[][] {
+                {"integer", null, BaseIntegerProperty.class},
+                {"integer", "custom", BaseIntegerProperty.class},
+                {"number", null, DecimalProperty.class},
+                {"number", "custom", DecimalProperty.class},
+                {"string", "custom", StringProperty.class},
+                {"boolean", "custom", BooleanProperty.class},
+                {"object", null, ObjectProperty.class},
+                {"object", "custom", ObjectProperty.class},
+                {"array", null, ArrayProperty.class},
+                {"array", "custom", ArrayProperty.class}
+            };
+    }
+
+    @Test(dataProvider = BY_IMPLEMENTATION)
+    public void testPredefinedProperty(final String type, final String format,
+            final Class<? extends Property> expectedClass) {
+        buildAndAssertProperty(type, format, expectedClass);
+    }
+
+    @Test(dataProvider = FROM_SPEC)
+    public void testSpecificationProperty(final String type, final String format,
+            final Class<? extends Property> expectedClass) {
+        buildAndAssertProperty(type, format, expectedClass);
+    }
+
+    @Test(dataProvider = CUSTOM_OR_PLAIN)
+    public void testCustomOrPlainProperty(final String type, final String format,
+            final Class<? extends Property> expectedClass) {
+        buildAndAssertProperty(type, format, expectedClass);
+    }
+
+    @Test(dataProvider = STRING_FORMATS)
+    public void testStringPredefinedFormats(final String type, final String format,
+            final Class<? extends Property> expectedClass) {
+        buildAndAssertProperty(type, format, expectedClass);
+    }
+
+    private void buildAndAssertProperty(final String type, final String format,
+            final Class<? extends Property> expectedClass) {
+        Property built = PropertyBuilder.build(type, format, null);
+        Assert.assertNotNull(built,
+            "Could not build for type: " + type + ", format: " + format + ", expected class: " + expectedClass);
+        Assert.assertEquals(built.getClass(), expectedClass);
+        Assert.assertEquals(built.getType(), type);
+        Assert.assertEquals(built.getFormat(), format);
     }
 
     @Test
-    public void testStringNoFormat() {
-        final Property noFormat = PropertyBuilder.build(StringProperty.TYPE, null, null);
-        Assert.assertEquals(noFormat.getType(), StringProperty.TYPE);
-        Assert.assertNull(noFormat.getFormat());
+    public void testUnknownType() {
+        Assert.assertNull(PropertyBuilder.build("unknownType", "custom", null));
     }
 
-    @Test
-    public void testStringCustomFormat() {
-        final String customFormatName = "custom";
-        final Property customFormatProperty = PropertyBuilder.build(StringProperty.TYPE, customFormatName, null);
-        Assert.assertNotNull(customFormatProperty);
-        Assert.assertEquals(customFormatProperty.getType(), StringProperty.TYPE);
-        Assert.assertEquals(customFormatProperty.getFormat(), customFormatName);
-    }
+    @Test(dataProvider = FROM_SPEC)
+    public void testBuildWithArgs(final String type, final String format,
+            final Class<? extends Property> expectedClass) {
+        EnumMap<PropertyId, Object> args = new EnumMap<PropertyId, Object>(PropertyId.class);
+        args.put(PropertyId.DESCRIPTION, "Example description");
 
-    @Test
-    public void testNumberFloat() {
-        final String floatFormat = "float";
-        final Property floatProperty = PropertyBuilder.build(DecimalProperty.TYPE, floatFormat, null);
-        Assert.assertEquals(floatProperty.getType(), DecimalProperty.TYPE);
-        Assert.assertEquals(floatProperty.getFormat(), floatFormat);
+        Property built = PropertyBuilder.build(type, format, args);
+        Assert.assertNotNull(built);
+        Assert.assertEquals(built.getClass(), expectedClass);
     }
-
-    @Test
-    public void testNumberNoFormat() {
-        final Property noFormat = PropertyBuilder.build(DecimalProperty.TYPE, null, null);
-        Assert.assertEquals(noFormat.getType(), DecimalProperty.TYPE);
-        Assert.assertNull(noFormat.getFormat());
-    }
-
-    @Test
-    public void testNumberCustomFormat() {
-        final String customFormatName = "custom";
-        final Property customFormatProperty = PropertyBuilder.build(DecimalProperty.TYPE, customFormatName, null);
-        Assert.assertNotNull(customFormatProperty);
-        Assert.assertEquals(customFormatProperty.getType(), DecimalProperty.TYPE);
-        Assert.assertEquals(customFormatProperty.getFormat(), customFormatName);
-    }
-
 }

--- a/modules/swagger-models/src/test/java/io/swagger/models/properties/PropertyBuilderTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/properties/PropertyBuilderTest.java
@@ -1,26 +1,59 @@
 package io.swagger.models.properties;
 
-import io.swagger.models.properties.Property;
-
 import org.testng.Assert;
+
 import org.testng.annotations.Test;
-
-import io.swagger.models.properties.StringProperty;
-import io.swagger.models.properties.PropertyBuilder;
-
 
 public class PropertyBuilderTest {
 
     @Test
-    public void testStringFormat() {
-        for (StringProperty.Format format : StringProperty.Format.values()) {
+    public void testStringPredefinedFormats() {
+        for (final StringProperty.Format format : StringProperty.Format.values()) {
             final String name = format.getName();
             final Property property = PropertyBuilder.build(StringProperty.TYPE, name, null);
             Assert.assertEquals(property.getType(), StringProperty.TYPE);
             Assert.assertEquals(property.getFormat(), name);
         }
+    }
+
+    @Test
+    public void testStringNoFormat() {
         final Property noFormat = PropertyBuilder.build(StringProperty.TYPE, null, null);
         Assert.assertEquals(noFormat.getType(), StringProperty.TYPE);
         Assert.assertNull(noFormat.getFormat());
     }
+
+    @Test
+    public void testStringCustomFormat() {
+        final String customFormatName = "custom";
+        final Property customFormatProperty = PropertyBuilder.build(StringProperty.TYPE, customFormatName, null);
+        Assert.assertNotNull(customFormatProperty);
+        Assert.assertEquals(customFormatProperty.getType(), StringProperty.TYPE);
+        Assert.assertEquals(customFormatProperty.getFormat(), customFormatName);
+    }
+
+    @Test
+    public void testNumberFloat() {
+        final String floatFormat = "float";
+        final Property floatProperty = PropertyBuilder.build(DecimalProperty.TYPE, floatFormat, null);
+        Assert.assertEquals(floatProperty.getType(), DecimalProperty.TYPE);
+        Assert.assertEquals(floatProperty.getFormat(), floatFormat);
+    }
+
+    @Test
+    public void testNumberNoFormat() {
+        final Property noFormat = PropertyBuilder.build(DecimalProperty.TYPE, null, null);
+        Assert.assertEquals(noFormat.getType(), DecimalProperty.TYPE);
+        Assert.assertNull(noFormat.getFormat());
+    }
+
+    @Test
+    public void testNumberCustomFormat() {
+        final String customFormatName = "custom";
+        final Property customFormatProperty = PropertyBuilder.build(DecimalProperty.TYPE, customFormatName, null);
+        Assert.assertNotNull(customFormatProperty);
+        Assert.assertEquals(customFormatProperty.getType(), DecimalProperty.TYPE);
+        Assert.assertEquals(customFormatProperty.getFormat(), customFormatName);
+    }
+
 }


### PR DESCRIPTION
An alternative implementation to #1400 for issue #993. It makes the non-specific Properties' isType methods not check the format anymore, and makes sure they come in the PropertyBuilder.Processor enum after their more specific colleagues.

This pull request contains the same test case commits as #1400.