### PR TITLE
Refs #1636 Option 5 - full JAX-RS compliance (#1106, #1629, #1617, #1614)

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -196,8 +196,8 @@ public class Reader {
         // class readable only if annotated with @Path or isSubresource, or and @Api not hidden
         boolean classReadable = (hasPathAnnotation || isSubresource) && !isApiHidden ;
 
-        // readable if @Api annotated or scanAllResources true in config
-        boolean readable = classReadable && (hasApiAnnotation || config.isScanAllResources());
+        // readable if classReadable or (scanAllResources true in config and @Api not hidden)
+        boolean readable = classReadable || (!isApiHidden && config.isScanAllResources());
 
         if (!readable) {
             return swagger;

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/HiddenParametersScannerTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/HiddenParametersScannerTest.java
@@ -1,7 +1,6 @@
 package io.swagger;
 
 import io.swagger.jaxrs.Reader;
-import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
@@ -14,14 +13,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 public class HiddenParametersScannerTest {
-    private Swagger swagger;
-
-    public HiddenParametersScannerTest() {
-        DefaultReaderConfig config = new DefaultReaderConfig();
-        config.setScanAllResources(true);
-        swagger = new Reader(new Swagger(), config).read(HiddenParametersResource.class);
-
-    }
+    private final Swagger swagger = new Reader(new Swagger()).read(HiddenParametersResource.class);
 
     @Test
     public void shouldScanMethodWithAllParamsHidden() throws Exception {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -1,7 +1,6 @@
 package io.swagger;
 
 import io.swagger.jaxrs.Reader;
-import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.*;
@@ -143,7 +142,7 @@ public class ReaderTest {
 
     @Test(description = "scan annotation from interface, issue#1427")
     public void scanInterfaceTest() {
-        final Swagger swagger = getSwagger(AnnotatedInterfaceImpl.class);
+        final Swagger swagger = new Reader(new Swagger()).read(AnnotatedInterfaceImpl.class);
         assertNotNull(swagger);
         assertNotNull(swagger.getPath("/v1/users/{id}").getGet());
     }
@@ -285,9 +284,7 @@ public class ReaderTest {
     }
 
     private Swagger getSwagger(Class<?> cls) {
-        DefaultReaderConfig config = new DefaultReaderConfig();
-        config.setScanAllResources(true);
-        return new Reader(new Swagger(), config).read(cls);
+        return new Reader(new Swagger()).read(cls);
     }
 
     private Operation getGet(Swagger swagger, String path) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReferenceTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReferenceTest.java
@@ -2,7 +2,6 @@ package io.swagger;
 
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.Reader;
-import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.matchers.SerializationMatchers;
 import io.swagger.models.Pet;
 import io.swagger.models.Swagger;
@@ -38,9 +37,7 @@ public class ReferenceTest {
 
     @Test(description = "Scan API with operation and response references")
     public void scanAPI() throws IOException {
-        DefaultReaderConfig config = new DefaultReaderConfig();
-        config.setScanAllResources(true);
-        final Swagger swagger = new Reader(new Swagger(), config).read(ResourceWithReferences.class);
+        final Swagger swagger = new Reader(new Swagger()).read(ResourceWithReferences.class);
         final String json = ResourceUtils.loadClassResource(getClass(), "ResourceWithReferences.json");
         SerializationMatchers.assertEqualsToJson(swagger, json);
     }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/RegexPathParamTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/RegexPathParamTest.java
@@ -1,7 +1,6 @@
 package io.swagger;
 
 import io.swagger.jaxrs.Reader;
-import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
@@ -14,9 +13,7 @@ public class RegexPathParamTest {
 
     @Test(description = "scan a simple resource")
     public void scanSimpleResource() {
-        DefaultReaderConfig config = new DefaultReaderConfig();
-        config.setScanAllResources(true);
-        Swagger swagger = new Reader(new Swagger(), config).read(RegexPathParamResource.class);
+        Swagger swagger = new Reader(new Swagger()).read(RegexPathParamResource.class);
         Operation get = swagger.getPaths().get("/{report_type}").getGet();
         Parameter param = get.getParameters().get(0);
         assertEquals(param.getName(), "report_type");

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -49,9 +49,7 @@ import static org.testng.Assert.fail;
 public class SimpleReaderTest {
 
     private Swagger getSwagger(Class<?> cls) {
-        DefaultReaderConfig config = new DefaultReaderConfig();
-        config.setScanAllResources(true);
-        return new Reader(new Swagger(), config).read(cls);
+        return new Reader(new Swagger()).read(cls);
     }
 
     private Map<String, Response> getGetResponses(Swagger swagger, String path) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/AnnotatedInterfaceImpl.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/AnnotatedInterfaceImpl.java
@@ -3,6 +3,8 @@ package io.swagger.resources;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
+import javax.ws.rs.Path;
+
 @Api(value = "/v1/users", tags = "annotatedInterface")
 public class AnnotatedInterfaceImpl implements AnnotatedInterface {
 

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ApiConsumesProducesResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ApiConsumesProducesResource.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Api(value = "/basic", description = "Basic resource", produces = MediaType.APPLICATION_ATOM_XML, consumes = MediaType.APPLICATION_XHTML_XML)
+@Path("/")
 public class ApiConsumesProducesResource {
 
     @GET

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/BothConsumesProducesResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/BothConsumesProducesResource.java
@@ -15,6 +15,7 @@ import javax.ws.rs.core.Response;
 @Api(value = "/basic", description = "Basic resource", produces = MediaType.APPLICATION_ATOM_XML, consumes = MediaType.APPLICATION_XHTML_XML)
 @Produces({"application/xml"})
 @Consumes({"application/yaml"})
+@Path("/")
 public class BothConsumesProducesResource {
 
     @GET

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ClassWithExamplePost.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ClassWithExamplePost.java
@@ -9,6 +9,7 @@ import javax.ws.rs.QueryParam;
 import java.util.ArrayList;
 
 @Api("/external/info/")
+@Path("/")
 public class ClassWithExamplePost {
     @ApiOperation(value = "test")
     @POST

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/HiddenParametersResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/HiddenParametersResource.java
@@ -15,6 +15,7 @@ import javax.ws.rs.core.Response;
 
 @Api(value = "/basic", description = "Basic resource")
 @Produces({"application/xml"})
+@Path("/")
 public class HiddenParametersResource {
     @GET
     @Path("/all-hidden/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/NoConsumesProducesResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/NoConsumesProducesResource.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Api(value = "/basic", description = "Basic resource")
+@Path("/")
 public class NoConsumesProducesResource {
 
     @GET

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/RegexPathParamResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/RegexPathParamResource.java
@@ -10,6 +10,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 
 @Api(value = "/external/info/")
+@Path("/")
 public class RegexPathParamResource {
     @GET
     @ApiOperation(value = "this", tags = "tag1")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithApiOperationCode.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithApiOperationCode.java
@@ -14,6 +14,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
 @Api
+@Path("/")
 public class ResourceWithApiOperationCode {
     @GET
     @Path("/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithApiResponseResponseContainer.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithApiResponseResponseContainer.java
@@ -16,6 +16,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
 @Api
+@Path("/")
 public class ResourceWithApiResponseResponseContainer {
     @GET
     @Path("/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithBodyParams.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithBodyParams.java
@@ -9,6 +9,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
 @Api
+@Path("/")
 public class ResourceWithBodyParams {
 
     @POST

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithCustomException.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithCustomException.java
@@ -17,6 +17,7 @@ import io.swagger.models.Sample;
 
 @Api(value = "/basicWithException", description = "Basic resource")
 @Produces({"application/xml"})
+@Path("/")
 public class ResourceWithCustomException {
 
     @GET

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithDeprecatedMethod.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithDeprecatedMethod.java
@@ -7,6 +7,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 @Api
+@Path("/")
 public class ResourceWithDeprecatedMethod {
 
     @Deprecated

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithEnums.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithEnums.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 
 @Api(value = "/basic", description = "Basic resource")
 @Produces({"application/xml"})
+@Path("/")
 public class ResourceWithEnums {
     @GET
     @Path("/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithImplicitFileParam.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithImplicitFileParam.java
@@ -9,6 +9,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
 @Api
+@Path("/")
 public class ResourceWithImplicitFileParam {
     @POST
     @Path("/testString")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithImplicitParams.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithImplicitParams.java
@@ -9,6 +9,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
 @Api
+@Path("/")
 public class ResourceWithImplicitParams {
 
     @POST

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithInnerClass.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithInnerClass.java
@@ -9,6 +9,7 @@ import javax.ws.rs.Path;
 import java.util.List;
 
 @Api("/basic")
+@Path("/")
 public class ResourceWithInnerClass {
 
     @GET

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithMapReturnValue.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithMapReturnValue.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Api(value = "/basic", description = "Basic resource")
+@Path("/")
 public class ResourceWithMapReturnValue {
     @GET
     @Path("/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithRanges.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithRanges.java
@@ -17,6 +17,7 @@ import javax.ws.rs.core.Response;
 
 @Api(value = "/basic", description = "Basic resource")
 @Produces({"application/xml"})
+@Path("/")
 public class ResourceWithRanges {
     @GET
     @Path("/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithReferences.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithReferences.java
@@ -13,6 +13,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 @Api(value = "/basic")
+@Path("/")
 public class ResourceWithReferences {
 
     @GET

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithResponse.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithResponse.java
@@ -15,6 +15,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 @Api(value = "/basic", description = "Basic resource")
+@Path("/")
 public class ResourceWithResponse {
     @GET
     @Path("/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithResponseHeaders.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithResponseHeaders.java
@@ -20,6 +20,7 @@ import javax.ws.rs.core.Response;
 
 @Api(value = "/basic", description = "Basic resource")
 @Produces({"application/xml"})
+@Path("/")
 public class ResourceWithResponseHeaders {
     @GET
     @Path("/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithTypedResponses.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithTypedResponses.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @Api(value = "/root")
+@Path("/")
 public class ResourceWithTypedResponses {
 
     @GET

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithValidation.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithValidation.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Response;
 
 @Api(value = "/basic", description = "Basic resource")
 @Produces({"application/xml"})
+@Path("/")
 public class ResourceWithValidation {
 
     @GET

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithVoidReturns.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithVoidReturns.java
@@ -16,6 +16,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 @Api(value = "/basic", description = "Basic resource")
+@Path("/")
 public class ResourceWithVoidReturns {
     @GET
     @Path("/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/RsConsumesProducesResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/RsConsumesProducesResource.java
@@ -15,6 +15,7 @@ import javax.ws.rs.core.Response;
 @Api(value = "/basic", description = "Basic resource")
 @Produces({"application/xml"})
 @Consumes({"application/yaml"})
+@Path("/")
 public class RsConsumesProducesResource {
 
     @GET

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResource.java
@@ -20,6 +20,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
+@Path("/")
 @Api(value = "/basic", description = "Basic resource")
 @Produces({"application/xml"})
 public class SimpleResource {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceWithoutAnnotations.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceWithoutAnnotations.java
@@ -16,6 +16,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
 @Produces({"application/xml"})
+@Path("/")
 public class SimpleResourceWithoutAnnotations {
     @GET
     @Path("/{id}")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleSelfReferencingSubResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleSelfReferencingSubResource.java
@@ -6,6 +6,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 
+@Path("/")
 public class SimpleSelfReferencingSubResource {
 
     @Path("/sub")

--- a/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/resources/ResourceWithBeanParams.java
+++ b/modules/swagger-jersey2-jaxrs/src/test/java/io/swagger/resources/ResourceWithBeanParams.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Api(value = "/basic", description = "Basic resource")
+@Path("/")
 public class ResourceWithBeanParams {
     @GET
     @Path("/{id}")


### PR DESCRIPTION
Refs #1636 Option 5 - full JAX-RS compliance (#1106, #1629, #1617, #1614)

@fehguy

It implements Option 5 behaviour in #1636, as discussed it implies quite a change in behaviour regarding JAX-RS classes scanning/reading, and possibly existing clients would experience issues if based on a "non fully JAX-RS" config. 
