### PR TITLE
Fixes Issue #1440: Use nickname, if specified, as operationId

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -714,7 +714,7 @@ public class Reader {
                 return null;
             }
             if (!"".equals(apiOperation.nickname())) {
-                operationId = method.getName();
+                operationId = apiOperation.nickname();
             }
 
             defaultResponseHeaders = parseResponseHeaders(apiOperation.responseHeaders());


### PR DESCRIPTION
Fixes #1440: Nickname, if specified, is now used as operationId