### PR TITLE
Fix #1714 - removed @Path from ApiListingResourceJson and deprecated

### DIFF
--- a/modules/swagger-jersey2-jaxrs/src/main/java/io/swagger/jersey/listing/ApiListingResourceJSON.java
+++ b/modules/swagger-jersey2-jaxrs/src/main/java/io/swagger/jersey/listing/ApiListingResourceJSON.java
@@ -2,9 +2,7 @@ package io.swagger.jersey.listing;
 
 import io.swagger.jaxrs.listing.ApiListingResource;
 
-import javax.ws.rs.Path;
-
-@Path("/")
+@Deprecated
 public class ApiListingResourceJSON
         extends ApiListingResource {
 }


### PR DESCRIPTION
As discussed in #1714, remove @Path and deprecates ApiListingResourceJSON