### PR TITLE
refs #1438 adds jsr-303 to param

### DIFF
--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -239,6 +239,25 @@ public class ReaderTest {
         assertEquals(name.getDescription(), "The books name");
     }
 
+    @Test(description = "it should scan parameters with Swagger and JSR-303 bean validation annotations")
+    public void scanBeanValidation(){
+
+        Swagger swagger = getSwagger(ResourceWithValidation.class);
+        assertNotNull(swagger);
+
+        QueryParameter par = (QueryParameter) swagger.getPaths().get("/303").getOperations().get(0).getParameters().get(0);
+        assertTrue(par.getRequired());
+        assertEquals(par.getMinimum(), 10D);
+
+        par = (QueryParameter) swagger.getPaths().get("/swagger-and-303").getOperations().get(0).getParameters().get(0);
+        assertTrue(par.getRequired());
+        assertEquals(par.getMinimum(), 7D);
+
+        par = (QueryParameter) swagger.getPaths().get("/swagger").getOperations().get(0).getParameters().get(0);
+        assertTrue(par.getRequired());
+        assertEquals(par.getMinimum(), 7D);
+    }
+
     @Test(description = "scan resource with annotated exception")
     public void scanDeclaredExceptions() {
         Swagger swagger = getSwagger(ResourceWithCustomException.class);

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithValidation.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithValidation.java
@@ -1,0 +1,59 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.models.Sample;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+@Api(value = "/basic", description = "Basic resource")
+@Produces({"application/xml"})
+public class ResourceWithValidation {
+
+    @GET
+    @Path("/swagger-and-303")
+    @ApiOperation(value = "Get",
+            httpMethod = "GET")
+    public Response getTestSwaggerAnd303(
+            @ApiParam(value = "sample param data", required = false, allowableValues = "range[7, infinity]")
+            @QueryParam("id") @NotNull @Min(5) Integer id) throws WebApplicationException {
+        Sample out = new Sample();
+        out.setName("foo");
+        out.setValue("bar");
+        return Response.ok().entity(out).build();
+    }
+
+    @GET
+    @Path("/swagger")
+    @ApiOperation(value = "Get",
+            httpMethod = "GET")
+    public Response getTestSwagger(
+            @ApiParam(value = "sample param data", required = true, allowableValues = "range[7, infinity]")
+            @QueryParam("id") Integer id) throws WebApplicationException {
+        Sample out = new Sample();
+        out.setName("foo");
+        out.setValue("bar");
+        return Response.ok().entity(out).build();
+    }
+
+    @GET
+    @Path("/303")
+    @ApiOperation(value = "Get",
+            httpMethod = "GET")
+    public Response getTest303(
+            @ApiParam(value = "sample param data")
+            @QueryParam("id") @NotNull @Min(10) Integer id) throws WebApplicationException {
+        Sample out = new Sample();
+        out.setName("foo");
+        out.setValue("bar");
+        return Response.ok().entity(out).build();
+    }
+}


### PR DESCRIPTION
As discussed with @fehguy, fixes #1438 adding support for JSR-303 annotations @Min, @Max and @NotNull (@Size was already processed) for operation parameters.

Behvaiour changes include: 

* If @NotNull, parameter 'required' will always be true (e.g. also if @ApiParam (required = false))

* If @Min(x) or @Max(x), parameter 'minimum' or 'maximum' will be set to x only if @ApiParam (allowableValues) is not specified.
