### PR TITLE
Adding in a clone method.

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/ComposedModel.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/ComposedModel.java
@@ -99,6 +99,19 @@ public class ComposedModel extends AbstractModel {
             }
         }
     }
+    
+    public Object clone() {
+        ComposedModel cloned = new ComposedModel();
+        super.cloneTo(cloned);
+        cloned.allOf = this.allOf;
+        cloned.parent = this.parent;
+        cloned.child = this.child;
+        cloned.interfaces = this.interfaces;
+        cloned.description = this.description;
+        cloned.example = this.example;
+
+        return cloned;
+    }
 
     @Override
     public int hashCode() {


### PR DESCRIPTION
This references issue 1277 https://github.com/swagger-api/swagger-core/issues/1277. 

Need this to fix an issue with the use of added in SwaggerSpecFilter caused a NullPointerException when using jackson sub types (https://github.com/swagger-api/swagger-core/blob/master/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java#L494).