### PR TITLE
Allow user created @PATCH, @GET ...etc annotations

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -925,8 +925,10 @@ public class Reader {
         } else if (method.getAnnotation(PATCH.class) != null) {
             return "patch";
         } else if (method.getAnnotation(HttpMethod.class) != null) {
-            HttpMethod httpMethod = (HttpMethod) method.getAnnotation(HttpMethod.class);
+            HttpMethod httpMethod = method.getAnnotation(HttpMethod.class);
             return httpMethod.value().toLowerCase();
+        } else if(!StringUtils.isEmpty(getHttpMethodFromCustomAnnotations(method))) {
+            return getHttpMethodFromCustomAnnotations(method);
         } else if ((ReflectionUtils.getOverriddenMethod(method)) != null) {
             return extractOperationMethod(apiOperation, ReflectionUtils.getOverriddenMethod(method), chain);
         } else if (chain != null && chain.hasNext()) {
@@ -934,6 +936,16 @@ public class Reader {
         } else {
             return null;
         }
+    }
+
+    private String getHttpMethodFromCustomAnnotations(Method method) {
+        for(Annotation methodAnnotation : method.getAnnotations()){
+            HttpMethod httpMethod = methodAnnotation.annotationType().getAnnotation(HttpMethod.class);
+            if(httpMethod != null) {
+                return httpMethod.value().toLowerCase();
+            }
+        }
+        return null;
     }
 
     private static Set<Scheme> parseSchemes(String schemes) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -84,6 +84,14 @@ public class SimpleReaderTest {
         return swagger.getPaths().get(path).getPut();
     }
 
+    private Operation getPatch(Swagger swagger, String path) {
+        return swagger.getPaths().get(path).getPatch();
+    }
+
+    private Operation getDelete(Swagger swagger, String path) {
+        return swagger.getPaths().get(path).getDelete();
+    }
+
     @Test(description = "scan a simple resource")
     public void scanSimpleResource() {
         Swagger swagger = getSwagger(SimpleResource.class);
@@ -116,6 +124,26 @@ public class SimpleReaderTest {
         assertEquals(bodyParam2.getIn(), "body");
         assertEquals(bodyParam2.getName(), "body");
         assertFalse(bodyParam2.getRequired());
+    }
+
+    @Test(description = "scan a resource with custom http method annotations")
+    public void scanResourceWithCustomHttpMethodAnnotations() {
+        Swagger swagger = getSwagger(ResourceWithCustomHTTPMethodAnnotations.class);
+
+        Operation get = getGet(swagger, "/");
+        assertNotNull(get);
+
+        Operation post = getPost(swagger, "/");
+        assertNotNull(post);
+
+        Operation patch = getPatch(swagger, "/");
+        assertNotNull(patch);
+
+        Operation put = getPut(swagger, "/");
+        assertNotNull(post);
+
+        Operation delete = getDelete(swagger, "/");
+        assertNotNull(delete);
     }
 
     @Test(description = "scan a resource with void return type")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithCustomHTTPMethodAnnotations.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithCustomHTTPMethodAnnotations.java
@@ -1,0 +1,77 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.*;
+import io.swagger.models.NotFoundModel;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Api(value = "/custom-http", description = "Resource using custom http methods")
+@Path("/")
+public class ResourceWithCustomHTTPMethodAnnotations {
+
+    @CUSTOMPATCH
+    @ApiOperation(value = "Patch Test")
+    public Response patchTest() {
+        return Response.ok().build();
+    }
+
+    @CUSTOMGET
+    @ApiOperation(value = "Get Test")
+    public Response getTest() {
+        return Response.ok().build();
+    }
+
+    @CUSTOMPOST
+    @ApiOperation(value = "Post Test")
+    public Response postTest() {
+        return Response.ok().build();
+    }
+
+    @CUSTOMPUT
+    @ApiOperation(value = "Put Test")
+    public Response putTest() {
+        return Response.ok().build();
+    }
+
+    @CUSTOMDELETE
+    @ApiOperation(value = "Delete Test")
+    public Response deleteTest() {
+        return Response.ok().build();
+    }
+
+
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @HttpMethod("PATCH")
+    public @interface CUSTOMPATCH {
+    }
+
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @HttpMethod("GET")
+    public @interface CUSTOMGET {
+    }
+
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @HttpMethod("POST")
+    public @interface CUSTOMPOST {
+    }
+
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @HttpMethod("PUT")
+    public @interface CUSTOMPUT {
+    }
+
+    @Target({ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @HttpMethod("DELETE")
+    public @interface CUSTOMDELETE {
+    }
+}


### PR DESCRIPTION
Solution to defect: [#1643](https://github.com/swagger-api/swagger-core/issues/1643).

Currently Javax does not support the PATCH annotation so some users have created their own in the form below to avoid them coupling their code to Swaggers `io.swagger.jaxrs.PATCH`:

```
@Target({ElementType.METHOD})
@Retention(RetentionPolicy.RUNTIME)
@HttpMethod("PATCH")
public @interface PATCH{ 
}
```

Which is picked up by Jersey but not by Swagger. This change makes swagger check through all resource method annotations to find the HttpMethod like above.