### PR TITLE
fixes #1526

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
@@ -67,9 +67,6 @@ public class ParameterProcessor {
                     p.setType(param.getDataType());
                 }
             }
-            if (StringUtils.isNotEmpty(param.getDataType())) {
-                p.setType(param.getDataType());
-            }
             if (helper.getMinItems() != null) {
                 p.setMinItems(helper.getMinItems());
             }

--- a/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
@@ -67,8 +67,8 @@ public class ParameterProcessor {
                     p.setType(param.getDataType());
                 }
             }
-            if (StringUtils.isNotEmpty(param.getExample())) {
-                p.setType(param.getExample());
+            if (StringUtils.isNotEmpty(param.getDataType())) {
+                p.setType(param.getDataType());
             }
             if (helper.getMinItems() != null) {
                 p.setMinItems(helper.getMinItems());

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithImplicitFileParam.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithImplicitFileParam.java
@@ -13,7 +13,7 @@ public class ResourceWithImplicitFileParam {
     @POST
     @Path("/testString")
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "sort", paramType = "form", dataType = "java.io.File", required = false, value = "file to upload")
+      @ApiImplicitParam(name = "sort", paramType = "form", dataType = "java.io.File", required = false, value = "file to upload")
     })
     @ApiOperation("Test operation with implicit parameters")
     public void testImplicitFileParam() {


### PR DESCRIPTION
from https://github.com/swagger-api/swagger-core/commit/62c100f33a54d7688e859cd011abb89a907e02ef, it appears the example is setting the type parameter, which is obviously wrong.