### PR TITLE
Ref #1757: Retain refs from Array/Map Property types when using "removingUnreferencedDefinitions"

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
@@ -1,6 +1,7 @@
 package io.swagger.core.filter;
 
 import io.swagger.model.ApiDescription;
+import io.swagger.models.ArrayModel;
 import io.swagger.models.Model;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
@@ -11,6 +12,7 @@ import io.swagger.models.Tag;
 import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 
@@ -106,8 +108,9 @@ public class SpecFilter {
 
         if (swagger.getResponses() != null) {
             for (Response response: swagger.getResponses().values()) {
-                if (response.getSchema() != null && response.getSchema() instanceof RefProperty) {
-                    referencedDefinitions.add(((RefProperty) response.getSchema()).getSimpleRef());
+                String propertyRef = getPropertyRef(response.getSchema());
+                if (propertyRef != null) {
+                    referencedDefinitions.add(propertyRef);
                 }
             }
         }
@@ -115,8 +118,9 @@ public class SpecFilter {
             for (Parameter p: swagger.getParameters().values()) {
                 if (p instanceof BodyParameter) {
                     BodyParameter bp = (BodyParameter) p;
-                    if (bp.getSchema() != null && bp.getSchema() instanceof RefModel) {
-                        referencedDefinitions.add(((RefModel) bp.getSchema()).getSimpleRef());
+                    String modelRef = getModelRef(bp.getSchema());
+                    if (modelRef != null) {
+                        referencedDefinitions.add(modelRef);
                     }
                 }
             }
@@ -127,8 +131,9 @@ public class SpecFilter {
                     for (Parameter p: path.getParameters()) {
                         if (p instanceof BodyParameter) {
                             BodyParameter bp = (BodyParameter) p;
-                            if (bp.getSchema() != null && bp.getSchema() instanceof RefModel) {
-                                referencedDefinitions.add(((RefModel) bp.getSchema()).getSimpleRef());
+                            String modelRef = getModelRef(bp.getSchema());
+                            if (modelRef != null) {
+                                referencedDefinitions.add(modelRef);
                             }
                         }
                     }
@@ -137,8 +142,9 @@ public class SpecFilter {
                     for (Operation op: path.getOperations()) {
                         if (op.getResponses() != null) {
                             for (Response response: op.getResponses().values()) {
-                                if (response.getSchema() != null && response.getSchema() instanceof RefProperty) {
-                                    referencedDefinitions.add(((RefProperty) response.getSchema()).getSimpleRef());
+                                String propertyRef = getPropertyRef(response.getSchema());
+                                if (propertyRef != null) {
+                                    referencedDefinitions.add(propertyRef);
                                 }
                             }
                         }
@@ -146,8 +152,9 @@ public class SpecFilter {
                             for (Parameter p: op.getParameters()) {
                                 if (p instanceof BodyParameter) {
                                     BodyParameter bp = (BodyParameter) p;
-                                    if (bp.getSchema() != null && bp.getSchema() instanceof RefModel) {
-                                        referencedDefinitions.add(((RefModel) bp.getSchema()).getSimpleRef());
+                                    String modelRef = getModelRef(bp.getSchema());
+                                    if (modelRef != null) {
+                                        referencedDefinitions.add(modelRef);
                                     }
                                 }
                             }
@@ -246,5 +253,28 @@ public class SpecFilter {
         clonedOperation.setResponses(op.getResponses());
 
         return clonedOperation;
+    }
+
+    private String getPropertyRef(Property property) {
+        if (property instanceof ArrayProperty &&
+                ((ArrayProperty) property).getItems() != null) {
+            return getPropertyRef(((ArrayProperty) property).getItems());
+        } else if (property instanceof MapProperty &&
+                ((MapProperty) property).getAdditionalProperties() != null) {
+            return getPropertyRef(((MapProperty) property).getAdditionalProperties());
+        } else if (property instanceof RefProperty) {
+            return ((RefProperty) property).getSimpleRef();
+        }
+        return null;
+    }
+
+    private String getModelRef(Model model) {
+        if (model instanceof ArrayModel &&
+                ((ArrayModel) model).getItems() != null) {
+            return getPropertyRef(((ArrayModel) model).getItems());
+        } else if (model instanceof RefModel) {
+            return ((RefModel) model).getSimpleRef();
+        }
+        return null;
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/filter/SpecFilterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/filter/SpecFilterTest.java
@@ -133,6 +133,25 @@ public class SpecFilterTest {
 
     }
 
+    @Test(description = "it should retain non-broken reference model properties")
+    public void retainNonBroeknReferenceModelProperties() throws IOException {
+        final Swagger swagger = getSwagger("specFiles/paramAndResponseRefArray.json");
+
+        assertNotNull(swagger.getDefinitions().get("User"));
+
+        final NoOpOperationsFilter noOpfilter = new NoOpOperationsFilter();
+        Swagger filtered = new SpecFilter().filter(swagger, noOpfilter, null, null, null);
+
+        assertNotNull(filtered.getDefinitions().get("User"));
+
+        final RemoveUnreferencedDefinitionsFilter refFilter = new RemoveUnreferencedDefinitionsFilter();
+        filtered = new SpecFilter().filter(swagger, refFilter, null, null, null);
+
+        assertNotNull(filtered.getDefinitions().get("User")); // ArrayProperty
+        assertNotNull(filtered.getDefinitions().get("Pet")); // ArrayModel
+
+    }
+
     @Test(description = "it should filter models where some fields have no properties")
     public void filterNoPropertiesModels() throws IOException {
         final String modelName = "Array";

--- a/modules/swagger-core/src/test/resources/specFiles/paramAndResponseRefArray.json
+++ b/modules/swagger-core/src/test/resources/specFiles/paramAndResponseRefArray.json
@@ -1,0 +1,227 @@
+{
+  "swagger": "2.0",
+  "title": "Petstore Sample API",
+  "info": {
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+    "title": "Petstore Sample API",
+    "contact": {
+      "name": "Swagger API Team"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "http://github.com/gruntjs/grunt/blob/master/LICENSE-MIT"
+    }
+  },
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "host": "petstore.swagger.io",
+  "basePath": "/api",
+  "paths": {
+    "/pet": {
+      "parameters": [
+        {
+          "name": "body",
+          "in": "body",
+          "description": "Pet object that needs to be added to the store",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        }
+      ],
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "found it",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/User"
+              }
+            }
+          },
+          "404": {
+            "description": "Order not found"
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Pet object that needs to be added to the store",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Pet"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "$ref": "http://my.company.com/responses/errors.json#/method-not-allowed"
+          },
+          "404": {
+            "$ref": "http://my.company.com/responses/errors.json#/not-found"
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "User": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "lastName": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "userStatus": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "firstName": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "Category": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Pet": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tag"
+          }
+        },
+        "category": {
+          "$ref": "#/definitions/Category"
+        },
+        "status": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "photoUrls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Tag": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "Order": {
+      "properties": {
+        "id": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "petId": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "status": {
+          "type": "string"
+        },
+        "complete": {
+          "type": "boolean"
+        },
+        "quantity": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "shipDate": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Should fix #1757.  I was unsure of how to get the ref (or refs) from ComposedModel objects, so I left them out.