### PR TITLE
update felix-plugin to generate the exported version numbers correctly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
         <joda-version>1.2</joda-version>
         <joda-time-version>2.2</joda-time-version>
 
-        <felix-version>2.3.4</felix-version>
+        <felix-version>2.3.7</felix-version>
         <servlet-api-version>2.5</servlet-api-version>
         <jersey-version>1.13</jersey-version>
         <jersey2-version>2.1</jersey2-version>


### PR DESCRIPTION
Hi Ron,
it took a while because it confused me that the maven build of swagger was not automatically adding the exported version as in the other projects that I had. Then I noticed that swagger was using maven-bundle-plugin 2.3.4. whereas the other projects that I had were using a newer version either 2.3.7, 2.4.0, or 2.5.4 and they are all automatically generating the exported version number. After switching swagger to use 2.3.7, the version numbers are now correctly included. So, I needed just a single line change ;-)
regards, aki