### PR TITLE
Add support for javax.validation.Pattern

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -39,6 +39,7 @@ import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.lang.annotation.Annotation;
@@ -474,6 +475,13 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 } else {
                     ap.setExclusiveMaximum(!max.inclusive());
                 }
+            }
+        }
+        if (annos.containsKey("javax.validation.constraints.Pattern")) {
+            Pattern pattern = (Pattern) annos.get("javax.validation.constraints.Pattern");
+            if (property instanceof StringProperty) {
+                StringProperty ap = (StringProperty) property;
+                ap.setPattern(pattern.regexp());
             }
         }
     }

--- a/modules/swagger-core/src/test/java/io/swagger/BeanValidatorTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/BeanValidatorTest.java
@@ -28,6 +28,9 @@ public class BeanValidatorTest {
         Assert.assertEquals((int) password.getMinLength(), 6);
         Assert.assertEquals((int) password.getMaxLength(), 20);
 
+        final StringProperty email= (StringProperty) properties.get("email");
+        Assert.assertEquals((String) email.getPattern(), "(.+?)@(.+?)");
+
         final DoubleProperty minBalance = (DoubleProperty) properties.get("minBalance");
         Assert.assertTrue(minBalance.getExclusiveMinimum());
 

--- a/modules/swagger-core/src/test/java/io/swagger/models/BeanValidationsModel.java
+++ b/modules/swagger-core/src/test/java/io/swagger/models/BeanValidationsModel.java
@@ -5,6 +5,7 @@ import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 public class BeanValidationsModel {
@@ -21,6 +22,8 @@ public class BeanValidationsModel {
     protected String password;
 
     protected String passwordHint;
+
+    @Pattern(regexp = "(.+?)@(.+?)")
     protected String email;
 
     @DecimalMin(value = "0.1", inclusive = false)


### PR DESCRIPTION
I don't know if it is valid thing to do but (ie. `ECMA262` regex is little bit different than Java), but until proper conversion will be done, there is no way how to specify regex for swagger from annotations other than simply reuse `@Pattern` annotation.