### PR TITLE
fixes ignored swagger config via context attribute

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/SwaggerConfigLocator.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/SwaggerConfigLocator.java
@@ -50,7 +50,7 @@ public class SwaggerConfigLocator {
         if (value != null) {
             return value;
         }
-        return new Swagger();
+        return null;
     }
 
     public void putSwagger(String id, Swagger swagger) {

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/SwaggerContextService.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/SwaggerContextService.java
@@ -147,6 +147,7 @@ public class SwaggerContextService {
         if (value == null && sc != null) {
             value = (Swagger) sc.getServletContext().getAttribute("swagger");
         }
+        if (value == null) value = new Swagger();
         return value;
     }
 

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SwaggerContextServiceTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SwaggerContextServiceTest.java
@@ -8,6 +8,8 @@ import io.swagger.jaxrs.config.SwaggerConfigLocator;
 import io.swagger.jaxrs.config.SwaggerContextService;
 import io.swagger.jaxrs.config.SwaggerScannerLocator;
 import io.swagger.jaxrs.config.WebXMLReader;
+import io.swagger.models.Info;
+import io.swagger.models.Swagger;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -280,4 +282,32 @@ public class SwaggerContextServiceTest {
         verify(servletConfig2, never()).getInitParameter(eq(CONFIG_ID_KEY));
 
     }
+
+    void stubWithContextSwaggerAttribute() {
+
+        Swagger swagger = new Swagger();
+        Info info = new Info().title("Test Title");
+        swagger.setInfo(info);
+        when(servletContext1.getAttribute("swagger")).thenReturn(swagger);
+
+        when(servletConfig1.getServletContext()).thenReturn(servletContext1);
+        when(servletConfig2.getServletContext()).thenReturn(servletContext2);
+
+        when(servletConfig1.getInitParameter(CONTEXT_ID_KEY)).thenReturn("test.1");
+        when(servletConfig2.getInitParameter(CONTEXT_ID_KEY)).thenReturn("test.2");
+
+    }
+
+    @Test(description = "should get correct swagger context set via context param \"swagger\"")
+    public void initConfigViaContextParamSwagger() {
+
+        stubWithContextSwaggerAttribute();
+
+        Swagger swagger = new SwaggerContextService().withServletConfig(servletConfig1).getSwagger();
+        assertEquals("Test Title",swagger.getInfo().getTitle());
+        //verify(servletConfig1, times(2)).getInitParameter(eq(CONTEXT_ID_KEY));
+
+
+    }
+
 }


### PR DESCRIPTION
@webron 

Fix for ignored swagger config via context attribute as reported by testuser1234 on IRC.

Before the fix, swagger configuration via  `context.setAttribute("swagger", swagger);` in client Bootstrap servlet (or equivalent)  would not be picked up by swagger

A workaround for unpatched code is configuring via new mechanism like:

`new SwaggerContextService().withServletConfig(config).updateSwagger(swagger);`