### PR TITLE
Look for parameter annotations on parent classes/interfaces.

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
@@ -1,6 +1,8 @@
 package io.swagger.util;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -209,7 +211,34 @@ public class ReflectionUtils {
         }
         return annotation;
     }
+    
+    public static Annotation[][] getParameterAnnotations(Method method) {
+	Annotation[][] methodAnnotations = method.getParameterAnnotations();
+	Method overriddenmethod = getOverriddenMethod(method);
 
+	if (overriddenmethod != null) {
+	    Annotation[][] overriddenAnnotations = overriddenmethod
+		    .getParameterAnnotations();
+
+	    for (int i = 0; i < methodAnnotations.length; i++) {
+		List<Type> types = new ArrayList<Type>();
+		for (int j = 0; j < methodAnnotations[i].length; j++) {
+		    types.add(methodAnnotations[i][j].annotationType());
+		}
+		for (int j = 0; j < overriddenAnnotations[i].length; j++) {
+		    if (!types.contains(overriddenAnnotations[i][j]
+			    .annotationType())) {
+			methodAnnotations[i] = ArrayUtils.add(
+				methodAnnotations[i],
+				overriddenAnnotations[i][j]);
+		    }
+		}
+
+	    }
+	}
+	return methodAnnotations;
+    }
+    
     /**
      * Checks if the type is void.
      *

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -858,7 +858,7 @@ public class Reader {
         }
 
         Type[] genericParameterTypes = method.getGenericParameterTypes();
-        Annotation[][] paramAnnotations = method.getParameterAnnotations();
+        Annotation[][] paramAnnotations = ReflectionUtils.getParameterAnnotations(method);
         for (int i = 0; i < genericParameterTypes.length; i++) {
             final Type type = TypeFactory.defaultInstance().constructType(genericParameterTypes[i], cls);
             List<Parameter> parameters = getParameters(type, Arrays.asList(paramAnnotations[i]));


### PR DESCRIPTION
This is a fix for issue #1506.
Reader got parameter annotations from a child method, ignoring any
on a parent class or interface. This fix will look for annotation
on the parent class or interface, if it exists. Credit mohitmutha
with the fix. I just implemented it and created the pull request.