### PR TITLE
Add extension method to intercept Operation parsed from Jersey resource method

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -297,6 +297,9 @@ public class Reader {
                     Operation operation = null;
                     if(apiOperation != null || config.isScanAllResources() || httpMethod != null || methodPath != null) {
                         operation = parseMethod(cls, method, globalParameters, classApiResponses);
+                        if (operation != null) {
+                            operation = methodParsed(apiOperation, operationPath, method, operation, SwaggerExtensions.chain());
+                        }
                     }
                     if (operation == null) {
                         continue;
@@ -971,6 +974,14 @@ public class Reader {
             }
         }
         return null;
+    }
+
+    public Operation methodParsed(ApiOperation apiOperation, String operationPath, Method method, Operation operation, Iterator<SwaggerExtension> chain) {
+        if (chain.hasNext()) {
+            return chain.next().methodParsed(apiOperation, operationPath, method, operation, chain);
+        } else {
+            return operation;
+        }
     }
 
     private static Set<Scheme> parseSchemes(String schemes) {

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/ext/AbstractSwaggerExtension.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/ext/AbstractSwaggerExtension.java
@@ -3,6 +3,7 @@ package io.swagger.jaxrs.ext;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.models.Operation;
 import io.swagger.models.parameters.Parameter;
 
 import java.lang.annotation.Annotation;
@@ -31,6 +32,15 @@ public abstract class AbstractSwaggerExtension implements SwaggerExtension {
             return chain.next().extractParameters(annotations, type, typesToSkip, chain);
         } else {
             return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public Operation methodParsed(ApiOperation apiOperation, String operationPath, Method method, Operation operation, Iterator<SwaggerExtension> chain) {
+        if (chain.hasNext()) {
+            return chain.next().methodParsed(apiOperation, operationPath, method, operation, chain);
+        } else {
+            return operation;
         }
     }
 

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/ext/SwaggerExtension.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/ext/SwaggerExtension.java
@@ -1,6 +1,7 @@
 package io.swagger.jaxrs.ext;
 
 import io.swagger.annotations.ApiOperation;
+import io.swagger.models.Operation;
 import io.swagger.models.parameters.Parameter;
 
 import java.lang.annotation.Annotation;
@@ -14,4 +15,6 @@ public interface SwaggerExtension {
     String extractOperationMethod(ApiOperation apiOperation, Method method, Iterator<SwaggerExtension> chain);
 
     List<Parameter> extractParameters(List<Annotation> annotations, Type type, Set<Type> typesToSkip, Iterator<SwaggerExtension> chain);
+
+    Operation methodParsed(ApiOperation apiOperation, String operationPath, Method method, Operation operation, Iterator<SwaggerExtension> chain);
 }


### PR DESCRIPTION
Adds method to `SwaggerExtension` interface to allow an extension to intercept when a Jersey method is parsed into a Swagger `Operation` model so that the extension can perform custom operations.  The specific use case intended to be addressed is being able to scan custom annotations on the Java method via reflection and then use those annotations to append vendor extensions to the operation.