### PR TITLE
Added support for inheriting parameter annotations on overriden methods.

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/ReflectionUtils.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/ReflectionUtils.java
@@ -183,9 +183,11 @@ public class ReflectionUtils {
             fields.add(field);
             fieldNames.add(field.getName());
         }
-        for (Field field : getDeclaredFields(cls.getSuperclass())) {
-            if (!fieldNames.contains(field.getName())) {
-                fields.add(field);
+        if (cls.getSuperclass() != null) {
+            for (Field field : getDeclaredFields(cls.getSuperclass())) {
+                if (!fieldNames.contains(field.getName())) {
+                    fields.add(field);
+                }
             }
         }
         return fields;

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -146,7 +146,9 @@ public class ReaderTest {
         Swagger swagger = getSwagger(DescendantResource.class);
         Operation overriddenMethodWithTypedParam = getGet(swagger, "/pet/{petId1}");
         assertNotNull(overriddenMethodWithTypedParam);
-        assertEquals(overriddenMethodWithTypedParam.getParameters().get(0).getDescription(), "ID of pet to return child");
+        Parameter firstParameter = overriddenMethodWithTypedParam.getParameters().get(0);
+        assertEquals(firstParameter.getDescription(), "ID of pet to return child");
+        assertEquals(firstParameter.getName(), "petId1");
 
         Operation methodWithoutTypedParam = getGet(swagger, "/pet/{petId2}");
         assertNotNull(methodWithoutTypedParam);
@@ -159,6 +161,10 @@ public class ReaderTest {
 
         Operation methodFromInterface = getGet(swagger, "/pet/{petId5}");
         assertNotNull(methodFromInterface);
+
+        Operation overriddenMethodWithoutParamAnnotation = getGet(swagger, "/pet/{petId8}");
+        assertNotNull(overriddenMethodWithoutParamAnnotation);
+        assertEquals(overriddenMethodWithoutParamAnnotation.getParameters().get(0).getName(), "petId8");
     }
 
     @Test(description = "scan implicit params")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/AbstractResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/AbstractResource.java
@@ -63,6 +63,20 @@ public abstract class AbstractResource<T extends Number> {
         return Response.ok().entity(pet).build();
     }
 
+    @GET
+    @Path("/{petId8}")
+    @ApiOperation(value = "Find pet by ID",
+            notes = "Returns a single pet",
+            response = String.class,
+            authorizations = @Authorization(value = "api_key")
+    )
+    @ApiResponses(value = {@ApiResponse(code = 400, message = "Invalid ID supplied"),
+            @ApiResponse(code = 404, message = "Pet not found")})
+    public Response overridenMethodWithoutParamAnnotations(@PathParam("petId8") Long petId) {
+        String pet = "dog";
+        return Response.ok().entity(pet).build();
+    }
+
     @DELETE
     @Path("/{petId1}")
     @ApiOperation(value = "Deletes a pet")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/DescendantResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/DescendantResource.java
@@ -49,6 +49,10 @@ public class DescendantResource extends AbstractResource<Long> implements Interf
         return super.overriddenMethodWithoutTypedParam(petId);
     }
 
+    public Response overridenMethodWithoutParamAnnotations(Long petId) {
+        return super.overridenMethodWithoutParamAnnotations(petId);
+    }
+
     @Override
     public Response methodFromInterface(@ApiParam(value = "ID of pet to return") Number petId) {
         return null;


### PR DESCRIPTION
One of the things I've run into using Jersey2 is that if I have a method with parameter annotations that is overriden, Swagger ends up giving the parameter a name of "body". This happens even if I also add a meaningful `@ApiParam` annotation to the parameter on the overriding method. You can see this by the following code I added in `ReaderTest.scanOverridenMethod` that fails without these changes:

```
        Swagger swagger = getSwagger(DescendantResource.class);
        Operation overriddenMethodWithTypedParam = getGet(swagger, "/pet/{petId1}");
        assertNotNull(overriddenMethodWithTypedParam);
        Parameter firstParameter = overriddenMethodWithTypedParam.getParameters().get(0);
        assertEquals(firstParameter.getDescription(), "ID of pet to return child");
        assertEquals(firstParameter.getName(), "petId1");
```

The implementation here is similar to the way `Reader.getAnnotation(Method,...` handles looking at overriden methods for method annotations, but in this case, it merges parameter annotations per parameter. It also allows parameter annotations to be overridden by preferring annotations on derived classes, when annotations have the same type.

I also fixed a problem I ran into that I commented on here: https://github.com/swagger-api/swagger-core/commit/818d23f
