### PR TITLE
Add support for specifying vendor extensions on ref props

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -145,7 +145,9 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
 
         JsonNode detailNode = node.get("$ref");
         if (detailNode != null) {
-            return new RefProperty(detailNode.asText()).description(description);
+            RefProperty refProperty = new RefProperty(detailNode.asText()).description(description);
+            refProperty.setVendorExtensionMap(getVendorExtensions(node));
+            return refProperty;
         }
 
         if (ObjectProperty.isType(type)) {

--- a/modules/swagger-core/src/test/java/io/swagger/ObjectPropertyTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ObjectPropertyTest.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 import io.swagger.util.Json;
 
@@ -47,4 +48,27 @@ public class ObjectPropertyTest {
         assertNotNull(op.getVendorExtensions().get("x-foo"));
         assertEquals(op.getVendorExtensions().get("x-foo"), "vendor x");
     }
+
+  @Test (description = "convert a model with ref properties keeps vendor extensions")
+  public void readModelWithRefProperty() throws IOException {
+    String json = "{" +
+        "   \"properties\":{" +
+        "      \"id\":{" +
+        "         \"type\":\"string\"" +
+        "      }," +
+        "      \"someObject\":{" +
+        "         \"$ref\":\"whatever\"," +
+        "        \"x-foo\": \"vendor x\"" +
+        "         }" +
+        "      }" +
+        "   }" +
+        "}";
+
+    ModelImpl model = Json.mapper().readValue(json, ModelImpl.class);
+
+    Property p = model.getProperties().get("someObject");
+    assertTrue(p instanceof RefProperty);
+    assertTrue(p.getVendorExtensions() != null);
+    assertTrue(p.getVendorExtensions().containsKey("x-foo"));
+  }
 }


### PR DESCRIPTION
I hope you don't mind this sudden PR. 

I'm using the swagger spec 2.0 with a version of my own custom code generation.  There are situations where I want to add vendor extensions on a $ref object.

For example,

```javascript
definitions:
  Foo:
    type: object
    properties:
      myRefProp:
        x-my-special-meta-annotation: true
        $ref: '#/definitions/Bar'
```
It looks like currently the vendor extensions aren't supported on $ref properties.

This commit basically adds that support, hope you can approve.

Thanks.