### PR TITLE
Fix #1717 - NPE with @ApiResponse at class level and no operation response

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -844,7 +844,7 @@ public class Reader {
         // merge class level @ApiResponse
         for (ApiResponse apiResponse : classApiResponses) {
             String key = apiResponse.code() == 0 ? "default":String.valueOf(apiResponse.code());
-            if (operation.getResponses().containsKey(key)) continue;
+            if (operation.getResponses() != null && operation.getResponses().containsKey(key)) continue;
             addResponse(operation, apiResponse);
         }
 

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -305,6 +305,15 @@ public class ReaderTest {
         assertTrue(operation.getResponses().containsKey("403"));
         assertTrue(operation.getResponses().containsKey("409"));
         assertEquals(operation.getResponses().get("409").getDescription(), "Conflict");
+
+        swagger = getSwagger(ResourceWithClassLevelApiResourceNoMethodLevelApiResources.class);
+        assertNotNull(swagger);
+        operation = getPut(swagger, "/{id}");
+        assertEquals(operation.getResponses().size(), 2);
+        assertTrue(operation.getResponses().containsKey("403"));
+        assertTrue(operation.getResponses().containsKey("409"));
+
+
     }
 
     private Swagger getSwagger(Class<?> cls) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithClassLevelApiResourceNoMethodLevelApiResources.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithClassLevelApiResourceNoMethodLevelApiResources.java
@@ -1,0 +1,50 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.models.Sample;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+@Api(value = "/basicApiResponse", description = "Basic resource")
+@Produces({"application/xml"})
+@Path("/")
+@ApiResponses({
+        @ApiResponse(code = 409, message = "Class level"),
+        @ApiResponse(code = 403, message = "Forbidden class level")
+})
+public class ResourceWithClassLevelApiResourceNoMethodLevelApiResources {
+
+    @GET
+    @Path("/{id}")
+    public Response getTest(
+            @ApiParam(value = "sample param data", required = true, allowableValues = "range[0,10]")
+            @DefaultValue("5")
+            @PathParam("id") String id,
+            @QueryParam("limit") Integer limit
+    ) {
+        return Response.ok().build();
+    }
+
+
+    @PUT
+    @Path("/{id}")
+    public Response putTest(
+            @ApiParam(value = "sample param data", required = true, allowableValues = "range[0,10]")
+            @DefaultValue("5")
+            @PathParam("id") String id,
+            Sample sample
+    ) {
+        return Response.ok().build();
+    }
+
+}


### PR DESCRIPTION
Fix #1717 - fix NPE with @ApiResponse at class level and no response in operation or @ApiOperation not defined for method
