### PR TITLE
Fix NPE with genericRef in RefProperty

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
@@ -58,12 +58,20 @@ public class RefProperty extends AbstractProperty implements Property {
 
     @JsonIgnore
     public RefFormat getRefFormat() {
-        return this.genericRef.getFormat();
+        if (genericRef != null) {
+            return this.genericRef.getFormat();
+        } else {
+            return null;
+        }
     }
 
     @JsonIgnore
     public String getSimpleRef() {
-        return genericRef.getSimpleRef();
+        if (genericRef != null) {
+            return this.genericRef.getSimpleRef();
+        } else {
+            return null;
+        }
     }
 
     @Override


### PR DESCRIPTION
genericRef can be null in RefProperty so add checking for null to avoid NPE

Ref: https://github.com/swagger-api/swagger-codegen/issues/1267