### PR TITLE
When no ApiOperation, produces or consumes not read

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -26,8 +26,6 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.AuthorizationScope;
-import io.swagger.annotations.Extension;
-import io.swagger.annotations.ExtensionProperty;
 import io.swagger.annotations.Info;
 import io.swagger.annotations.ResponseHeader;
 import io.swagger.annotations.SwaggerDefinition;
@@ -63,14 +61,6 @@ import io.swagger.util.BaseReaderUtils;
 import io.swagger.util.ParameterProcessor;
 import io.swagger.util.PathUtils;
 import io.swagger.util.ReflectionUtils;
-
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.HttpMethod;
-import javax.ws.rs.Produces;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -86,6 +76,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.Produces;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Reader {
     private static final Logger LOGGER = LoggerFactory.getLogger(Reader.class);
@@ -797,7 +793,7 @@ public class Reader {
 
         operation.operationId(operationId);
 
-        if (apiOperation != null && apiOperation.consumes() != null && apiOperation.consumes().isEmpty()) {
+        if (apiOperation == null || apiOperation.consumes() == null || apiOperation.consumes().isEmpty()) {
             final Consumes consumes = ReflectionUtils.getAnnotation(method, Consumes.class);
             if (consumes != null) {
                 for (String mediaType : ReaderUtils.splitContentValues(consumes.value())) {
@@ -806,7 +802,7 @@ public class Reader {
             }
         }
 
-        if (apiOperation != null && apiOperation.produces() != null && apiOperation.produces().isEmpty()) {
+        if (apiOperation == null || apiOperation.produces() == null || apiOperation.produces().isEmpty()) {
             final Produces produces = ReflectionUtils.getAnnotation(method, Produces.class);
             if (produces != null) {
                 for (String mediaType : ReaderUtils.splitContentValues(produces.value())) {

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -1,19 +1,15 @@
 /**
  * Copyright 2016 SmartBear Software
  * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
  * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
  * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
  */
-
 package io.swagger.jaxrs;
 
 import com.fasterxml.jackson.databind.JavaType;
@@ -84,6 +80,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Reader {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Reader.class);
     private static final String SUCCESSFUL_OPERATION = "successful operation";
     private static final String PATH_DELIMITER = "/";
@@ -101,14 +98,12 @@ public class Reader {
     }
 
     /**
-     * Scans a set of classes for both ReaderListeners and Swagger annotations. All found listeners will
-     * be instantiated before any of the classes are scanned for Swagger annotations - so they can be invoked
-     * accordingly.
+     * Scans a set of classes for both ReaderListeners and Swagger annotations. All found listeners will be instantiated before any of the classes are
+     * scanned for Swagger annotations - so they can be invoked accordingly.
      *
      * @param classes a set of classes to scan
      * @return the generated Swagger definition
      */
-
     public Swagger read(Set<Class<?>> classes) {
 
         Map<Class<?>, ReaderListener> listeners = new HashMap<Class<?>, ReaderListener>();
@@ -161,7 +156,6 @@ public class Reader {
     /**
      * Scans a single class for Swagger annotations - does not invoke ReaderListeners
      */
-
     public Swagger read(Class<?> cls) {
 
         SwaggerDefinition swaggerDefinition = cls.getAnnotation(SwaggerDefinition.class);
@@ -171,6 +165,7 @@ public class Reader {
 
         return read(cls, "", null, false, new String[0], new String[0], new HashMap<String, Tag>(), new ArrayList<Parameter>(), new HashSet<Class<?>>());
     }
+
     protected Swagger read(Class<?> cls, String parentPath, String parentMethod, boolean isSubresource, String[] parentConsumes, String[] parentProduces, Map<String, Tag> parentTags, List<Parameter> parentParameters) {
         return read(cls, parentPath, parentMethod, isSubresource, parentConsumes, parentProduces, parentTags, parentParameters, new HashSet<Class<?>>());
     }
@@ -192,7 +187,7 @@ public class Reader {
         boolean isApiHidden = hasApiAnnotation && api.hidden();
 
         // class readable only if annotated with @Path or isSubresource, or and @Api not hidden
-        boolean classReadable = (hasPathAnnotation || isSubresource) && !isApiHidden ;
+        boolean classReadable = (hasPathAnnotation || isSubresource) && !isApiHidden;
 
         // readable if classReadable or (scanAllResources true in config and @Api not hidden)
         boolean readable = classReadable || (!isApiHidden && config.isScanAllResources());
@@ -202,7 +197,7 @@ public class Reader {
         }
 
         // api readable only if @Api present; cannot be hidden because checked in classReadable.
-        boolean apiReadable =  hasApiAnnotation;
+        boolean apiReadable = hasApiAnnotation;
 
         if (apiReadable) {
             // the value will be used as a tag for 2.0 UNLESS a Tags annotation is present
@@ -217,13 +212,9 @@ public class Reader {
 
             if (!api.produces().isEmpty()) {
                 produces = new String[]{api.produces()};
-            } else if (cls.getAnnotation(Produces.class) != null) {
-                produces = ReaderUtils.splitContentValues(cls.getAnnotation(Produces.class).value());
             }
             if (!api.consumes().isEmpty()) {
                 consumes = new String[]{api.consumes()};
-            } else if (cls.getAnnotation(Consumes.class) != null) {
-                consumes = ReaderUtils.splitContentValues(cls.getAnnotation(Consumes.class).value());
             }
             globalSchemes.addAll(parseSchemes(api.protocols()));
             Authorization[] authorizations = api.authorizations();
@@ -253,9 +244,7 @@ public class Reader {
             // merge consumes, produces
 
             // look for method-level annotated properties
-
             // handle sub-resources by looking at return type
-
             final List<Parameter> globalParameters = new ArrayList<Parameter>();
 
             // look for constructor-level annotated properties
@@ -285,7 +274,7 @@ public class Reader {
                     String httpMethod = extractOperationMethod(apiOperation, method, SwaggerExtensions.chain());
 
                     Operation operation = null;
-                    if(apiOperation != null || config.isScanAllResources() || httpMethod != null || methodPath != null) {
+                    if (apiOperation != null || config.isScanAllResources() || httpMethod != null || methodPath != null) {
                         operation = parseMethod(cls, method, globalParameters);
                     }
                     if (operation == null) {
@@ -315,6 +304,10 @@ public class Reader {
                         }
                     }
 
+                    if (consumes.length == 0 && cls.getAnnotation(Consumes.class) != null) {
+                        consumes = ReaderUtils.splitContentValues(cls.getAnnotation(Consumes.class).value());
+                    }
+
                     String[] apiConsumes = consumes;
                     if (parentConsumes != null) {
                         Set<String> both = new HashSet<String>(Arrays.asList(apiConsumes));
@@ -323,6 +316,10 @@ public class Reader {
                             both.addAll(new HashSet<String>(operation.getConsumes()));
                         }
                         apiConsumes = both.toArray(new String[both.size()]);
+                    }
+
+                    if (produces.length == 0 && cls.getAnnotation(Produces.class) != null) {
+                        produces = ReaderUtils.splitContentValues(cls.getAnnotation(Produces.class).value());
                     }
 
                     String[] apiProduces = produces;
@@ -988,32 +985,33 @@ public class Reader {
     }
 
     enum ContainerWrapper {
+
         LIST("list") {
-            @Override
-            protected Property doWrap(Property property) {
-                return new ArrayProperty(property);
-            }
-        },
+                    @Override
+                    protected Property doWrap(Property property) {
+                        return new ArrayProperty(property);
+                    }
+                },
         ARRAY("array") {
-            @Override
-            protected Property doWrap(Property property) {
-                return new ArrayProperty(property);
-            }
-        },
+                    @Override
+                    protected Property doWrap(Property property) {
+                        return new ArrayProperty(property);
+                    }
+                },
         MAP("map") {
-            @Override
-            protected Property doWrap(Property property) {
-                return new MapProperty(property);
-            }
-        },
+                    @Override
+                    protected Property doWrap(Property property) {
+                        return new MapProperty(property);
+                    }
+                },
         SET("set") {
-            @Override
-            protected Property doWrap(Property property) {
-                ArrayProperty arrayProperty = new ArrayProperty(property);
-                arrayProperty.setUniqueItems(true);
-                return arrayProperty;
-            }
-        };
+                    @Override
+                    protected Property doWrap(Property property) {
+                        ArrayProperty arrayProperty = new ArrayProperty(property);
+                        arrayProperty.setUniqueItems(true);
+                        return arrayProperty;
+                    }
+                };
 
         private final String container;
 

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -4,20 +4,46 @@ import io.swagger.jaxrs.Reader;
 import io.swagger.jaxrs.config.DefaultReaderConfig;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
-import io.swagger.models.parameters.*;
-import io.swagger.resources.*;
-import org.testng.annotations.Test;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.parameters.FormParameter;
+import io.swagger.models.parameters.HeaderParameter;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.parameters.PathParameter;
+import io.swagger.models.parameters.QueryParameter;
+import io.swagger.resources.AnnotatedInterfaceImpl;
+import io.swagger.resources.ApiConsumesProducesResource;
+import io.swagger.resources.BookResource;
+import io.swagger.resources.BothConsumesProducesResource;
+import io.swagger.resources.DescendantResource;
+import io.swagger.resources.NoConsumesProducesResource;
+import io.swagger.resources.ResourceWithCustomException;
+import io.swagger.resources.ResourceWithDeprecatedMethod;
+import io.swagger.resources.ResourceWithEmptyPath;
+import io.swagger.resources.ResourceWithImplicitFileParam;
+import io.swagger.resources.ResourceWithImplicitParams;
+import io.swagger.resources.ResourceWithKnownInjections;
+import io.swagger.resources.ResourceWithValidation;
+import io.swagger.resources.RsConsumesProducesResource;
+import io.swagger.resources.SimpleMethods;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
-
-import static org.testng.Assert.*;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.OPTIONS;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.core.MediaType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.Test;
 
 public class ReaderTest {
+
     private static final String APPLICATION_XML = "application/xml";
     private static final String TEXT_PLAIN = "text/plain";
     private static final String TEXT_HTML = "text/html";
@@ -41,10 +67,14 @@ public class ReaderTest {
         assertEquals(getGet(swagger, "/{id}").getProduces().get(0), MediaType.APPLICATION_ATOM_XML);
         assertEquals(getGet(swagger, "/{id}/value").getConsumes().get(0), APPLICATION_XML);
         assertEquals(getGet(swagger, "/{id}/value").getProduces().get(0), TEXT_PLAIN);
+        
         assertEquals(getPut(swagger, "/{id}").getConsumes().get(0), MediaType.APPLICATION_JSON);
         assertEquals(getPut(swagger, "/{id}").getProduces().get(0), TEXT_PLAIN);
         assertEquals(getPut(swagger, "/{id}/value").getConsumes().get(0), APPLICATION_XML);
         assertEquals(getPut(swagger, "/{id}/value").getProduces().get(0), TEXT_PLAIN);
+        
+        assertEquals(getPost(swagger, "/{id}").getConsumes().get(0), MediaType.APPLICATION_JSON);
+        assertEquals(getPost(swagger, "/{id}").getProduces().get(0), TEXT_PLAIN);
     }
 
     @Test(description = "scan consumes and produces values with rs class level annotations")
@@ -58,8 +88,8 @@ public class ReaderTest {
         assertEquals(getPut(swagger, "/{id}").getProduces().get(0), TEXT_PLAIN);
         assertEquals(getPut(swagger, "/{id}/value").getConsumes().get(0), APPLICATION_XML);
         assertEquals(getPut(swagger, "/{id}/value").getProduces().get(0), TEXT_PLAIN);
-        assertEquals(getPut(swagger, "/split").getProduces(), Arrays.asList("image/jpeg",  "image/gif", "image/png"));
-        assertEquals(getPut(swagger, "/split").getConsumes(), Arrays.asList("image/jpeg",  "image/gif", "image/png"));
+        assertEquals(getPut(swagger, "/split").getProduces(), Arrays.asList("image/jpeg", "image/gif", "image/png"));
+        assertEquals(getPut(swagger, "/split").getConsumes(), Arrays.asList("image/jpeg", "image/gif", "image/png"));
     }
 
     @Test(description = "scan consumes and produces values with both class level annotations")
@@ -212,11 +242,11 @@ public class ReaderTest {
     }
 
     @Test(description = "it should scan parameters from base resource class")
-    public void scanParametersFromBaseResource(){
+    public void scanParametersFromBaseResource() {
         Swagger swagger = getSwagger(BookResource.class);
         assertNotNull(swagger);
 
-        List<Parameter> parameters =  getGet(swagger, "/{id}/v1/books/{name}").getParameters();
+        List<Parameter> parameters = getGet(swagger, "/{id}/v1/books/{name}").getParameters();
         assertEquals(parameters.size(), 4);
 
         Parameter description = parameters.get(0);
@@ -241,7 +271,7 @@ public class ReaderTest {
     }
 
     @Test(description = "it should scan parameters with Swagger and JSR-303 bean validation annotations")
-    public void scanBeanValidation(){
+    public void scanBeanValidation() {
 
         Swagger swagger = getSwagger(ResourceWithValidation.class);
         assertNotNull(swagger);
@@ -296,5 +326,9 @@ public class ReaderTest {
 
     private Operation getPut(Swagger swagger, String path) {
         return swagger.getPath(path).getPut();
+    }
+
+    private Operation getPost(Swagger swagger, String path) {
+        return swagger.getPath(path).getPost();
     }
 }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -14,6 +14,7 @@ import io.swagger.resources.ApiConsumesProducesResource;
 import io.swagger.resources.BookResource;
 import io.swagger.resources.BothConsumesProducesResource;
 import io.swagger.resources.DescendantResource;
+import io.swagger.resources.NoApiConsumesProducesClassLevelAnnotations;
 import io.swagger.resources.NoConsumesProducesResource;
 import io.swagger.resources.ResourceWithCustomException;
 import io.swagger.resources.ResourceWithDeprecatedMethod;
@@ -66,14 +67,21 @@ public class ReaderTest {
         assertEquals(getGet(swagger, "/{id}").getProduces().get(0), MediaType.APPLICATION_ATOM_XML);
         assertEquals(getGet(swagger, "/{id}/value").getConsumes().get(0), APPLICATION_XML);
         assertEquals(getGet(swagger, "/{id}/value").getProduces().get(0), TEXT_PLAIN);
-        
+
         assertEquals(getPut(swagger, "/{id}").getConsumes().get(0), MediaType.APPLICATION_JSON);
         assertEquals(getPut(swagger, "/{id}").getProduces().get(0), TEXT_PLAIN);
         assertEquals(getPut(swagger, "/{id}/value").getConsumes().get(0), APPLICATION_XML);
         assertEquals(getPut(swagger, "/{id}/value").getProduces().get(0), TEXT_PLAIN);
-        
+
         assertEquals(getPost(swagger, "/{id}").getConsumes().get(0), MediaType.APPLICATION_JSON);
         assertEquals(getPost(swagger, "/{id}").getProduces().get(0), TEXT_PLAIN);
+    }
+
+    @Test(description = "scan consumes and produces class level annotations without api class level annotation")
+    public void scanNoApiConsumesProducesClassLevelAnnotations() {
+        Swagger swagger = getSwagger(NoApiConsumesProducesClassLevelAnnotations.class);
+        assertEquals(getGet(swagger, "/{id}").getConsumes().get(0), "application/yaml");
+        assertEquals(getGet(swagger, "/{id}").getProduces().get(0), MediaType.APPLICATION_XML);
     }
 
     @Test(description = "scan consumes and produces values with rs class level annotations")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ApiConsumesProducesResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ApiConsumesProducesResource.java
@@ -3,9 +3,9 @@ package io.swagger.resources;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.models.Sample;
-
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -47,6 +47,14 @@ public class ApiConsumesProducesResource {
             notes = "No details provided",
             position = 1)
     public Response rsConsumesProduces() {
+        return Response.ok().build();
+    }
+    
+    @POST
+    @Path("/{id}")
+    @Produces({"text/plain"})
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response rsConsumesProducesWoApiOperation() {
         return Response.ok().build();
     }
 

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/NoApiConsumesProducesClassLevelAnnotations.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/NoApiConsumesProducesClassLevelAnnotations.java
@@ -1,0 +1,26 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.models.Sample;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+@Produces({"application/xml"})
+@Consumes({"application/yaml"})
+@Path("/")
+public class NoApiConsumesProducesClassLevelAnnotations {
+    
+    @GET
+    @Path("/{id}")
+    @ApiOperation(value = "Get object by ID",
+            notes = "No details provided",
+            response = Sample.class,
+            position = 0)
+    public Response noConsumesProduces() {
+        return Response.ok().entity("ok").build();
+    }
+
+}


### PR DESCRIPTION
When annotation ApiOperation is not present, the code does not fall back to
standard Produces and Consumes annotations.