### PR TITLE
Fix #1103. Do not rely on ServletContext to initialize swagger instance.

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
@@ -8,11 +8,7 @@ import io.swagger.config.ScannerFactory;
 import io.swagger.config.SwaggerConfig;
 import io.swagger.core.filter.SwaggerSpecFilter;
 import io.swagger.jaxrs.Reader;
-import io.swagger.models.Contact;
-import io.swagger.models.Info;
-import io.swagger.models.License;
-import io.swagger.models.Scheme;
-import io.swagger.models.Swagger;
+import io.swagger.models.*;
 import org.apache.commons.lang3.StringUtils;
 import org.reflections.Reflections;
 import org.reflections.scanners.ResourcesScanner;
@@ -23,10 +19,9 @@ import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
-public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfig {
+public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfig, ReaderConfig {
     Logger LOGGER = LoggerFactory.getLogger(BeanConfig.class);
 
     Reader reader = new Reader(new Swagger());
@@ -45,6 +40,9 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
     Info info;
     String host;
     String basePath;
+
+    boolean scanAllResources;
+    Set<String> ignoredRoutes = new HashSet<String>();
 
     public String getResourcePackage() {
         return this.resourcePackage;
@@ -286,5 +284,23 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
         return swagger.info(info)
                 .host(host)
                 .basePath(basePath);
+    }
+
+    @Override
+    public boolean isScanAllResources() {
+        return scanAllResources;
+    }
+
+    public void setScanAllResources(boolean scanAllResources) {
+        this.scanAllResources = scanAllResources;
+    }
+
+    @Override
+    public Collection<String> getIgnoredRoutes() {
+        return Collections.unmodifiableSet(ignoredRoutes);
+    }
+
+    public void addIgnoredRoutes(String... ignoredRoutes) {
+        this.ignoredRoutes.addAll(Arrays.asList(ignoredRoutes));
     }
 }

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
@@ -37,12 +37,15 @@ public class ApiListingResource {
     ServletContext context;
 
     protected synchronized Swagger scan(Application app, ServletConfig sc) {
-        Swagger swagger = new Swagger();
+        Swagger swagger = null;
         Scanner scanner = ScannerFactory.getScanner();
         LOGGER.debug("using scanner " + scanner);
 
         if (scanner != null) {
             SwaggerSerializers.setPrettyPrint(scanner.getPrettyPrint());
+            if (context != null)
+                swagger = (Swagger) context.getAttribute("swagger");
+
             Set<Class<?>> classes;
             if (scanner instanceof JaxrsScanner) {
                 JaxrsScanner jaxrsScanner = (JaxrsScanner) scanner;
@@ -69,6 +72,8 @@ public class ApiListingResource {
                         LOGGER.debug("no configurator");
                     }
                 }
+                if (context != null)
+                    context.setAttribute("swagger", swagger);
             }
         }
         return swagger;

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/SwaggerUtils.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/SwaggerUtils.java
@@ -1,0 +1,82 @@
+package io.swagger.jaxrs.utils;
+
+import io.swagger.models.Swagger;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Utility class used to store {@link Swagger} by {@link Host}
+ *
+ * @author pierredeman
+ */
+public class SwaggerUtils {
+    private static Map<Host, Swagger> swaggers = new ConcurrentHashMap<Host, Swagger>();
+
+    /**
+     * @param key The Host whose associated value is to be returned
+     * @return the Swagger to which the specified Host is mapped, or {@code null} if there is no Swagger for the Host.
+     * @throws NullPointerException if the specified Host is {@code null}
+     */
+    public static Swagger getSwagger(Host key) {
+        return swaggers.get(key);
+    }
+
+    /**
+     * @param key   The Host with which the specified value is to be associated
+     * @param value The Swagger to be associated with the specified Host
+     * @return the previous Swagger associated with Host, or
+     * {@code null} if there was no mapping for Host.
+     * @throws NullPointerException if the specified key or value is {@code null}
+     *                              and this map does not permit {@code null} keys or values
+     */
+    public static Swagger putSwagger(Host key, Swagger value) {
+        return swaggers.put(key, value);
+    }
+
+    public static class Host {
+        final String scheme;
+        final String host;
+        final int port;
+        final String path;
+
+        private Host(String scheme, String host, int port, String path) {
+            this.scheme = scheme;
+            this.host = host;
+            this.port = port;
+            this.path = path;
+        }
+
+        public static Host from(final URI uri) {
+            String path = uri.getPath();
+            if (path.endsWith("/swagger") || path.endsWith("/swagger.json") || path.endsWith("/swagger.yaml"))
+                path = path.substring(0, path.lastIndexOf('/'));
+            return new Host(uri.getScheme(), uri.getHost(), uri.getPort(), path);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Host host1 = (Host) o;
+
+            if (port != host1.port) return false;
+            if (scheme != null ? !scheme.equals(host1.scheme) : host1.scheme != null) return false;
+            if (host != null ? !host.equals(host1.host) : host1.host != null) return false;
+            if (path != null ? !path.equals(host1.path) : host1.path != null) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = scheme != null ? scheme.hashCode() : 0;
+            result = 31 * result + (host != null ? host.hashCode() : 0);
+            result = 31 * result + port;
+            result = 31 * result + (path != null ? path.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/jaxrs/utils/SwaggerUtilsTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/jaxrs/utils/SwaggerUtilsTest.java
@@ -1,0 +1,114 @@
+package io.swagger.jaxrs.utils;
+
+import io.swagger.models.Swagger;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.AssertJUnit.assertEquals;
+
+public class SwaggerUtilsTest {
+
+    @Test()
+    public void testGetSwagger() throws Exception {
+        final Swagger swagger = SwaggerUtils.getSwagger(SwaggerUtils.Host.from(URI.create("http://localhost")));
+        assertNull(swagger);
+    }
+
+    @Test()
+    public void testPutSwagger() throws Exception {
+        final SwaggerUtils.Host host = SwaggerUtils.Host.from(URI.create("http://localhost"));
+        final Swagger swagger = new Swagger();
+        SwaggerUtils.putSwagger(host, swagger);
+        Assert.assertEquals(swagger, SwaggerUtils.getSwagger(host));
+    }
+
+    @Test()
+    public void testSimpleHost() throws Exception {
+        final SwaggerUtils.Host h = SwaggerUtils.Host.from(URI.create("http://localhost"));
+        assertEquals("http", h.scheme);
+        assertEquals("localhost", h.host);
+        assertEquals(-1, h.port);
+        assertEquals("", h.path);
+
+        final SwaggerUtils.Host h2 = SwaggerUtils.Host.from(URI.create("http://localhost"));
+        assertEquals(h, h2);
+        assertEquals(h.hashCode(), h2.hashCode());
+    }
+
+    @Test()
+    public void testFullHost() throws Exception {
+        final SwaggerUtils.Host h = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path"));
+        assertEquals("http", h.scheme);
+        assertEquals("localhost", h.host);
+        assertEquals(8080, h.port);
+        assertEquals("/path", h.path);
+
+        final SwaggerUtils.Host h2 = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path"));
+        assertEquals(h, h2);
+        assertEquals(h.hashCode(), h2.hashCode());
+    }
+
+    @Test()
+    public void testSwaggerHost() throws Exception {
+        final SwaggerUtils.Host h = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path/swagger"));
+        assertEquals("http", h.scheme);
+        assertEquals("localhost", h.host);
+        assertEquals(8080, h.port);
+        assertEquals("/path", h.path);
+
+        final SwaggerUtils.Host h2 = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path/swagger"));
+        assertEquals(h, h2);
+        assertEquals(h.hashCode(), h2.hashCode());
+    }
+
+    @Test()
+    public void testJsonSwaggerHost() throws Exception {
+        final SwaggerUtils.Host h = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path/swagger.json"));
+        assertEquals("http", h.scheme);
+        assertEquals("localhost", h.host);
+        assertEquals(8080, h.port);
+        assertEquals("/path", h.path);
+
+        final SwaggerUtils.Host h2 = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path/swagger.json"));
+        assertEquals(h, h2);
+        assertEquals(h.hashCode(), h2.hashCode());
+    }
+
+    @Test()
+    public void testYamlSwaggerHost() throws Exception {
+        final SwaggerUtils.Host h = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path/swagger.yaml"));
+        assertEquals("http", h.scheme);
+        assertEquals("localhost", h.host);
+        assertEquals(8080, h.port);
+        assertEquals("/path", h.path);
+
+        final SwaggerUtils.Host h2 = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path/swagger.yaml"));
+        assertEquals(h, h2);
+        assertEquals(h.hashCode(), h2.hashCode());
+    }
+
+    @Test()
+    public void testNotEqualsHost() throws Exception {
+        final SwaggerUtils.Host ref = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path"));
+
+        final SwaggerUtils.Host schemeDiff = SwaggerUtils.Host.from(URI.create("https://localhost:8080/path"));
+        assertNotEquals(ref, schemeDiff);
+        assertNotEquals(ref.hashCode(), schemeDiff.hashCode());
+
+        final SwaggerUtils.Host hostDiff = SwaggerUtils.Host.from(URI.create("http://localhost1:8080/path"));
+        assertNotEquals(ref, hostDiff);
+        assertNotEquals(ref.hashCode(), hostDiff.hashCode());
+
+        final SwaggerUtils.Host portDiff = SwaggerUtils.Host.from(URI.create("http://localhost:8081/path"));
+        assertNotEquals(ref, portDiff);
+        assertNotEquals(ref.hashCode(), portDiff.hashCode());
+
+        final SwaggerUtils.Host pathDiff = SwaggerUtils.Host.from(URI.create("http://localhost:8080/path1"));
+        assertNotEquals(ref, pathDiff);
+        assertNotEquals(ref.hashCode(), pathDiff.hashCode());
+    }
+}


### PR DESCRIPTION
I based my fix on PR#1535.
Then, I added a little object based on PR#1563 to maintain multi-tenancy of swagger definitions in a single app.