### PR TITLE
Refs #1106, #1629, #1617, #1614 - JAX-RS Root and Subresources identification, scanning and reading

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
@@ -254,8 +254,7 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
         config.setScanners(new ResourcesScanner(), new TypeAnnotationsScanner(), new SubTypesScanner());
 
         final Reflections reflections = new Reflections(config);
-        Set<Class<?>> classes = reflections.getTypesAnnotatedWith(Api.class);
-        classes.addAll(reflections.getTypesAnnotatedWith(javax.ws.rs.Path.class));
+        Set<Class<?>> classes = reflections.getTypesAnnotatedWith(javax.ws.rs.Path.class);
         classes.addAll(reflections.getTypesAnnotatedWith(SwaggerDefinition.class));
 
         Set<Class<?>> output = new HashSet<Class<?>>();

--- a/modules/swagger-jaxrs/src/test/java/com/subresourcesTest/ChildResource.java
+++ b/modules/swagger-jaxrs/src/test/java/com/subresourcesTest/ChildResource.java
@@ -1,0 +1,26 @@
+package com.subresourcesTest;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Response;
+
+/**
+ * Created by rbolles on 1/20/16.
+ */
+@Api(tags = "children", description = "operations about children")
+public class ChildResource {
+
+    @GET
+    @ApiOperation(value = "Get Child by id")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Success")
+    })
+    public Response getChildren(
+    ) {
+        return Response.ok().entity("Hello World").build();
+    }
+}

