### PR TITLE
head operation in `Path`

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/HttpMethod.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/HttpMethod.java
@@ -9,5 +9,6 @@ public enum HttpMethod {
     PUT,
     PATCH,
     DELETE,
+    HEAD,
     OPTIONS
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/Path.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Path.java
@@ -184,8 +184,10 @@ public class Path {
         if (patch != null) {
             result.put(HttpMethod.PATCH, patch);
         }
+        if (head != null) {
+            result.put(HttpMethod.HEAD, head);
+        }
         if (options != null) {
-            result.put(HttpMethod.OPTIONS, options);
             result.put(HttpMethod.OPTIONS, options);
         }
 


### PR DESCRIPTION
No `HEAD` in enum `HttpMethod`, no `head` in `Path.getOperationMap()`.
It seems wrong, so I created this PR.

Pls check and merge.

Thanks!