### PR TITLE
Default value returns correct type

### DIFF
--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleScannerTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleScannerTest.java
@@ -221,7 +221,7 @@ public class SimpleScannerTest {
 
         PathParameter param0 = (PathParameter) params.get(0);
         assertEquals(param0.getName(), "id");
-        assertEquals(param0.getDefaultValue(), "5");
+        assertEquals(param0.getDefaultValue(), Long.valueOf("5"));
         assertEquals(param0.getMinimum(), 0.0);
         assertEquals(param0.getMaximum(), 10.0);
 

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleScannerTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleScannerTest.java
@@ -221,7 +221,7 @@ public class SimpleScannerTest {
 
         PathParameter param0 = (PathParameter) params.get(0);
         assertEquals(param0.getName(), "id");
-        assertEquals(param0.getDefaultValue(), Long.valueOf("5"));
+        assertEquals(param0.getDefaultValue(), 5L);
         assertEquals(param0.getMinimum(), 0.0);
         assertEquals(param0.getMaximum(), 10.0);
 

--- a/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/ScannerTest.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/ScannerTest.java
@@ -50,11 +50,11 @@ public class ScannerTest {
         final List<Parameter> params = getParameters(swagger, "/bean/{id}");
 
         final HeaderParameter headerParam1 = (HeaderParameter) params.get(0);
-        assertEquals(headerParam1.getDefaultValue(), "1");
+        assertEquals(headerParam1.getDefaultValue(), Long.valueOf("1"));
         assertEquals(headerParam1.getName(), "test order annotation 1");
 
         final HeaderParameter headerParam2 = (HeaderParameter) params.get(1);
-        assertEquals(headerParam2.getDefaultValue(), "2");
+        assertEquals(headerParam2.getDefaultValue(), Long.valueOf("2"));
         assertEquals(headerParam2.getName(), "test order annotation 2");
 
         final QueryParameter priority1 = (QueryParameter) params.get(2);

--- a/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/ScannerTest.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/ScannerTest.java
@@ -50,11 +50,11 @@ public class ScannerTest {
         final List<Parameter> params = getParameters(swagger, "/bean/{id}");
 
         final HeaderParameter headerParam1 = (HeaderParameter) params.get(0);
-        assertEquals(headerParam1.getDefaultValue(), Long.valueOf("1"));
+        assertEquals(headerParam1.getDefaultValue(), 1L);
         assertEquals(headerParam1.getName(), "test order annotation 1");
 
         final HeaderParameter headerParam2 = (HeaderParameter) params.get(1);
-        assertEquals(headerParam2.getDefaultValue(), Long.valueOf("2"));
+        assertEquals(headerParam2.getDefaultValue(), 2L);
         assertEquals(headerParam2.getName(), "test order annotation 2");
 
         final QueryParameter priority1 = (QueryParameter) params.get(2);

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
@@ -3,16 +3,14 @@ package io.swagger.models.parameters;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.BaseIntegerProperty;
 import io.swagger.models.properties.BooleanProperty;
 import io.swagger.models.properties.DecimalProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -144,8 +142,8 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
         }
     }
 
-    public String getDefaultValue() {
-        return defaultValue;
+    public Object getDefaultValue() {
+        return getDefault();
     }
 
     public void setDefaultValue(String defaultValue) {

--- a/modules/swagger-models/src/test/java/io/swagger/models/parameters/DefaultValueTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/parameters/DefaultValueTest.java
@@ -1,0 +1,69 @@
+package io.swagger.models.parameters;
+
+import io.swagger.models.properties.BaseIntegerProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.DecimalProperty;
+import io.swagger.models.properties.EmailProperty;
+import io.swagger.models.properties.FloatProperty;
+import io.swagger.models.properties.LongProperty;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+public class DefaultValueTest {
+
+    @Test
+    public void booleanTypeReturnsDefaultValueAsBoolean() {
+        final QueryParameter prop1 = new QueryParameter();
+        prop1.setDefaultValue("true");
+        prop1.setType(BooleanProperty.TYPE);
+
+        assertTrue(prop1.getDefaultValue() instanceof Boolean);
+    }
+
+    @Test
+    public void decimalTypeReturnsDefaultValueAsDouble() {
+        final QueryParameter prop1 = new QueryParameter();
+        prop1.setDefaultValue("1.2");
+        prop1.setType(DecimalProperty.TYPE);
+
+        assertTrue(prop1.getDefaultValue() instanceof Double);
+    }
+
+    @Test
+    public void floatTypeReturnsDefaultValueAsDouble() {
+        final QueryParameter prop1 = new QueryParameter();
+        prop1.setDefaultValue("1.2");
+        prop1.setType(FloatProperty.TYPE);
+
+        assertTrue(prop1.getDefaultValue() instanceof Double);
+    }
+
+    @Test
+    public void integerTypeReturnsDefaultValueAsLong() {
+        final QueryParameter prop1 = new QueryParameter();
+        prop1.setDefaultValue("1");
+        prop1.setType(BaseIntegerProperty.TYPE);
+
+        assertTrue(prop1.getDefaultValue() instanceof Long);
+    }
+
+    @Test
+    public void longTypeReturnsDefaultValueAsLong() {
+        final QueryParameter prop1 = new QueryParameter();
+        prop1.setDefaultValue("1");
+        prop1.setType(LongProperty.TYPE);
+
+        assertTrue(prop1.getDefaultValue() instanceof Long);
+    }
+
+    @Test
+    public void emailTypeReturnsDefaultValueAsString() {
+        final QueryParameter prop1 = new QueryParameter();
+        prop1.setDefaultValue("email@abc.com");
+        prop1.setType(EmailProperty.TYPE);
+
+        assertTrue(prop1.getDefaultValue() instanceof String);
+    }
+
+}


### PR DESCRIPTION
Currently parameter default value is always returned as String regardless of its type. So, if I generate swagger definition from ```@DefaultValue("true") @QueryParam("async") boolean async``` it will generate the definition with boolean value as String       ``` - name: "async"
        in: "query"
        ... default: "true"  ``` which is wrong.

This pr changes it to return ```getDefault()``` instead of String value, which returns the correct type instead of String.