### PR TITLE
Fixed issue 1746 - Api and ApiImplicitParam annotations not read when they are in a parent of the resource class

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
@@ -1,6 +1,8 @@
 package io.swagger.util;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
+
+import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -209,7 +211,34 @@ public class ReflectionUtils {
         }
         return annotation;
     }
+    
+    public static Annotation[][] getParameterAnnotations(Method method) {
+	Annotation[][] methodAnnotations = method.getParameterAnnotations();
+	Method overriddenmethod = getOverriddenMethod(method);
 
+	if (overriddenmethod != null) {
+	    Annotation[][] overriddenAnnotations = overriddenmethod
+		    .getParameterAnnotations();
+
+	    for (int i = 0; i < methodAnnotations.length; i++) {
+		List<Type> types = new ArrayList<Type>();
+		for (int j = 0; j < methodAnnotations[i].length; j++) {
+		    types.add(methodAnnotations[i][j].annotationType());
+		}
+		for (int j = 0; j < overriddenAnnotations[i].length; j++) {
+		    if (!types.contains(overriddenAnnotations[i][j]
+			    .annotationType())) {
+			methodAnnotations[i] = ArrayUtils.add(
+				methodAnnotations[i],
+				overriddenAnnotations[i][j]);
+		    }
+		}
+
+	    }
+	}
+	return methodAnnotations;
+    }
+    
     /**
      * Checks if the type is void.
      *

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -858,7 +858,7 @@ public class Reader {
         }
 
         Type[] genericParameterTypes = method.getGenericParameterTypes();
-        Annotation[][] paramAnnotations = method.getParameterAnnotations();
+        Annotation[][] paramAnnotations = ReflectionUtils.getParameterAnnotations(method);
         for (int i = 0; i < genericParameterTypes.length; i++) {
             final Type type = TypeFactory.defaultInstance().constructType(genericParameterTypes[i], cls);
             List<Parameter> parameters = getParameters(type, Arrays.asList(paramAnnotations[i]));

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -187,7 +187,7 @@ public class Reader {
         String[] produces = new String[0];
         final Set<Scheme> globalSchemes = EnumSet.noneOf(Scheme.class);
 
-        Api api = (Api) cls.getAnnotation(Api.class);
+        Api api = ReflectionUtils.getAnnotation(cls, Api.class);
 
         boolean hasPathAnnotation = (ReflectionUtils.getAnnotation(cls, javax.ws.rs.Path.class) != null);
         boolean hasApiAnnotation = (api != null);
@@ -410,7 +410,7 @@ public class Reader {
     }
 
     private void readImplicitParameters(Method method, Operation operation) {
-        ApiImplicitParams implicitParams = method.getAnnotation(ApiImplicitParams.class);
+        ApiImplicitParams implicitParams = ReflectionUtils.getAnnotation(method, ApiImplicitParams.class);
         if (implicitParams != null && implicitParams.value().length > 0) {
             for (ApiImplicitParam param : implicitParams.value()) {
                 Parameter p = readImplicitParam(param);

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -3,6 +3,7 @@ package io.swagger;
 import io.swagger.jaxrs.Reader;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
+import io.swagger.models.Tag;
 import io.swagger.models.parameters.*;
 import io.swagger.resources.*;
 import org.testng.annotations.Test;
@@ -314,6 +315,27 @@ public class ReaderTest {
         assertTrue(operation.getResponses().containsKey("409"));
 
 
+    }
+
+    @Test(description = "scan resource (impl) which has the Api annotations only declared in its interface")
+    public void scanApiAnnotationWhichAreOnlyPresentInInterfaceAndNotInImplementation() {
+        Swagger swagger = getSwagger(ResourceWithAnnotationsOnlyInInterfaceImpl.class);
+        assertNotNull(swagger);
+
+        final List<Tag> tags = swagger.getTags();
+        assertEquals(tags.size(), 1);
+        assertEquals(tags.get(0).getName(), "someTag");
+    }
+
+    @Test(description = "scan resource (impl) which has the ApiParam annotations only declared in its interface")
+    public void scanApiImplicitParamAnnotationWhichAreOnlyPresentInInterfaceAndNotInImplementation() {
+        Swagger swagger = getSwagger(ResourceWithAnnotationsOnlyInInterfaceImpl.class);
+        assertNotNull(swagger);
+
+        List<Parameter> parameters = getGet(swagger, "/pet/randomPet").getParameters();
+        assertNotNull(parameters);
+        assertEquals(parameters.size(), 1);
+        assertEquals(parameters.get(0).getName(), "petImplicitIdParam");
     }
 
     private Swagger getSwagger(Class<?> cls) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithAnnotationsOnlyInInterface.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithAnnotationsOnlyInInterface.java
@@ -1,0 +1,20 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/pet")
+@Api(tags = "someTag")
+public interface ResourceWithAnnotationsOnlyInInterface {
+
+    @GET
+    @Path("/randomPet")
+    @ApiOperation(value = "getRandomPet")
+    @ApiImplicitParams({ @ApiImplicitParam(name = "petImplicitIdParam", paramType = "query", dataType = "string") })
+    String getRandomPet();
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithAnnotationsOnlyInInterfaceImpl.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithAnnotationsOnlyInInterfaceImpl.java
@@ -1,0 +1,9 @@
+package io.swagger.resources;
+
+public class ResourceWithAnnotationsOnlyInInterfaceImpl implements ResourceWithAnnotationsOnlyInInterface {
+
+    @Override
+    public String getRandomPet() {
+        return "No pet today..";
+    }
+}


### PR DESCRIPTION
This fixes issue 1746.

I changed two lines in Reader.java to support these annotations in interfaces/superclasses and provided two testcases for this.

Also credit to [mohitmutha](https://github.com/swagger-api/swagger-core/issues/1506) for finding a solution to a similar problem and @captdestrukto to provide a [pull request](https://github.com/swagger-api/swagger-core/pull/1735) for that one

Please note that my pull request also incorporates the changes proposed by captdestrukto; it is a cumulative pull request :)