### PR TITLE
Ignore property if XmlAccessType.NONE and no XmlElement

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/jackson/XMLInfoTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/jackson/XMLInfoTest.java
@@ -1,12 +1,6 @@
 package io.swagger.jackson;
 
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertEquals;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.testng.annotations.Test;
-
 import io.swagger.annotations.ApiModel;
 import io.swagger.converter.ModelConverter;
 import io.swagger.converter.ModelConverterContextImpl;
@@ -14,11 +8,17 @@ import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.Xml;
 import io.swagger.models.properties.Property;
-
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.List;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
 
 public class XMLInfoTest extends SwaggerTestBase {
 
@@ -48,6 +48,7 @@ public class XMLInfoTest extends SwaggerTestBase {
     @XmlRootElement(name = "xmlDecoratedBean")
     @ApiModel(description = "DESC")
     static class XmlDecoratedBean {
+
         @XmlElement(name = "elementB")
         public int b;
 
@@ -58,4 +59,63 @@ public class XMLInfoTest extends SwaggerTestBase {
         @JsonProperty("elementC")
         public String c;
     }
+
+    @Test
+    public void testReadingXmlAccessorTypeNone() throws Exception {
+        final ModelConverter mr = modelResolver();
+        final Model model = mr.resolve(XmlDecoratedBeanXmlAccessorNone.class, new ModelConverterContextImpl(mr), null);
+        assertTrue(model instanceof ModelImpl);
+
+        final ModelImpl impl = (ModelImpl) model;
+
+        final Xml xml = impl.getXml();
+        assertNotNull(xml);
+        assertEquals(xml.getName(), "xmlDecoratedBean");
+
+        final Property property = impl.getProperties().get("a");
+        assertNotNull(property);
+
+        assertNull(impl.getProperties().get("b"));
+    }
+
+    @Test
+    public void testReadingXmlAccessorTypePublic() throws Exception {
+        final ModelConverter mr = modelResolver();
+        final Model model = mr.resolve(XmlDecoratedBeanXmlAccessorPublic.class, new ModelConverterContextImpl(mr), null);
+        assertTrue(model instanceof ModelImpl);
+
+        final ModelImpl impl = (ModelImpl) model;
+
+        final Xml xml = impl.getXml();
+        assertNotNull(xml);
+        assertEquals(xml.getName(), "xmlDecoratedBean");
+
+        final Property propertyA = impl.getProperties().get("a");
+        assertNotNull(propertyA);
+        
+        Property propertyB = impl.getProperties().get("b");
+        assertNotNull(propertyB);
+    }
+
+    @XmlRootElement(name = "xmlDecoratedBean")
+    @XmlAccessorType(XmlAccessType.NONE)
+    @ApiModel
+    static class XmlDecoratedBeanXmlAccessorNone {
+
+        @XmlElement
+        public int a;
+
+        public String b;
+    }
+
+    @XmlRootElement(name = "xmlDecoratedBean")
+    @ApiModel
+    static class XmlDecoratedBeanXmlAccessorPublic {
+
+        @XmlElement
+        public int a;
+
+        public String b;
+    }
+
 }


### PR DESCRIPTION
Adding functionality, if class is tagged XmlAccessType.NONE and the
property is not tagged XmlElement, the property is ignored in the
output.