### PR TITLE
#1557 filter out unreferenced definitions if specified in filter

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/core/filter/AbstractSpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/core/filter/AbstractSpecFilter.java
@@ -38,4 +38,8 @@ public abstract class AbstractSpecFilter implements SwaggerSpecFilter {
             Map<String, List<String>> headers) {
         return true;
     }
+
+    public boolean isRemovingUnreferencedDefinitions() {
+        return false;
+    }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/filter/RemoveUnreferencedDefinitionsFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/filter/RemoveUnreferencedDefinitionsFilter.java
@@ -1,0 +1,12 @@
+package io.swagger.filter;
+
+import io.swagger.core.filter.AbstractSpecFilter;
+
+/**
+ * signals to remove unreferenced definitions.
+ **/
+public class RemoveUnreferencedDefinitionsFilter extends AbstractSpecFilter {
+    public boolean isRemovingUnreferencedDefinitions() {
+        return true;
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/filter/SpecFilterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/filter/SpecFilterTest.java
@@ -114,6 +114,25 @@ public class SpecFilterTest {
         }
     }
 
+
+    @Test(description = "it should filter away broken reference model properties")
+    public void filterAwayBrokenReferenceModelProperties() throws IOException {
+        final Swagger swagger = getSwagger("specFiles/paramAndResponseRef.json");
+
+        assertNotNull(swagger.getDefinitions().get("Order"));
+
+        final NoOpOperationsFilter noOpfilter = new NoOpOperationsFilter();
+        Swagger filtered = new SpecFilter().filter(swagger, noOpfilter, null, null, null);
+
+        assertNotNull(filtered.getDefinitions().get("Order"));
+
+        final RemoveUnreferencedDefinitionsFilter refFilter = new RemoveUnreferencedDefinitionsFilter();
+        filtered = new SpecFilter().filter(swagger, refFilter, null, null, null);
+
+        assertNull(filtered.getDefinitions().get("Order"));
+
+    }
+
     @Test(description = "it should filter models where some fields have no properties")
     public void filterNoPropertiesModels() throws IOException {
         final String modelName = "Array";

--- a/modules/swagger-core/src/test/resources/specFiles/paramAndResponseRef.json
+++ b/modules/swagger-core/src/test/resources/specFiles/paramAndResponseRef.json
@@ -1,0 +1,218 @@
+{
+  "swagger": "2.0",
+  "title": "Petstore Sample API",
+  "info": {
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "title": "Petstore Sample API",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "paths": {
+    "/pet": {
+      "parameters": [
+        {
+          "name": "body",
+          "in": "body",
+          "description": "Pet object that needs to be added to the store",
+          "required": false,
+          "schema": {
+            "$ref": "#/definitions/Pet"
+          }
+        }
+      ],
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "found it",
+            "schema": {
+              "$ref": "#/definitions/User"
+            }
+          },
+          "404": {
+            "description": "Order not found"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "$ref": "http://my.company.com/responses/errors.json#/method-not-allowed"
+          },
+          "404": {
+            "$ref": "http://my.company.com/responses/errors.json#/not-found"
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "Category": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Pet": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "status": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "photoUrls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Tag": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Order": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "petId": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "status": {
+          "type": "string"
+        },
+        "complete": {
+          "type": "boolean"
+        },
+        "quantity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "shipDate": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
@@ -81,10 +81,8 @@ public class ApiListingResource {
             }
         }
         if (SwaggerContextService.isScannerIdInitParamDefined(sc)) {
-            LOGGER.error("scan isScannerIdInitParamDefined " + sc.getServletName() + "_" + SwaggerContextService.getScannerIdFromInitParam(sc));
             initializedScanner.put(sc.getServletName() + "_" + SwaggerContextService.getScannerIdFromInitParam(sc), true);
         } else if (SwaggerContextService.isConfigIdInitParamDefined(sc)) {
-            LOGGER.error("scan isConfigIdInitParamDefined " + sc.getServletName() + "_" + SwaggerContextService.getConfigIdFromInitParam(sc));
             initializedConfig.put(sc.getServletName() + "_" + SwaggerContextService.getConfigIdFromInitParam(sc), true);
         } else {
             initialized = true;
@@ -101,12 +99,10 @@ public class ApiListingResource {
         Swagger swagger = new SwaggerContextService().withServletConfig(sc).getSwagger();
         synchronized (ApiListingResource.class) {
             if (SwaggerContextService.isScannerIdInitParamDefined(sc)) {
-                LOGGER.error("process isScannerIdInitParamDefined " + sc.getServletName() + "_" + SwaggerContextService.getScannerIdFromInitParam(sc));
                 if (!initializedScanner.containsKey(sc.getServletName() + "_" + SwaggerContextService.getScannerIdFromInitParam(sc))) {
                     swagger = scan(app, sc);
                 }
             } else {
-                LOGGER.error("process isConfigIdInitParamDefined " + sc.getServletName() + "_" + SwaggerContextService.getConfigIdFromInitParam(sc));
                 if (SwaggerContextService.isConfigIdInitParamDefined(sc)) {
                     if (!initializedConfig.containsKey(sc.getServletName() + "_" + SwaggerContextService.getConfigIdFromInitParam(sc))) {
                         swagger = scan(app, sc);


### PR DESCRIPTION
@fehguy 

solution for #1557, allowing to filter out unreferenced definitions from returned Swagger, if specified in filter by extending `AbstractSpecFilter` and overriding `isRemovingUnreferencedDefinitions()`:

```java
public class RemoveUnreferencedDefinitionsFilter extends AbstractSpecFilter {
    public boolean isRemovingUnreferencedDefinitions() {
        return true;
    }
}
```

Checks for the following references and compares with definitions:

swagger.parameters.parameter(BodyParam).schema
swagger.responses.Response.schema
swagger.paths.Path.parameters.parameter(BodyParam).schema
swagger.paths.Path.operations.Operation.responses.Response.schema
swagger.paths.Path.operations.Operation.parameters.parameter(BodyParam).schema

Method `isRemovingUnreferencedDefinitions` has not been added to interface `SwaggerSpecFilter` to avoid breaking compatibility with existent client filters directly implementing `SwaggerSpecFilter`.

Cleaning is performed after all other filters (in additional iteration) to possibly support future updates e.g. with multiple filters, etc, as kind of "final cleanup".