### PR TITLE
Fix initialization of SwaggerConfigLocator with Swagger instance

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
@@ -209,7 +209,7 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
                 .withServletConfig(servletConfig)
                 .withSwaggerConfig(this)
                 .withScanner(this)
-                .initConfig()
+                .initConfig(this.getSwagger())
                 .initScanner();
     }
 


### PR DESCRIPTION
During initialization process Swagger instance isn't stored in SwaggerConfigLocator. If system has more than one BeanConfig it can't restore it correctly.