### PR TITLE
Add description field in security definitions

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/auth/AbstractSecuritySchemeDefinition.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/auth/AbstractSecuritySchemeDefinition.java
@@ -11,6 +11,8 @@ public abstract class AbstractSecuritySchemeDefinition implements SecurityScheme
 
     private final Map<String, Object> vendorExtensions = new HashMap<String, Object>();
 
+    private String description;
+
     @JsonAnyGetter
     public Map<String, Object> getVendorExtensions() {
         return vendorExtensions;
@@ -23,19 +25,49 @@ public abstract class AbstractSecuritySchemeDefinition implements SecurityScheme
         }
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+    public String getDescription() {
+        return description;
+    }
 
-        AbstractSecuritySchemeDefinition that = (AbstractSecuritySchemeDefinition) o;
-
-        return !(vendorExtensions != null ? !vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions != null);
-
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     @Override
     public int hashCode() {
-        return vendorExtensions != null ? vendorExtensions.hashCode() : 0;
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((description == null) ? 0 : description.hashCode());
+        result = prime * result + ((vendorExtensions == null) ? 0 : vendorExtensions.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        AbstractSecuritySchemeDefinition other = (AbstractSecuritySchemeDefinition) obj;
+        if (description == null) {
+            if (other.description != null) {
+                return false;
+            }
+        } else if (!description.equals(other.description)) {
+            return false;
+        }
+        if (vendorExtensions == null) {
+            if (other.vendorExtensions != null) {
+                return false;
+            }
+        } else if (!vendorExtensions.equals(other.vendorExtensions)) {
+            return false;
+        }
+        return true;
     }
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/auth/SecuritySchemeDefinition.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/auth/SecuritySchemeDefinition.java
@@ -15,4 +15,8 @@ public interface SecuritySchemeDefinition {
 
     @JsonAnySetter
     void setVendorExtension(String name, Object value);
+
+    String getDescription();
+
+    void setDescription(String description);
 }


### PR DESCRIPTION
#### Issue

The field description of [security definitions](https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#fixed-fields-15) is missing from the Java POJO, thus lost during deserialization. 

### Test

Tested with Swagger containing: 

```json
"securityDefinitions": {
  "securityDefinition1": {
    "type": "basic",
    "description": "Swagger.securityDefinitions.*.description"
  }
}
```

And main method: 

```java
Swagger swagger = Json.mapper().readValue(file.toFile(), Swagger.class);
System.out.println(swagger.getSecurityDefinitions().get("securityDefinition1").getDescription());
```

Output: `Swagger.securityDefinitions.*.description`