### PR TITLE
issue #1667

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractProperty.java
@@ -52,6 +52,11 @@ public abstract class AbstractProperty implements Property {
         this.example = example;
     }
 
+    @Override
+    public void setExample(String example) {
+        this.setExample((Object) example);
+    }
+
     public Integer getPosition() {
         return position;
     }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/Property.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/Property.java
@@ -36,6 +36,10 @@ public interface Property {
 
     void setExample(Object example);
 
+    @Deprecated
+    @JsonIgnore
+    void setExample(String example);
+
     Boolean getReadOnly();
 
     void setReadOnly(Boolean readOnly);


### PR DESCRIPTION
Removal of `Property#setExample(String)` can cause linkage errors at runtime, if there are conflicting versions of swagger-models. For example, springfox-swagger2 uses swagger-core:1.5.6, which pulls in swagger-models:1.5.6. If swagger-codegen is also in the classpath, `Property#setExample(String)` from the swagger-models:1.5.6 clashes with `Property#setExample(Object)`; overriding the transitive dependency is not an option due to the incompatible signature-change. This change adds the method back to the `Property` class but marks it as deprecated, thereby preserving backwards-compatibility.