### PR TITLE
issue-1318 - change Property.example from String to Object so number …

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractProperty.java
@@ -11,7 +11,7 @@ public abstract class AbstractProperty implements Property {
     String name;
     String type;
     String format;
-    String example;
+    Object example;
     Xml xml;
     boolean required;
     Integer position;
@@ -44,11 +44,11 @@ public abstract class AbstractProperty implements Property {
         this.name = name;
     }
 
-    public String getExample() {
+    public Object getExample() {
         return example;
     }
 
-    public void setExample(String example) {
+    public void setExample(Object example) {
         this.example = example;
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/BaseIntegerProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/BaseIntegerProperty.java
@@ -19,4 +19,17 @@ public class BaseIntegerProperty extends AbstractNumericProperty {
     public static boolean isType(String type, String format) {
         return TYPE.equals(type);
     }
+
+    @Override
+    public void setExample(Object example) {
+        if (example instanceof String) {
+            try {
+                this.example = Long.parseLong((String)example);
+            } catch (NumberFormatException e) {
+                this.example = example;
+            }
+        } else {
+            this.example = example;
+        }
+    }
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/BooleanProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/BooleanProperty.java
@@ -20,15 +20,24 @@ public class BooleanProperty extends AbstractProperty implements Property {
     }
 
     public BooleanProperty example(Boolean example) {
-        this.setExample(String.valueOf(example));
+        this.example = example;
         return this;
+    }
+
+    @Override
+    public void setExample(Object example) {
+        if (example instanceof String) {
+            this.example = Boolean.parseBoolean((String)example);
+        } else {
+            this.example = example;
+        }
     }
 
     public BooleanProperty _default(String _default) {
         try {
             this.setDefault(Boolean.parseBoolean(_default));
         } catch (Exception e) {
-            //cotinue
+            //continue
         }
         return this;
     }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/DecimalProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/DecimalProperty.java
@@ -39,4 +39,17 @@ public class DecimalProperty extends AbstractNumericProperty {
         this.setVendorExtension(key, obj);
         return this;
     }
+
+    @Override
+    public void setExample(Object example) {
+        if (example instanceof String) {
+            try {
+                this.example = Double.parseDouble((String)example);
+            } catch (NumberFormatException e) {
+                this.example = example;
+            }
+        } else {
+            this.example = example;
+        }
+    }
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/DoubleProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/DoubleProperty.java
@@ -39,7 +39,7 @@ public class DoubleProperty extends DecimalProperty {
     }
 
     public DoubleProperty example(Double example) {
-        this.setExample(String.valueOf(example));
+        this.example = example;
         return this;
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/FloatProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/FloatProperty.java
@@ -40,8 +40,21 @@ public class FloatProperty extends DecimalProperty {
     }
 
     public FloatProperty example(Float example) {
-        this.setExample(String.valueOf(example));
+        this.example = example;
         return this;
+    }
+
+    @Override
+    public void setExample(Object example) {
+        if (example instanceof String) {
+            try {
+                this.example = Float.parseFloat((String)example);
+            } catch (NumberFormatException e) {
+                this.example = example;
+            }
+        } else {
+            this.example = example;
+        }
     }
 
     public FloatProperty _default(String _default) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/IntegerProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/IntegerProperty.java
@@ -39,8 +39,21 @@ public class IntegerProperty extends BaseIntegerProperty {
     }
 
     public IntegerProperty example(Integer example) {
-        this.setExample(String.valueOf(example));
+        this.example = example;
         return this;
+    }
+
+    @Override
+    public void setExample(Object example) {
+        if (example instanceof String) {
+            try {
+                this.example = Integer.parseInt((String)example);
+            } catch (NumberFormatException e) {
+                this.example = example;
+            }
+        } else {
+            this.example = example;
+        }
     }
 
     public IntegerProperty _default(String _default) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/LongProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/LongProperty.java
@@ -39,7 +39,7 @@ public class LongProperty extends BaseIntegerProperty {
     }
 
     public LongProperty example(Long example) {
-        this.setExample(String.valueOf(example));
+        this.example = example;
         return this;
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/Property.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/Property.java
@@ -32,9 +32,9 @@ public interface Property {
 
     void setRequired(boolean required);
 
-    String getExample();
+    Object getExample();
 
-    void setExample(String example);
+    void setExample(Object example);
 
     Boolean getReadOnly();
 


### PR DESCRIPTION
…and boolean fields are not represented as strings

I have a class:

public class PasswordPolicy {
    @ApiModelProperty(example = "4")
    public int minPasswordLength;
    @ApiModelProperty(example = "true")
    public boolean requireMixedCase;
    @ApiModelProperty(example = "true")
    public boolean requireNumericChars;
    @ApiModelProperty(example = "true")
    public boolean requireSpecialChars;
    @ApiModelProperty(example = "true")
    public boolean passwordExpires;
    @ApiModelProperty(example = "90")
    public int maxPasswordAge;
    @ApiModelProperty(example = "3")
    public int lockAfterFailedAttempts;
    @ApiModelProperty(example = "2")
    public int lockPeriod;
}

With the existing code my model schema looked like this:

{
  "minPasswordLength": "4",
  "requireMixedCase": "true",
  "requireNumericChars": "true",
  "requireSpecialChars": "true",
  "passwordExpires": "true",
  "maxPasswordAge": "90",
  "lockAfterFailedAttempts": "3",
  "lockPeriod": "2"
}

While this works it is a bit misleading to users since it looks like these are string properties, not numeric or boolean.  With my code change the model schema becomes what you want it to be:

{
  "minPasswordLength": 4,
  "requireMixedCase": true,
  "requireNumericChars": true,
  "requireSpecialChars": true,
  "passwordExpires": true,
  "maxPasswordAge": 90,
  "lockAfterFailedAttempts": 3,
  "lockPeriod": 2
}

You still specify the example value in @ApiModelProperty as a String so those using the annotation don't need to change anything.