### PR TITLE
dataType class loading issue in managed containers such as play framework

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -1,67 +1,31 @@
 package io.swagger.jackson;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.JsonIdentityReference;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerator;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyMetadata;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.collect.Iterables;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.converter.ModelConverter;
 import io.swagger.converter.ModelConverterContext;
-import io.swagger.models.ComposedModel;
-import io.swagger.models.Model;
-import io.swagger.models.ModelImpl;
-import io.swagger.models.RefModel;
-import io.swagger.models.Xml;
-import io.swagger.models.properties.AbstractNumericProperty;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.IntegerProperty;
-import io.swagger.models.properties.MapProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.PropertyBuilder;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
-import io.swagger.models.properties.UUIDProperty;
+import io.swagger.models.*;
+import io.swagger.models.properties.*;
 import io.swagger.util.AllowableValues;
 import io.swagger.util.AllowableValuesUtils;
 import io.swagger.util.PrimitiveType;
-
-import com.google.common.collect.Iterables;
+import io.swagger.util.ReflectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class ModelResolver extends AbstractModelConverter implements ModelConverter {
     Logger LOGGER = LoggerFactory.getLogger(ModelResolver.class);
@@ -636,7 +600,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
     protected JavaType getInnerType(String innerType) {
         try {
-            Class<?> innerClass = Class.forName(innerType);
+            Class<?> innerClass = ReflectionUtils.loadClassByName(innerType);
             if (innerClass != null) {
                 TypeFactory tf = _mapper.getTypeFactory();
                 return tf.constructType(innerClass);

--- a/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
@@ -5,17 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.lang.reflect.*;
+import java.util.*;
 
 public class ReflectionUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReflectionUtils.class);
@@ -26,11 +17,30 @@ public class ReflectionUtils {
             return primitive.getKeyClass();
         }
         try {
-            return Class.forName(type);
+            return loadClassByName(type);
         } catch (Exception e) {
             LOGGER.error(String.format("Failed to resolve '%s' into class", type), e);
         }
         return null;
+    }
+
+    /**
+     * Load Class by class name. If class not found in it's Class loader or one of the parent class loaders - delegate to the Thread's ContextClassLoader
+     *
+     * @param className Canonical class name
+     * @return Class definition of className
+     * @throws ClassNotFoundException
+     */
+    public static Class<?> loadClassByName(String className) throws ClassNotFoundException
+    {
+        try
+        {
+            return Class.forName(className);
+        }
+        catch (ClassNotFoundException e)
+        {
+            return Thread.currentThread().getContextClassLoader().loadClass(className);
+        }
     }
 
     /**


### PR DESCRIPTION
When setting dataType on ApiModelProperty annotation, where the type is referenced from an ApiImplicitParam annotation - I get the below exception, running from Play Framework 2.4.6.
This issue may be relevant to other frameworks. This is due to the framework's customized class loading mechanism. In play - the project sources are loaded in a child class loader of the loaded dependencies, this cater for hot swapping during development. As a side effect, a class imported as a dependency can't load a local project class from it's current class loader or one of it's parent class loaders.
Sorry for the lack of UT coverage, it was difficult for me to simulate such a scenario.

```
Caused by: java.lang.IllegalArgumentException: Unrecognized Type: [null]
	at com.fasterxml.jackson.databind.type.TypeFactory._constructType(TypeFactory.java:405) ~[jackson-databind.jar:2.5.4]
	at com.fasterxml.jackson.databind.type.TypeFactory.constructType(TypeFactory.java:354) ~[jackson-databind.jar:2.5.4]
	at com.fasterxml.jackson.databind.ObjectMapper.constructType(ObjectMapper.java:1332) ~[jackson-databind.jar:2.5.4]
	at io.swagger.scala.converter.SwaggerScalaModelConverter.resolveProperty(SwaggerScalaModelConverter.scala:34) ~[na:na]
	at io.swagger.converter.ModelConverterContextImpl.resolveProperty(ModelConverterContextImpl.java:79) ~[swagger-core-1.5.4.jar:1.5.4]
	at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:355) ~[swagger-core-1.5.4.jar:1.5.4]
	at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:159) ~[swagger-core-1.5.4.jar:1.5.4]
	at io.swagger.scala.converter.SwaggerScalaModelConverter.resolve(SwaggerScalaModelConverter.scala:101) ~[na:na]
	at io.swagger.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:99) ~[swagger-core-1.5.4.jar:1.5.4]
	at io.swagger.jackson.ModelResolver.resolveProperty(ModelResolver.java:138) ~[swagger-core-1.5.4.jar:1.5.4]
	at io.swagger.jackson.ModelResolver.resolveProperty(ModelResolver.java:103) ~[swagger-core-1.5.4.jar:1.5.4]
	at io.swagger.scala.converter.SwaggerScalaModelConverter.resolveProperty(SwaggerScalaModelConverter.scala:69) ~[na:na]
	at io.swagger.converter.ModelConverterContextImpl.resolveProperty(ModelConverterContextImpl.java:79) ~[swagger-core-1.5.4.jar:1.5.4]
	at io.swagger.converter.ModelConverters.readAsProperty(ModelConverters.java:58) ~[swagger-core-1.5.4.jar:1.5.4]
	at io.swagger.util.ParameterProcessor.applyAnnotations(ParameterProcessor.java:155) ~[swagger-core-1.5.4.jar:1.5.4]
	at play.modules.swagger.PlayReader.readImplicitParam(PlayReader.java:386) ~[swagger-play2_2.11-1.5.0.jar:1.5.0]
```