### PR TITLE
Fix deserialization of Swagger with API-level vendor extensions

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/Swagger.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Swagger.java
@@ -391,7 +391,7 @@ public class Swagger {
     @JsonAnySetter
     public void setVendorExtension(String name, Object value) {
         if (name.startsWith("x-")) {
-            vendorExtensions.put(name, value);
+            vendorExtension(name, value);
         }
     }
 


### PR DESCRIPTION
## Issue

When deserializing a Swagger with API level vendor extensions, I get an NPE on `.swagger.vendorExtensions`.

The field being null by default, there should be an NPE check when trying to add an element to it.

## How to reproduce

Deserialize the following Swagger.

```java
Yaml.mapper().readValue(pathToTheSwaggerFile, Swagger.class);
```

```yaml
---
swagger: "2.0"
info:
  version: "1.0"
  title: "Protect-Policy-Summary"
  contact: {}
host: "localhost:8501"
basePath: "/api"
tags:
- name: "{policyNumber}"
schemes:
- "http"
paths:
  /{policyNumber}:
    get:
      tags:
      - "{policyNumber}"
      summary: "Retrieve Protect Policy-level data"
      description: "Retrieve Protect Policy-level data"
      operationId: "getPolicyNumber"
      consumes: []
      produces:
      - "application/json"
      parameters:
      - name: "policyNumber"
        in: "path"
        required: true
        type: "string"
      - name: "brand"
        in: "query"
        description: "brand"
        required: false
        type: "string"
      responses:
        200:
          description: "Successful Policy-level data retrieval"
x-raml-documentation:
- title: "Protect Policy Summary"
  content: "System API to handle Protect Policy-level data\n"
```

## Stack trace

```
Exception in thread "main" com.fasterxml.jackson.databind.JsonMappingException: N/A (through reference chain: io.swagger.models.Swagger["x-raml-documentation"])
	at com.fasterxml.jackson.databind.deser.SettableAnyProperty._throwAsIOE(SettableAnyProperty.java:195)
	at com.fasterxml.jackson.databind.deser.SettableAnyProperty.set(SettableAnyProperty.java:153)
	at com.fasterxml.jackson.databind.deser.SettableAnyProperty.deserializeAndSet(SettableAnyProperty.java:125)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1278)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:243)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:118)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3066)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2115)
	at fr.quilici.tests.TestDivers.main(TestDivers.java:34)
Caused by: java.lang.NullPointerException
	at io.swagger.models.Swagger.setVendorExtension(Swagger.java:377)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at com.fasterxml.jackson.databind.deser.SettableAnyProperty.set(SettableAnyProperty.java:151)
	... 7 more
```