--- a/modules/swagger-jaxrs/src/test/java/com/subresourcesTest/RootResource.java
+++ b/modules/swagger-jaxrs/src/test/java/com/subresourcesTest/RootResource.java
@@ -1,0 +1,20 @@
+package com.subresourcesTest;
+
+import io.swagger.annotations.Api;
+
+import javax.ws.rs.Path;
+
+/**
+ * Created by rbolles on 1/20/16.
+ */
+
+@Api(tags = "root")
+@Path("/api/1.0")
+public class RootResource {
+
+    @Path("/children")
+    public ChildResource getChildResource() {
+        return new ChildResource();
+    }
+
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/BeanConfigTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/BeanConfigTest.java
@@ -1,5 +1,6 @@
 package io.swagger;
 
+import com.subresourcesTest.RootResource;
 import io.swagger.jaxrs.config.BeanConfig;
 import io.swagger.models.Scheme;
 import io.swagger.models.Swagger;
@@ -12,6 +13,7 @@ import java.util.Set;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class BeanConfigTest {
     private final Set expectedKeys = new HashSet<String>(Arrays.asList("/packageA", "/packageB"));
@@ -47,5 +49,16 @@ public class BeanConfigTest {
         assertNotNull(swagger);
         assertEquals(swagger.getPaths().keySet(), expectedKeys);
         assertEquals(swagger.getSchemes(), expectedSchemas);
+    }
+
+    @Test
+    public void testBeanConfigOnlyScansResourcesAnnoatedWithPaths() throws Exception {
+        BeanConfig bc = new BeanConfig();
+        bc.setResourcePackage("com.subresourcesTest");
+
+        Set<Class<?>> classes = bc.classes();
+
+        assertEquals(classes.size(), 1, "BeanConfig should only pick up the root resource because it has a @Path annotation at the class level");
+        assertTrue(classes.contains(RootResource.class));
     }
 }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/HiddenParametersScannerTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/HiddenParametersScannerTest.java
@@ -1,6 +1,7 @@
 package io.swagger;
 
 import io.swagger.jaxrs.Reader;
+import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
@@ -13,7 +14,14 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 public class HiddenParametersScannerTest {
-    private final Swagger swagger = new Reader(new Swagger()).read(HiddenParametersResource.class);
+    private Swagger swagger;
+
+    public HiddenParametersScannerTest() {
+        DefaultReaderConfig config = new DefaultReaderConfig();
+        config.setScanAllResources(true);
+        swagger = new Reader(new Swagger(), config).read(HiddenParametersResource.class);
+
+    }
 
     @Test
     public void shouldScanMethodWithAllParamsHidden() throws Exception {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -1,6 +1,7 @@
 package io.swagger;
 
 import io.swagger.jaxrs.Reader;
+import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.*;
@@ -142,7 +143,7 @@ public class ReaderTest {
 
     @Test(description = "scan annotation from interface, issue#1427")
     public void scanInterfaceTest() {
-        final Swagger swagger = new Reader(new Swagger()).read(AnnotatedInterfaceImpl.class);
+        final Swagger swagger = getSwagger(AnnotatedInterfaceImpl.class);
         assertNotNull(swagger);
         assertNotNull(swagger.getPath("/v1/users/{id}").getGet());
     }
@@ -284,7 +285,9 @@ public class ReaderTest {
     }
 
     private Swagger getSwagger(Class<?> cls) {
-        return new Reader(new Swagger()).read(cls);
+        DefaultReaderConfig config = new DefaultReaderConfig();
+        config.setScanAllResources(true);
+        return new Reader(new Swagger(), config).read(cls);
     }
 
     private Operation getGet(Swagger swagger, String path) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReferenceTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReferenceTest.java
@@ -2,6 +2,7 @@ package io.swagger;
 
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.Reader;
+import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.matchers.SerializationMatchers;
 import io.swagger.models.Pet;
 import io.swagger.models.Swagger;
@@ -37,7 +38,9 @@ public class ReferenceTest {
 
     @Test(description = "Scan API with operation and response references")
     public void scanAPI() throws IOException {
-        final Swagger swagger = new Reader(new Swagger()).read(ResourceWithReferences.class);
+        DefaultReaderConfig config = new DefaultReaderConfig();
+        config.setScanAllResources(true);
+        final Swagger swagger = new Reader(new Swagger(), config).read(ResourceWithReferences.class);
         final String json = ResourceUtils.loadClassResource(getClass(), "ResourceWithReferences.json");
         SerializationMatchers.assertEqualsToJson(swagger, json);
     }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/RegexPathParamTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/RegexPathParamTest.java
@@ -1,6 +1,7 @@
 package io.swagger;
 
 import io.swagger.jaxrs.Reader;
+import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
@@ -13,7 +14,9 @@ public class RegexPathParamTest {
 
     @Test(description = "scan a simple resource")
     public void scanSimpleResource() {
-        Swagger swagger = new Reader(new Swagger()).read(RegexPathParamResource.class);
+        DefaultReaderConfig config = new DefaultReaderConfig();
+        config.setScanAllResources(true);
+        Swagger swagger = new Reader(new Swagger(), config).read(RegexPathParamResource.class);
         Operation get = swagger.getPaths().get("/{report_type}").getGet();
         Parameter param = get.getParameters().get(0);
         assertEquals(param.getName(), "report_type");

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -49,7 +49,9 @@ import static org.testng.Assert.fail;
 public class SimpleReaderTest {
 
     private Swagger getSwagger(Class<?> cls) {
-        return new Reader(new Swagger()).read(cls);
+        DefaultReaderConfig config = new DefaultReaderConfig();
+        config.setScanAllResources(true);
+        return new Reader(new Swagger(), config).read(cls);
     }
 
     private Map<String, Response> getGetResponses(Swagger swagger, String path) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-public class SimpleScannerTest {
+public class SimpleReaderTest {
 
     private Swagger getSwagger(Class<?> cls) {
         return new Reader(new Swagger()).read(cls);

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SubResourceReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SubResourceReaderTest.java
@@ -21,8 +21,8 @@ public class SubResourceReaderTest {
     @Test(description = "scan a resource with subresources")
     public void readResourceWithSubresources() {
         final Swagger swagger = getSwagger(ResourceWithSubResources.class);
-        assertEquals(getOperationId(swagger, "/employees"), "getTest");
-        assertEquals(getOperationId(swagger, "/employees/{id}"), "getSubresourceOperation");
+        assertEquals(getOperationId(swagger, "/employees/{id}"), "getAllEmployees");
+        assertEquals(getOperationId(swagger, "/employees/{id}/{id}"), "getSubresourceOperation");
         assertEquals(getOperationId(swagger, "/employees/noPath"), "getGreeting");
     }
 

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SubResourceReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SubResourceReaderTest.java
@@ -16,10 +16,10 @@ import java.util.Arrays;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-public class SubResourceScannerTest {
+public class SubResourceReaderTest {
 
     @Test(description = "scan a resource with subresources")
-    public void scanResourceWithSubresources() {
+    public void readResourceWithSubresources() {
         final Swagger swagger = getSwagger(ResourceWithSubResources.class);
         assertEquals(getOperationId(swagger, "/employees"), "getTest");
         assertEquals(getOperationId(swagger, "/employees/{id}"), "getSubresourceOperation");
@@ -27,7 +27,7 @@ public class SubResourceScannerTest {
     }
 
     @Test(description = "scan another resource with subresources")
-    public void scanAnotherResourceWithSubresources() {
+    public void readAnotherResourceWithSubresources() {
         final Swagger swagger = getSwagger(TestResource.class);
         final Operation get = getGet(swagger, "/test/more/otherStatus");
         assertEquals(get.getOperationId(), "otherStatus");
@@ -42,7 +42,7 @@ public class SubResourceScannerTest {
     }
 
     @Test(description = "scan resource with class-based sub-resources")
-    public void scanResourceWithClassBasedSubresources() {
+    public void readResourceWithClassBasedSubresources() {
         final Swagger swagger = getSwagger(SubResourceHead.class);
         assertEquals(swagger.getPaths().size(), 3);
         assertEquals(getOperationId(swagger, "/head/noPath"), "getGreeting");

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithSubResources.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithSubResources.java
@@ -14,7 +14,7 @@ public class ResourceWithSubResources {
             response = Employee.class,
             responseContainer = "list",
             tags = "Employees")
-    @GET
+    @Path("{id}")
     public SubResource getTest() {
         return new SubResource();
     }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SubResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SubResource.java
@@ -9,7 +9,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
-@Api(hidden = true)
+@Api
 public class SubResource {
     @ApiOperation(value = "gets an object by ID", tags = "Employees", response = Employee.class, responseContainer = "list")
     @GET

--- a/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/ScannerTest.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/ScannerTest.java
@@ -2,6 +2,7 @@ package io.swagger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.jaxrs.Reader;
+import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
@@ -89,6 +90,9 @@ public class ScannerTest {
     }
 
     private Swagger getSwagger(Class<?> clas) {
-        return new Reader(new Swagger()).read(clas);
+        DefaultReaderConfig config = new DefaultReaderConfig();
+        config.setScanAllResources(true);
+        return new Reader(new Swagger(), config).read(clas);
+
     }
 }


### PR DESCRIPTION
@fehguy Refs #1106, #1629, #1617, #1614

As discussed, changes JAX-RS root and subresources identification, scanning and reading to be compliant with JAX-RS specs: Root resources are identified by @Path annotation at class level, and sub resources are identified by @Path annotation at method level, along with no @HttpMethod annotation.

It integrates changes from #1617, changing BeanConfig scanning to only consider @Path annotations, and #1629, used as base for further implementation.

Classes not annotated with @Path are only read in case config.scanAllResources is true, maintaining anyway @Api.hidden processing (@Api.hidden classes are never processed).

Tests have been adapted by setting always scanAllResources = true to be able to handle current test root resources classes which are not always annotated with @Path. A further enhancement would be comprehensively adjusting current test resources/classes to fully adhere to JAX-RS specs, possibly in scope of a different ticket.

Code has been tested via project tests and running swagger-samples projects. 