### PR TITLE
Close #1382 - @ApiResponse at class level

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponse.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponse.java
@@ -29,6 +29,10 @@ import java.lang.annotation.Target;
  * successful code), but the successful response should be described as well using the
  * {@link ApiOperation}.
  * <p>
+ * This annotation can be applied at method or class level; class level annotations will
+ * be parsed only if an @ApiResponse annotation with the same code is not defined at method
+ * level or in thrown Exception
+ * <p>
  * If your API has uses a different response class for these responses, you can describe them
  * here by associating a response class with a response code.
  * Note, Swagger does not allow multiple response types for a single response code.

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -283,6 +283,21 @@ public class ReaderTest {
         assertTrue(operation.getResponses().containsKey("409"));
     }
 
+    @Test(description = "scan resource with annotated exception")
+    public void scanDeclaredExceptionsAndCombineWithMethodResponsesClassLevel() {
+        Swagger swagger = getSwagger(ResourceWithCustomExceptionAndClassLevelApiResource.class);
+        assertNotNull(swagger);
+
+        Operation operation = getPut(swagger, "/{id}");
+        assertEquals(operation.getResponses().size(), 5);
+        assertTrue(operation.getResponses().containsKey("200"));
+        assertTrue(operation.getResponses().containsKey("400"));
+        assertTrue(operation.getResponses().containsKey("404"));
+        assertTrue(operation.getResponses().containsKey("403"));
+        assertTrue(operation.getResponses().containsKey("409"));
+        assertEquals(operation.getResponses().get("409").getDescription(), "Conflict");
+    }
+
     private Swagger getSwagger(Class<?> cls) {
         return new Reader(new Swagger()).read(cls);
     }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithCustomExceptionAndClassLevelApiResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithCustomExceptionAndClassLevelApiResource.java
@@ -1,0 +1,62 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.models.Sample;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+@Api(value = "/basicWithException", description = "Basic resource")
+@Produces({"application/xml"})
+@Path("/")
+@ApiResponses({
+        @ApiResponse(code = 409, message = "Conflict class level"),
+        @ApiResponse(code = 403, message = "Forbidden class level")
+})
+public class ResourceWithCustomExceptionAndClassLevelApiResource {
+
+    @GET
+    @Path("/{id}")
+    @ApiOperation(value = "Get object by ID",
+            notes = "No details provided",
+            response = Sample.class,
+            position = 0)
+    public Response getTest(
+            @ApiParam(value = "sample param data", required = true, allowableValues = "range[0,10]")
+            @DefaultValue("5")
+            @PathParam("id") String id,
+            @QueryParam("limit") Integer limit
+    ) throws CustomException {
+        return Response.ok().build();
+    }
+
+
+    @PUT
+    @Path("/{id}")
+    @ApiOperation(value = "Update object by ID",
+            notes = "No details provided",
+            response = Sample.class,
+            position = 0)
+    @ApiResponses({
+            @ApiResponse(code = 409, message = "Conflict")
+    })
+    public Response putTest(
+            @ApiParam(value = "sample param data", required = true, allowableValues = "range[0,10]")
+            @DefaultValue("5")
+            @PathParam("id") String id,
+            Sample sample
+    ) throws CustomException {
+        return Response.ok().build();
+    }
+
+}


### PR DESCRIPTION
@fehguy 

Close #1382 - @ApiResponse at class level get parsed and merged in operation responses if a response with same code is not defined at method level or in thrown Exception

wiki update in https://github.com/frantuma/swagger-core/wiki/Annotations-1.5.X/10a2248ce5072c74c52b8ce0dc7a0fdc2522095e