### PR TITLE
 #1424 avoid an endless scan by not scanning resources over a recursive reference

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -164,10 +164,13 @@ public class Reader {
      */
 
     public Swagger read(Class<?> cls) {
-        return read(cls, "", null, false, new String[0], new String[0], new HashMap<String, Tag>(), new ArrayList<Parameter>());
+        return read(cls, "", null, false, new String[0], new String[0], new HashMap<String, Tag>(), new ArrayList<Parameter>(), new HashSet<Class<?>>());
+    }
+    protected Swagger read(Class<?> cls, String parentPath, String parentMethod, boolean readHidden, String[] parentConsumes, String[] parentProduces, Map<String, Tag> parentTags, List<Parameter> parentParameters) {
+        return read(cls, parentPath, parentMethod, readHidden, parentConsumes, parentProduces, parentTags, parentParameters, new HashSet<Class<?>>());
     }
 
-    protected Swagger read(Class<?> cls, String parentPath, String parentMethod, boolean readHidden, String[] parentConsumes, String[] parentProduces, Map<String, Tag> parentTags, List<Parameter> parentParameters) {
+    private Swagger read(Class<?> cls, String parentPath, String parentMethod, boolean readHidden, String[] parentConsumes, String[] parentProduces, Map<String, Tag> parentTags, List<Parameter> parentParameters, Set<Class<?>> scannedResources) {
         Api api = (Api) cls.getAnnotation(Api.class);
         Map<String, SecurityScope> globalScopes = new HashMap<String, SecurityScope>();
 
@@ -309,8 +312,9 @@ public class Reader {
                         apiProduces = both.toArray(new String[both.size()]);
                     }
                     final Class<?> subResource = getSubResource(method);
-                    if (subResource != null) {
-                        read(subResource, operationPath, httpMethod, true, apiConsumes, apiProduces, tags, operation.getParameters());
+                    if (subResource != null && !scannedResources.contains(subResource)) {
+                        scannedResources.add(subResource);
+                        read(subResource, operationPath, httpMethod, true, apiConsumes, apiProduces, tags, operation.getParameters(), scannedResources);
                     }
 
                     // can't continue without a valid http method

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleScannerTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleScannerTest.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Functions;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
+
 import io.swagger.jaxrs.Reader;
 import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.models.ArrayModel;
@@ -49,7 +50,9 @@ import io.swagger.resources.ResourceWithTypedResponses;
 import io.swagger.resources.ResourceWithVoidReturns;
 import io.swagger.resources.SimpleResource;
 import io.swagger.resources.SimpleResourceWithoutAnnotations;
+import io.swagger.resources.SimpleSelfReferencingSubResource;
 import io.swagger.resources.TaggedResource;
+
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -317,6 +320,24 @@ public class SimpleScannerTest {
         assertFalse(param2.getRequired());
         assertNull(param2.getDescription());
     }
+
+    @Test(description = "scan a simple self-referencing subresource")
+    public void scanSimpleSelfReferencingSubResource() {
+        DefaultReaderConfig config = new DefaultReaderConfig();
+        config.setScanAllResources(true);
+        Swagger swagger = new Reader(new Swagger(), config).read(SimpleSelfReferencingSubResource.class);
+
+        assertEquals(swagger.getPaths().size(), 2);
+
+        // these two paths are directly reachable without passing thru a recursive reference
+        Operation retrieve = getGet(swagger, "/sub");
+        assertNotNull(retrieve);
+        assertEquals(retrieve.getParameters().size(), 0);
+
+        retrieve = getGet(swagger, "/sub/recurse2");
+        assertNotNull(retrieve);
+        assertEquals(retrieve.getParameters().size(), 0);
+}
 
     @Test(description = "scan resource with ApiOperation.code() value")
     public void scanResourceWithApiOperationCodeValue() {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleSelfReferencingSubResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleSelfReferencingSubResource.java
@@ -1,0 +1,51 @@
+package io.swagger.resources;
+
+
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+public class SimpleSelfReferencingSubResource {
+
+    @Path("/sub")
+    public SubResource retrieveSubResource() {
+        return new SubResource();
+    }
+
+    public static class SubResource {
+
+        @GET
+        @Produces("application/json")
+        public SubResource retrieve() {
+            return this;
+        }
+
+        @Path("/recurse")
+        public SubResource retrieveSelf() {
+            return this;
+        }
+        @Path("/recurse2")
+        public SubResource2 retrieveSelf2() {
+            return new SubResource2();
+        }
+    }
+
+    public static class SubResource2 {
+
+        @GET
+        @Produces("application/json")
+        public SubResource2 retrieve() {
+            return this;
+        }
+
+        @Path("/recurse")
+        public SubResource2 retrieveSelf() {
+            return this;
+        }
+        @Path("/recurse1")
+        public SubResource retrieveSelf1() {
+            return new SubResource();
+        }
+    }
+}


### PR DESCRIPTION
Hi Ron,
here is a new PR based on our discussion from last week.
The sub resource paths are shown/included along the paths until we see a recursive reference.
thanks.
regards, aki