### PR TITLE
Add vendor extensions to ArrayProperty. [241]

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -165,7 +165,9 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
             detailNode = node.get("items");
             if (detailNode != null) {
                 Property subProperty = propertyFromNode(detailNode);
-                return new ArrayProperty().items(subProperty).description(description);
+                ArrayProperty arrayProperty = new ArrayProperty().items(subProperty).description(description);
+                arrayProperty.setVendorExtensionMap(getVendorExtensions(node));
+                return arrayProperty;
             }
         }
 

--- a/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
@@ -4,7 +4,6 @@ import io.swagger.TestUtils;
 import io.swagger.models.*;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.util.List;
 import java.util.Map;
 
@@ -122,5 +121,12 @@ public class JsonDeserializationTest {
         assertTrue(xBooleanValue);
 
         assertFalse(vendorExtensions.containsKey("not-an-extension"));
+
+        //check for vendor extensions in array property types
+        vendorExtensions = swagger.getDefinitions().get("Health").getProperties().get("array").getVendorExtensions();
+
+        xStringValue = (String) vendorExtensions.get("x-string-value");
+        assertNotNull(xStringValue);
+        assertEquals(xStringValue, "string_value");
     }
 }

--- a/modules/swagger-core/src/test/resources/specFiles/propertyWithVendorExtensions.json
+++ b/modules/swagger-core/src/test/resources/specFiles/propertyWithVendorExtensions.json
@@ -31,6 +31,13 @@
                     "x-number-value": 123,
                     "x-boolean-value": true,
                     "not-an-extension": "foobar"
+                },
+                "array": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Health"
+                    },
+                    "x-string-value": "string_value"
                 }
             }
         }


### PR DESCRIPTION
Regarding the discussion in swagger-api/swagger-spec#241 this adds deserialization for vendor extensions to ArrayProperty.

ObjectPropery and MapProperty are already taken care of in swagger-api/swagger-core/pull/1414