### PR TITLE
 #1244 use reflection to support BeanParam

### DIFF
--- a/modules/swagger-jaxrs/pom.xml
+++ b/modules/swagger-jaxrs/pom.xml
@@ -91,6 +91,7 @@
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
         </dependency>
+        <!-- built with jsr311 but compatible with jsr311 or jsr399 in runtime -->
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
@@ -3,6 +3,7 @@ package io.swagger.jaxrs;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.ext.AbstractSwaggerExtension;
 import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtensions;
 import io.swagger.models.parameters.CookieParameter;
 import io.swagger.models.parameters.FormParameter;
 import io.swagger.models.parameters.HeaderParameter;
@@ -13,12 +14,21 @@ import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
+import io.swagger.util.Json;
+import io.swagger.util.ParameterProcessor;
 
 import javax.ws.rs.CookieParam;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -27,6 +37,17 @@ import java.util.List;
 import java.util.Set;
 
 public class DefaultParameterExtension extends AbstractSwaggerExtension {
+    // make jaxrs 2.0 classes optional
+    private static Class<?> CLASS_BEAN_PARAM;
+    static {
+        try {
+            CLASS_BEAN_PARAM = Class.forName("javax.ws.rs.BeanParam", true, DefaultParameterExtension.class.getClassLoader());
+        } catch (Throwable t) {
+            //ignore and assume no jsr399-api on classpath
+        }
+    }
+
+    final ObjectMapper mapper = Json.mapper();
 
     @Override
     public List<Parameter> extractParameters(List<Annotation> annotations, Type type, Set<Type> typesToSkip, Iterator<SwaggerExtension> chain) {
@@ -83,6 +104,8 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
                     fp.setProperty(schema);
                 }
                 parameter = fp;
+            } else {
+                handleAdditionalAnnotation(parameters, annotation, type, typesToSkip);
             }
         }
         if (parameter != null) {
@@ -90,6 +113,67 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
         }
 
         return parameters;
+    }
+
+    /**
+     * Adds additional annotation processing support 
+     * 
+     * @param parameters
+     * @param annotation
+     * @param type
+     * @param typesToSkip
+     */
+    private void handleAdditionalAnnotation(List<Parameter> parameters, Annotation annotation, 
+        final Type type, Set<Type> typesToSkip) {
+        if (CLASS_BEAN_PARAM != null && CLASS_BEAN_PARAM.isAssignableFrom(annotation.getClass())) {
+            // Use Jackson's logic for processing Beans
+            final BeanDescription beanDesc = mapper.getSerializationConfig().introspect(constructType(type));
+            final List<BeanPropertyDefinition> properties = beanDesc.findProperties();
+
+            for (final BeanPropertyDefinition propDef : properties) {
+                final AnnotatedField field = propDef.getField();
+                final AnnotatedMethod setter = propDef.getSetter();
+                final List<Annotation> paramAnnotations = new ArrayList<Annotation>();
+                final Iterator<SwaggerExtension> extensions = SwaggerExtensions.chain();
+                Type paramType = null;
+
+                // Gather the field's details
+                if (field != null) {
+                    paramType = field.getGenericType();
+
+                    for (final Annotation fieldAnnotation : field.annotations()) {
+                        if (!paramAnnotations.contains(fieldAnnotation)) {
+                            paramAnnotations.add(fieldAnnotation);
+                        }
+                    }
+                }
+
+                // Gather the setter's details but only the ones we need
+                if (setter != null) {
+                    // Do not set the param class/type from the setter if the values are already identified
+                    if (paramType == null) {
+                        paramType = setter.getGenericParameterTypes() != null ? setter.getGenericParameterTypes()[0] : null;
+                    }
+
+                    for (final Annotation fieldAnnotation : setter.annotations()) {
+                        if (!paramAnnotations.contains(fieldAnnotation)) {
+                            paramAnnotations.add(fieldAnnotation);
+                        }
+                    }
+                }
+
+                // Re-process all Bean fields and let the default swagger-jaxrs/swagger-jersey-jaxrs processors do their thing
+                List<Parameter> extracted =
+                        extensions.next().extractParameters(paramAnnotations, paramType, typesToSkip, extensions);
+
+                // since downstream processors won't know how to introspect @BeanParam, process here
+                for (Parameter param : extracted) {
+                    if (ParameterProcessor.applyAnnotations(null, param, paramType, paramAnnotations) != null) {
+                        parameters.add(param);
+                    }
+                }
+            }
+        }
     }
 
     @Override

