### PR TITLE
Include responses from a method's declared exceptions

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponses.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponses.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  *
  * @see ApiResponse
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiResponses {
     /**

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -239,6 +239,31 @@ public class ReaderTest {
         assertEquals(name.getDescription(), "The books name");
     }
 
+    @Test(description = "scan resource with annotated exception")
+    public void scanDeclaredExceptions() {
+        Swagger swagger = getSwagger(ResourceWithCustomException.class);
+        assertNotNull(swagger);
+
+        Operation operation = getGet(swagger, "/{id}");
+        assertEquals(operation.getResponses().size(), 3);
+        assertTrue(operation.getResponses().containsKey("200"));
+        assertTrue(operation.getResponses().containsKey("400"));
+        assertTrue(operation.getResponses().containsKey("404"));
+    }
+
+    @Test(description = "scan resource with annotated exception")
+    public void scanDeclaredExceptionsAndCombineWithMethodResponses() {
+        Swagger swagger = getSwagger(ResourceWithCustomException.class);
+        assertNotNull(swagger);
+
+        Operation operation = getPut(swagger, "/{id}");
+        assertEquals(operation.getResponses().size(), 4);
+        assertTrue(operation.getResponses().containsKey("200"));
+        assertTrue(operation.getResponses().containsKey("400"));
+        assertTrue(operation.getResponses().containsKey("404"));
+        assertTrue(operation.getResponses().containsKey("409"));
+    }
+
     private Swagger getSwagger(Class<?> cls) {
         return new Reader(new Swagger()).read(cls);
     }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/CustomException.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/CustomException.java
@@ -1,0 +1,12 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.models.NotFoundModel;
+
+@ApiResponses({
+        @ApiResponse(code = 400, message = "Invalid ID", response = NotFoundModel.class),
+        @ApiResponse(code = 404, message = "object not found")})
+public class CustomException extends RuntimeException {
+
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithCustomException.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithCustomException.java
@@ -1,0 +1,56 @@
+package io.swagger.resources;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.models.Sample;
+
+@Api(value = "/basicWithException", description = "Basic resource")
+@Produces({"application/xml"})
+public class ResourceWithCustomException {
+
+    @GET
+    @Path("/{id}")
+    @ApiOperation(value = "Get object by ID",
+            notes = "No details provided",
+            response = Sample.class,
+            position = 0)
+    public Response getTest(
+            @ApiParam(value = "sample param data", required = true, allowableValues = "range[0,10]")
+            @DefaultValue("5")
+            @PathParam("id") String id,
+            @QueryParam("limit") Integer limit
+    ) throws CustomException {
+        return Response.ok().build();
+    }
+
+
+    @PUT
+    @Path("/{id}")
+    @ApiOperation(value = "Update object by ID",
+            notes = "No details provided",
+            response = Sample.class,
+            position = 0)
+    @ApiResponses({
+            @ApiResponse(code = 409, message = "Conflict")
+    })
+    public Response putTest(
+            @ApiParam(value = "sample param data", required = true, allowableValues = "range[0,10]")
+            @DefaultValue("5")
+            @PathParam("id") String id,
+            Sample sample
+    ) throws CustomException {
+        return Response.ok().build();
+    }
+
+}


### PR DESCRIPTION
A common pattern in JAX-RS applications is to have resources throw
custom exceptions, and configure an ExceptionMapper to map them to a
specific HTTP status code.

This pattern does not mesh well with how swagger collects the APIs
info: swagger expects the developer to declare for every method the
list of possible responses, regardless of the exceptions it declares to
throw.

```java
@PUT
@ApiOperation("desc")
@ApiResponses({
        @ApiResponse(code = 204, message = "Everything is awesome")
        @ApiResponse(code = 500, message = "Internal error")
        @ApiResponse(code = 502, message = "Upstream error")
})
@Path("/op")
void operation(Params params) throws UpstreamServerError, InternalServerError;
```

This pull request proposes to also check the exceptions declared in the
throws clause of a method for `@ApiResponse` annotations, and include
them in the method possible responses.

So that the previous example would become:

```java
 @PUT
 @ApiOperation("desc")
 @ApiResponses({
        @ApiResponse(code = 204, message = "Everything is awesome")
 })
 @Path("/op")
 void operation(Params params) throws UpstreamServerError, InternalServerError;
 ```

By moving the other response codes to the exceptions:

```java
@ApiResponses({
       @ApiResponse(code = 502, message = "Upstream error")
}
public class UpstreamServerError extends RuntimeException {
  :
}
```

In my particular case, I have an app with hundreds of resource methods
which already declare the possible exceptions they throw.
This improvement would save me hundreds and hundreds of repetitions of
return statuses.