### PR TITLE
Fix serialization/deserialization of 'required' property on ObjectProperty

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/properties/PropertySerializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/properties/PropertySerializationTest.java
@@ -14,6 +14,7 @@ import io.swagger.models.properties.FloatProperty;
 import io.swagger.models.properties.IntegerProperty;
 import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.MapProperty;
+import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
@@ -293,4 +294,21 @@ public class PropertySerializationTest {
         assertEquals(m.writeValueAsString(p), json);
     }
 
+    @Test(description = "it should serialize an object property with required set")
+    public void serializeObjectPropertyWithRequiredProperties() throws IOException {
+        final ObjectProperty p = new ObjectProperty()
+                .property("stringProperty", new StringProperty()
+                        .required(true));
+        final String json = "{\"type\":\"object\",\"properties\":{\"stringProperty\":{\"type\":\"string\"}},\"required\":[\"stringProperty\"]}";
+        assertEquals(m.writeValueAsString(p), json);
+    }
+
+    @Test(description = "it should deserialize an object property with required set")
+    public void deserializeObjectPropertyWithRequiredProperties() throws IOException {
+        final ObjectProperty p = new ObjectProperty()
+                .property("stringProperty", new StringProperty()
+                        .required(true));
+        final String json = "{\"type\":\"object\",\"properties\":{\"stringProperty\":{\"type\":\"string\"}},\"required\":[\"stringProperty\"]}";
+        assertEquals(p, m.readValue(json, ObjectProperty.class));
+    }
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/ObjectProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/ObjectProperty.java
@@ -1,8 +1,15 @@
 package io.swagger.models.properties;
 
 import io.swagger.models.Xml;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
 public class ObjectProperty extends AbstractProperty implements Property {
     public static final String TYPE = "object";
@@ -82,6 +89,37 @@ public class ObjectProperty extends AbstractProperty implements Property {
 
     public Map<String, Property> getProperties(){
       return this.properties;
+    }
+
+    @JsonGetter("required")
+    public List<String> getRequiredProperties() {
+        List<String> output = new ArrayList<String>();
+        if (properties != null) {
+            for (String key : properties.keySet()) {
+                Property prop = properties.get(key);
+                if (prop != null && prop.getRequired()) {
+                    output.add(key);
+                }
+            }
+        }
+        Collections.sort(output);
+        if (output.size() > 0) {
+            return output;
+        } else {
+            return null;
+        }
+    }
+
+    @JsonSetter("required")
+    public void setRequiredProperties(List<String> required) {
+        if (properties != null) {
+            for (String s : required) {
+                Property p = properties.get(s);
+                if (p != null) {
+                    p.setRequired(true);
+                }
+            }
+        }
     }
 
     public void setProperties(Map<String, Property> properties){

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -95,6 +95,7 @@ public class PropertyBuilder {
         TYPE("type"),
         FORMAT("format"),
         READ_ONLY("readOnly"),
+        REQUIRED("required"),
         VENDOR_EXTENSIONS("vendorExtensions");
 
         private String propertyName;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
@@ -108,6 +108,11 @@ public class StringProperty extends AbstractProperty implements Property {
         return this;
     }
 
+    public StringProperty required(boolean required) {
+        this.setRequired(required);
+        return this;
+    }
+
     public List<String> getEnum() {
         return _enum;
     }


### PR DESCRIPTION
### Scope

Handle property _required_ of `ObjectProperty` during serialization and deserialization. 

### Issues before dev

#### Serialization

Running the code below: 

```java
ModelImpl model = new ModelImpl()
                .property("prop",
                        new ObjectProperty()
                                .name("Prop")
                                .required(true)
                                .property("stringProperty", new StringProperty()
                                        .required(true)
                                        .title("stringProperty")));
System.out.println(Json.pretty().writeValueAsString(model););
```

Was outputting:

```json
{
  "required" : [ "prop" ],
  "properties" : {
    "prop" : {
      "type" : "object",
      "properties" : {
        "stringProperty" : {
          "type" : "string",
          "title" : "stringProperty"
        }
      }
    }
  }
}
```

The _required_ field of the `ObjectProperty` was ignored.

#### Deserialization

When deserializing the following JSON: 

```json
{
  "required" : [ "prop" ],
  "properties" : {
    "prop" : {
      "type" : "object",
      "properties" : {
        "stringProperty" : {
          "type" : "string",
          "title" : "stringProperty"
        }
      },
      "required" : [ "stringProperty" ]
    }
  }
}
```

The code below was outputting _true:false_ instead of _true:true_: 

```java
Model model = Json.mapper().readValue(jsonAsString), ModelImpl.class);
Property property = model.getProperties().get("prop");
System.out.println(property.getRequired() + ":" + 
    ((ObjectProperty) property).getProperties().get("stringProperty").getRequired());
```

### Result after dev

The following code: 

```java
public static void main(String[] args) throws Exception {
    String modelAsJson = serializationTest();
    deserializationTest(modelAsJson);
}

private static String serializationTest() throws Exception {
    ModelImpl model = new ModelImpl()
            .property("prop",
                    new ObjectProperty()
                            .name("Prop")
                            .required(true)
                            .property("stringProperty", new StringProperty()
                                    .required(true)
                                    .title("stringProperty")));

    String modelAsJson = pretty().writeValueAsString(model);
    out.println(format("Serialized model: %s", modelAsJson));
    return modelAsJson;
}

private static void deserializationTest(String propertyAsJson) throws Exception {
    ModelImpl model = mapper().readValue(propertyAsJson, ModelImpl.class);
    Property property = model.getProperties().get("prop");
    out.println(format("Deserialized model: .prop.required = %s", property.getRequired()));
    out.println(format("Deserialized model: .prop.stringProperty.required = %s",
            ((ObjectProperty) property).getProperties().get("stringProperty").getRequired()));
}
```

Outputs: 

```
Serialized model: {
  "required" : [ "prop" ],
  "properties" : {
    "prop" : {
      "type" : "object",
      "properties" : {
        "stringProperty" : {
          "type" : "string",
          "title" : "stringProperty"
        }
      },
      "required" : [ "stringProperty" ]
    }
  }
}
Deserialized model: .prop.required = true
Deserialized model: .prop.stringProperty.required = true
```