--- a/modules/swagger-jersey2-jaxrs/src/main/java/io/swagger/jersey/SwaggerJersey2Jaxrs.java
+++ b/modules/swagger-jersey2-jaxrs/src/main/java/io/swagger/jersey/SwaggerJersey2Jaxrs.java
@@ -41,55 +41,8 @@ public class SwaggerJersey2Jaxrs extends AbstractSwaggerExtension {
             return parameters;
         }
         for (final Annotation annotation : annotations) {
-            if (annotation instanceof BeanParam) {
-                // Use Jackson's logic for processing Beans
-                final BeanDescription beanDesc = mapper.getSerializationConfig().introspect(constructType(type));
-                final List<BeanPropertyDefinition> properties = beanDesc.findProperties();
-
-                for (final BeanPropertyDefinition propDef : properties) {
-                    final AnnotatedField field = propDef.getField();
-                    final AnnotatedMethod setter = propDef.getSetter();
-                    final List<Annotation> paramAnnotations = new ArrayList<Annotation>();
-                    final Iterator<SwaggerExtension> extensions = SwaggerExtensions.chain();
-                    Type paramType = null;
-
-                    // Gather the field's details
-                    if (field != null) {
-                        paramType = field.getGenericType();
-
-                        for (final Annotation fieldAnnotation : field.annotations()) {
-                            if (!paramAnnotations.contains(fieldAnnotation)) {
-                                paramAnnotations.add(fieldAnnotation);
-                            }
-                        }
-                    }
-
-                    // Gather the setter's details but only the ones we need
-                    if (setter != null) {
-                        // Do not set the param class/type from the setter if the values are already identified
-                        if (paramType == null) {
-                            paramType = setter.getGenericParameterTypes() != null ? setter.getGenericParameterTypes()[0] : null;
-                        }
-
-                        for (final Annotation fieldAnnotation : setter.annotations()) {
-                            if (!paramAnnotations.contains(fieldAnnotation)) {
-                                paramAnnotations.add(fieldAnnotation);
-                            }
-                        }
-                    }
-
-                    // Re-process all Bean fields and let the default swagger-jaxrs/swagger-jersey-jaxrs processors do their thing
-                    List<Parameter> extracted =
-                            extensions.next().extractParameters(paramAnnotations, paramType, typesToSkip, extensions);
-
-                    // since downstream processors won't know how to introspect @BeanParam, process here
-                    for (Parameter param : extracted) {
-                        if (ParameterProcessor.applyAnnotations(null, param, paramType, paramAnnotations) != null) {
-                            parameters.add(param);
-                        }
-                    }
-                }
-            } else if (annotation instanceof FormDataParam) {
+            // just handle the jersey specific annotation
+            if (annotation instanceof FormDataParam) {
                 FormDataParam fd = (FormDataParam) annotation;
                 if (java.io.InputStream.class.isAssignableFrom(constructType(type).getRawClass())) {
                     final Parameter param = new FormParameter().type("file").name(fd.value());

--- a/pom.xml
+++ b/pom.xml
@@ -218,6 +218,7 @@
                         <exclude>**/io/swagger/converter/ModelConverters.*</exclude>
 
                         <!-- JAXRS -->
+                        <exclude>**/io/swagger/jaxrs/DefaultParameterExtension.*</exclude>
                         <exclude>**/io/swagger/jaxrs/json/JacksonJsonProvider.*</exclude>
                         <exclude>**/io/swagger/jaxrs/listing/ApiListingResource.*</exclude>
                         <exclude>**/io/swagger/jaxrs/listing/SwaggerSerializers.*</exclude>


### PR DESCRIPTION
Hi,
I created a PR based on the current 1.5.5-SNAPSHOT.

I moved the part of jsr-399 specific handling code from swagger-jersey2-jaxrs to swagger-jaxrs using reflection and the relevant unit tests are still executed in swagger-jersey2-jaxrs as jsr-399 is not linked to swagger-jaxrs.

And I verified the updated swagger-jaxrs using cxf in standalone and in osgi using BeanParam.

I would appreciate if you could look at it and merge it if you you see no objection.

Thanks.
Regards, aki