### PR TITLE
Fix #1512 - nickname not to be considered for path

### DIFF
--- a/modules/swagger-servlet/src/main/java/io/swagger/servlet/extensions/ServletReaderExtension.java
+++ b/modules/swagger-servlet/src/main/java/io/swagger/servlet/extensions/ServletReaderExtension.java
@@ -222,7 +222,7 @@ public class ServletReaderExtension implements ReaderExtension {
         final String operationPath = apiOperation == null ? null : apiOperation.nickname();
         return PathUtils.collectPath(context.getParentPath(),
                 apiAnnotation == null ? null : apiAnnotation.value(),
-                StringUtils.defaultIfBlank(operationPath, method.getName()));
+                method.getName());
     }
 
     @Override

--- a/modules/swagger-servlet/src/test/java/io/swagger/servlet/ReaderTest.java
+++ b/modules/swagger-servlet/src/test/java/io/swagger/servlet/ReaderTest.java
@@ -43,12 +43,12 @@ public class ReaderTest {
 
         Assert.assertEquals(swagger.getHost(), "host");
         Assert.assertEquals(swagger.getBasePath(), "/api");
-        Assert.assertNotNull(swagger.getPath("/resources/users"));
+        Assert.assertNotNull(swagger.getPath("/resources/testMethod3"));
         Assert.assertNotNull(swagger.getDefinitions().get("SampleData"));
         Assert.assertEquals(swagger.getExternalDocs().getDescription(), "docs");
         Assert.assertEquals(swagger.getExternalDocs().getUrl(), "url_to_docs");
 
-        Path path = swagger.getPath("/resources/users");
+        Path path = swagger.getPath("/resources/testMethod3");
         Assert.assertNotNull(path);
         Operation get = path.getGet();
         Assert.assertNotNull( get );

--- a/modules/swagger-servlet/src/test/java/io/swagger/servlet/extensions/PathGetterTest.java
+++ b/modules/swagger-servlet/src/test/java/io/swagger/servlet/extensions/PathGetterTest.java
@@ -13,7 +13,7 @@ public class PathGetterTest extends BaseServletReaderExtensionTest {
         return new Object[][]{
                 {"testMethod1", "/tests/resources/testMethod1"},
                 {"testMethod2", "/tests/resources/testMethod2"},
-                {"testMethod3", "/tests/resources/users"},
+                {"testMethod3", "/tests/resources/testMethod3"},
                 {"testMethod4", "/tests/resources/testMethod4"},
         };
     }
@@ -23,7 +23,7 @@ public class PathGetterTest extends BaseServletReaderExtensionTest {
         return new Object[][]{
                 {"testMethod1", "/tests/testMethod1"},
                 {"testMethod2", "/tests/testMethod2"},
-                {"testMethod3", "/tests/users"},
+                {"testMethod3", "/tests/testMethod3"},
                 {"testMethod4", "/tests/testMethod4"},
         };
     }


### PR DESCRIPTION
Fix #1512 - doesn't consider anymore nickname for path building in swagger-servlet. 

Note: nickname is still used in swagger-jaxrs, we would possibly have a consistent behaviour and apply the change also in jaxrs