### PR TITLE
added host, schemes, proper handling of basePath

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/WebXMLReader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/WebXMLReader.java
@@ -12,9 +12,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletConfig;
+import java.util.ArrayList;
+import java.util.List;
 
 public class WebXMLReader implements SwaggerConfig {
-    protected String basePath, host, filterClass, apiVersion, title, scheme = "http";
+    protected String basePath,
+            host,
+            filterClass,
+            apiVersion,
+            title;
+    protected String[] schemes = new String[]{"http"};
     private Logger LOGGER = LoggerFactory.getLogger(WebXMLReader.class);
 
     public WebXMLReader(ServletConfig servletConfig) {
@@ -29,25 +36,46 @@ public class WebXMLReader implements SwaggerConfig {
         if (shouldPrettyPrint != null) {
             scanner.setPrettyPrint(Boolean.parseBoolean(shouldPrettyPrint));
         }
-        basePath = servletConfig.getInitParameter("swagger.api.basepath");
-        title = servletConfig.getInitParameter("swagger.api.title");
+
+        // we support full base path (i.e full URL to the server) or just base path
+        this.host = servletConfig.getInitParameter("swagger.api.host");
+        String schemesString = servletConfig.getInitParameter("swagger.api.schemes");
+
+        // split the CSV string and update the `schemes` variable
+        if(schemesString != null) {
+            String[] parts = schemesString.split(",");
+            List<String> schemes = new ArrayList<String>();
+            for(String scheme : parts) {
+                String s = scheme.trim();
+                if(!s.isEmpty()) {
+                    schemes.add(s);
+                }
+            }
+            this.schemes = schemes.toArray(new String[schemes.size()]);
+        }
+        this.title = servletConfig.getInitParameter("swagger.api.title");
+
         if (title == null) {
             title = "";
         }
 
+        this.basePath = servletConfig.getInitParameter("swagger.api.basepath");
         if (basePath != null) {
             String[] parts = basePath.split("://");
             if (parts.length > 1) {
                 int pos = parts[1].indexOf("/");
                 if (pos >= 0) {
-                    scheme = parts[0];
+                    this.schemes = new String[]{parts[0]};
                     basePath = parts[1].substring(pos);
                     host = parts[1].substring(0, pos);
                 } else {
-                    scheme = parts[0];
+                    this.schemes = new String[]{parts[0]};
                     basePath = null;
                     host = parts[1];
                 }
+            }
+            else {
+                // it is a proper basePath, nothing to do
             }
         }
 
@@ -75,9 +103,13 @@ public class WebXMLReader implements SwaggerConfig {
                 swagger.info(new Info());
             }
 
+            List<Scheme> schemes = new ArrayList<Scheme>();
+            for(String scheme : this.schemes) {
+                schemes.add(Scheme.forValue(scheme));
+            }
             swagger.basePath(basePath)
                     .host(host)
-                    .scheme(Scheme.forValue(scheme))
+                    .schemes(schemes)
                     .getInfo()
                     .title(title)
                     .version(apiVersion);


### PR DESCRIPTION
This commit adds two new configurations from the `web.xml`, and backwards-compatible support for the previous `basePath` setting.

When configuring the `DefaultJaxrsConfig`, you can configure each section as such:

```xml
  <servlet>
    <servlet-name>DefaultJaxrsConfig</servlet-name>
    <servlet-class>io.swagger.jaxrs.config.DefaultJaxrsConfig</servlet-class>
    <init-param>
      <param-name>api.version</param-name>
      <param-value>1.0.0</param-value>
    </init-param>
    <init-param>
      <!-- sets the basePath, which should always start with `/`.  For legacy support,
           the full basePath is supported -->
      <param-name>swagger.api.basepath</param-name>
      <param-value>/v2</param-value>
    </init-param>
    <init-param>
      <!-- sets the host.  Note, the scheme is not used here, nor is the basePath -->
      <param-name>swagger.api.host</param-name>
      <param-value>foo.bar.com:8909</param-value>
    </init-param>
    <init-param>
      <!-- sets schemes.  Use a CSV string to do so, order will be preserved -->
      <param-name>swagger.api.schemes</param-name>
      <param-value>https,http</param-value>
    </init-param>
    <load-on-startup>2</load-on-startup>
  </servlet>
```

Fixes #1583 
