### PR TITLE
Refs #1107, #1318, #1118 - property example serialization

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/Property.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/Property.java
@@ -1,6 +1,8 @@
 package io.swagger.models.properties;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import io.swagger.models.Xml;
 
 import java.util.Map;
@@ -32,8 +34,10 @@ public interface Property {
 
     void setRequired(boolean required);
 
+    @JsonGetter
     Object getExample();
 
+    @JsonSetter
     void setExample(Object example);
 
     @Deprecated


### PR DESCRIPTION
Refs #1107, #1318, #1118, https://github.com/kongchen/swagger-maven-plugin/issues/233

initially triggered by #1107 analysis, solves possibly regression related to #1640, causing property field "example" not to be serialized to json.

This fix doesn't solve however neither #1107 (swagger-ui related, but probably solved by updating core/models) nor #1118 and it doesn't address similar discussion in https://github.com/kongchen/swagger-maven-plugin/issues/233.

Either part of this PR, or of further work on #1118, the following steps could be taken to cover the whole "area".

1 - Resolving from ApiModelProperty annotation.

similarly to discussion in https://github.com/kongchen/swagger-maven-plugin/issues/233, code could be enhanced to parse example value according to format and property type.

2 - Array type deserialization in PropertyDeserialization.

Code could be enhanced by deserializing additional properties (which should be part of swagger schema if not mistaken) also for array types, e.g. "example".

@webron please let me know what you think