### PR TITLE
Description lost during object property deserialization

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -167,7 +167,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                       properties.put(field.getKey(), property);
                   }
               }
-                ObjectProperty objectProperty = new ObjectProperty(properties);
+                ObjectProperty objectProperty = new ObjectProperty(properties).description(description);
                 objectProperty.setVendorExtensionMap(getVendorExtensions(node));
                 return objectProperty;
             }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/ObjectProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/ObjectProperty.java
@@ -31,6 +31,11 @@ public class ObjectProperty extends AbstractProperty implements Property {
         return this;
     }
 
+    public ObjectProperty description(String description) {
+        this.setDescription(description);
+        return this;
+    }
+
     public Map<String, Property> getProperties(){
       return this.properties;
     }


### PR DESCRIPTION
### Issue

When deserializing a Swagger definition containing an inline schema, the said schema's property is not set in the object `ObjectProperty`. 
Extract from my definition: 

```json
"paths": {
  "/path1": {
    "get": {
      "summary": "Swagger.paths.*.*.summary",
      "responses": {
        "default": {
          "description": "Swagger.paths.*.*.responses.*.description",
          "schema": {
            "type": "object",
            "description": "Swagger.paths.*.*.responses.*.schema.description",
            "properties": {
              "property1": {
                "type": "string",
                "description": "Swagger.Paths.*.*.responses.*.schema.properties.*.description"
              }
            }
          }
        }
      }
    }
  }
}
```

Which means the following: 

```java
Swagger swagger = Json.mapper().readValue(myFile, Swagger.class);
System.out.println(swagger.getPath("/path1").getGet().getResponses().get("default").getSchema().getDescription());
```

Outputs null.