### PR TITLE
Add 'title' attribute during deserialization of non-primitive properties

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -168,13 +168,15 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
 
     Property propertyFromNode(JsonNode node) {
         final String type = getString(node, PropertyBuilder.PropertyId.TYPE);
+        final String title = getString(node, PropertyBuilder.PropertyId.TITLE);
         final String format = getString(node, PropertyBuilder.PropertyId.FORMAT);
-        final Xml xml = getXml(node);
 
         String description = getString(node, PropertyBuilder.PropertyId.DESCRIPTION);
         JsonNode detailNode = node.get("$ref");
         if (detailNode != null) {
-            return new RefProperty(detailNode.asText()).description(description);
+            return new RefProperty(detailNode.asText())
+                    .description(description)
+                    .title(title);
         }
 
         if (ObjectProperty.isType(type) || node.get("properties") != null) {
@@ -182,7 +184,9 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
             if (detailNode != null && detailNode.getNodeType().equals(JsonNodeType.OBJECT)) {
                 Property items = propertyFromNode(detailNode);
                 if (items != null) {
-                    MapProperty mapProperty = new MapProperty(items).description(description);
+                    MapProperty mapProperty = new MapProperty(items)
+                            .description(description)
+                            .title(title);
                     mapProperty.setVendorExtensionMap(getVendorExtensions(node));
                     return mapProperty;
                 }
@@ -209,7 +213,9 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                 }
 
                 if("array".equals(detailNodeType)) {
-                    ArrayProperty ap = new ArrayProperty().description(description);
+                    ArrayProperty ap = new ArrayProperty()
+                            .description(description)
+                            .title(title);
                     ap.setDescription(description);
 
                     if(properties.keySet().size() == 1) {
@@ -219,7 +225,9 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                     ap.setVendorExtensionMap(getVendorExtensions(node));
                     return ap;
                 }
-                ObjectProperty objectProperty = new ObjectProperty(properties).description(description);
+                ObjectProperty objectProperty = new ObjectProperty(properties)
+                        .description(description)
+                        .title(title);
                 objectProperty.setVendorExtensionMap(getVendorExtensions(node));
 
                 List<String> required = getRequired(node, PropertyBuilder.PropertyId.REQUIRED);
@@ -232,7 +240,10 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
             detailNode = node.get("items");
             if (detailNode != null) {
                 Property subProperty = propertyFromNode(detailNode);
-                ArrayProperty arrayProperty = new ArrayProperty().items(subProperty).description(description);
+                ArrayProperty arrayProperty = new ArrayProperty()
+                        .items(subProperty)
+                        .description(description)
+                        .title(title);
                 arrayProperty.setVendorExtensionMap(getVendorExtensions(node));
                 return arrayProperty;
             }

--- a/modules/swagger-core/src/test/java/io/swagger/deserialization/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/deserialization/JsonDeserializationTest.java
@@ -36,6 +36,7 @@ public class JsonDeserializationTest {
     public void testObjectProperty() throws IOException {
         final String json = "{\n" +
                 "   \"type\":\"object\",\n" +
+                "   \"title\":\"objectProperty\",\n" +
                 "   \"description\":\"top level object\",\n" +
                 "   \"properties\":{\n" +
                 "      \"property1\":{\n" +
@@ -54,7 +55,8 @@ public class JsonDeserializationTest {
                 "}";
         final Property result = m.readValue(json, Property.class);
         assertTrue(result instanceof ObjectProperty);
-        assertEquals(((ObjectProperty) result).getProperties().size(), 3);
+        assertEquals(3, ((ObjectProperty) result).getProperties().size());
+        assertEquals("objectProperty", ((ObjectProperty) result).getTitle());
 
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/ArrayProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/ArrayProperty.java
@@ -37,6 +37,11 @@ public class ArrayProperty extends AbstractProperty implements Property {
         return this;
     }
 
+    public ArrayProperty title(String title) {
+        this.setTitle(title);
+        return this;
+    }
+
     public ArrayProperty items(Property items) {
         setItems(items);
         return this;

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/MapProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/MapProperty.java
@@ -36,6 +36,11 @@ public class MapProperty extends AbstractProperty implements Property {
         return this;
     }
 
+    public MapProperty title(String title) {
+        this.setTitle(title);
+        return this;
+    }
+
     public MapProperty vendorExtension(String key, Object obj) {
         this.setVendorExtension(key, obj);
         return this;


### PR DESCRIPTION
### Scope

During deserialization of non-primitive properties, the attribute `title` was lost. Now it is retrieved in all cases.

See `JsonDeserializationTest#testObjectProperty` for a live example. 

### BONUS

- remove unused `xml` element in `PropertyDeserializer#propertyFromNode`
- invert conditions in assertEquals in `JsonDeserializationTest#testObjectProperty`. The `expected` & `actual` values were in the wrong order resulting in confusing Junit traces (`expected: <0> but was: <3>` instead of `expected: <3> but was: <0>`).