### PR TITLE
Added Model.getDiscriminator() for #1671

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/Model.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Model.java
@@ -30,4 +30,7 @@ public interface Model {
     Object clone();
 
     Map<String, Object> getVendorExtensions();
+
+    String getDiscriminator();
+
 }


### PR DESCRIPTION
As discussed in the issue #1671, this pull request simply adds a getDiscriminator() method to the Model interface. The discriminator property is already supported by ModelImpl and detailed in the swagger 2.0 spec. 