### PR TITLE
Fixing 1201 - array property constraint deserialisation

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -1,5 +1,6 @@
 package io.swagger.util;
 
+import com.google.common.collect.Maps;
 import io.swagger.models.Xml;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.MapProperty;
@@ -9,13 +10,7 @@ import io.swagger.models.properties.PropertyBuilder;
 import io.swagger.models.properties.RefProperty;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +63,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                     child instanceof NumericNode ||
                     child instanceof IntNode ||
                     child instanceof LongNode ||
-                    child instanceof DoubleNode || 
+                    child instanceof DoubleNode ||
                     child instanceof FloatNode) {
                     result.add(child.asText());
                 }
@@ -117,7 +112,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
         } else {
             throw new RuntimeException("Required property should be a list");
         }
-        
+
     }
 
     private static JsonNode getDetailNode(JsonNode node, PropertyBuilder.PropertyId type) {
@@ -167,12 +162,41 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
         return xml;
     }
 
+    private Map<PropertyBuilder.PropertyId, Object> argsFromNode(JsonNode node) {
+        if (node == null) return Collections.emptyMap();
+        final Map<PropertyBuilder.PropertyId, Object> args = new EnumMap<PropertyBuilder.PropertyId, Object>(PropertyBuilder.PropertyId.class);
+        args.put(PropertyBuilder.PropertyId.TYPE, getString(node, PropertyBuilder.PropertyId.TYPE));
+        args.put(PropertyBuilder.PropertyId.FORMAT, getString(node, PropertyBuilder.PropertyId.FORMAT));
+        args.put(PropertyBuilder.PropertyId.DESCRIPTION, getString(node, PropertyBuilder.PropertyId.DESCRIPTION));
+        args.put(PropertyBuilder.PropertyId.EXAMPLE, getString(node, PropertyBuilder.PropertyId.EXAMPLE));
+        args.put(PropertyBuilder.PropertyId.ENUM, getEnum(node, PropertyBuilder.PropertyId.ENUM));
+        args.put(PropertyBuilder.PropertyId.TITLE, getString(node, PropertyBuilder.PropertyId.TITLE));
+        args.put(PropertyBuilder.PropertyId.DEFAULT, getString(node, PropertyBuilder.PropertyId.DEFAULT));
+        args.put(PropertyBuilder.PropertyId.PATTERN, getString(node, PropertyBuilder.PropertyId.PATTERN));
+        args.put(PropertyBuilder.PropertyId.DESCRIMINATOR, getString(node, PropertyBuilder.PropertyId.DESCRIMINATOR));
+        args.put(PropertyBuilder.PropertyId.MIN_ITEMS, getInteger(node, PropertyBuilder.PropertyId.MIN_ITEMS));
+        args.put(PropertyBuilder.PropertyId.MAX_ITEMS, getInteger(node, PropertyBuilder.PropertyId.MAX_ITEMS));
+        args.put(PropertyBuilder.PropertyId.MIN_PROPERTIES, getInteger(node, PropertyBuilder.PropertyId.MIN_PROPERTIES));
+        args.put(PropertyBuilder.PropertyId.MAX_PROPERTIES, getInteger(node, PropertyBuilder.PropertyId.MAX_PROPERTIES));
+        args.put(PropertyBuilder.PropertyId.MIN_LENGTH, getInteger(node, PropertyBuilder.PropertyId.MIN_LENGTH));
+        args.put(PropertyBuilder.PropertyId.MAX_LENGTH, getInteger(node, PropertyBuilder.PropertyId.MAX_LENGTH));
+        args.put(PropertyBuilder.PropertyId.MINIMUM, getDouble(node, PropertyBuilder.PropertyId.MINIMUM));
+        args.put(PropertyBuilder.PropertyId.MAXIMUM, getDouble(node, PropertyBuilder.PropertyId.MAXIMUM));
+        args.put(PropertyBuilder.PropertyId.EXCLUSIVE_MINIMUM, getBoolean(node, PropertyBuilder.PropertyId.EXCLUSIVE_MINIMUM));
+        args.put(PropertyBuilder.PropertyId.EXCLUSIVE_MAXIMUM, getBoolean(node, PropertyBuilder.PropertyId.EXCLUSIVE_MAXIMUM));
+        args.put(PropertyBuilder.PropertyId.UNIQUE_ITEMS, getBoolean(node, PropertyBuilder.PropertyId.UNIQUE_ITEMS));
+        args.put(PropertyBuilder.PropertyId.READ_ONLY, getBoolean(node, PropertyBuilder.PropertyId.READ_ONLY));
+        args.put(PropertyBuilder.PropertyId.VENDOR_EXTENSIONS, getVendorExtensions(node));
+        return args;
+    }
+
     Property propertyFromNode(JsonNode node) {
         final String type = getString(node, PropertyBuilder.PropertyId.TYPE);
         final String title = getString(node, PropertyBuilder.PropertyId.TITLE);
         final String format = getString(node, PropertyBuilder.PropertyId.FORMAT);
 
         String description = getString(node, PropertyBuilder.PropertyId.DESCRIPTION);
+
         JsonNode detailNode = node.get("$ref");
         if (detailNode != null) {
             return new RefProperty(detailNode.asText())
@@ -217,6 +241,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                     ArrayProperty ap = new ArrayProperty()
                             .description(description)
                             .title(title);
+                    PropertyBuilder.merge(ap, argsFromNode(detailNode));
                     ap.setDescription(description);
 
                     if(properties.keySet().size() == 1) {
@@ -245,41 +270,21 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                         .items(subProperty)
                         .description(description)
                         .title(title);
+                PropertyBuilder.merge(arrayProperty, argsFromNode(node));
                 arrayProperty.setVendorExtensionMap(getVendorExtensions(node));
                 return arrayProperty;
             }
         }
 
-        final Map<PropertyBuilder.PropertyId, Object> args = new EnumMap<PropertyBuilder.PropertyId, Object>(PropertyBuilder.PropertyId.class);
-        args.put(PropertyBuilder.PropertyId.TYPE, type);
-        args.put(PropertyBuilder.PropertyId.FORMAT, format);
-        args.put(PropertyBuilder.PropertyId.DESCRIPTION, description);
-        args.put(PropertyBuilder.PropertyId.EXAMPLE, getString(node, PropertyBuilder.PropertyId.EXAMPLE));
-        args.put(PropertyBuilder.PropertyId.ENUM, getEnum(node, PropertyBuilder.PropertyId.ENUM));
-        args.put(PropertyBuilder.PropertyId.TITLE, getString(node, PropertyBuilder.PropertyId.TITLE));
-        args.put(PropertyBuilder.PropertyId.DEFAULT, getString(node, PropertyBuilder.PropertyId.DEFAULT));
-        args.put(PropertyBuilder.PropertyId.PATTERN, getString(node, PropertyBuilder.PropertyId.PATTERN));
-        args.put(PropertyBuilder.PropertyId.DESCRIMINATOR, getString(node, PropertyBuilder.PropertyId.DESCRIMINATOR));
-        args.put(PropertyBuilder.PropertyId.MIN_ITEMS, getInteger(node, PropertyBuilder.PropertyId.MIN_ITEMS));
-        args.put(PropertyBuilder.PropertyId.MAX_ITEMS, getInteger(node, PropertyBuilder.PropertyId.MAX_ITEMS));
-        args.put(PropertyBuilder.PropertyId.MIN_PROPERTIES, getInteger(node, PropertyBuilder.PropertyId.MIN_PROPERTIES));
-        args.put(PropertyBuilder.PropertyId.MAX_PROPERTIES, getInteger(node, PropertyBuilder.PropertyId.MAX_PROPERTIES));
-        args.put(PropertyBuilder.PropertyId.MIN_LENGTH, getInteger(node, PropertyBuilder.PropertyId.MIN_LENGTH));
-        args.put(PropertyBuilder.PropertyId.MAX_LENGTH, getInteger(node, PropertyBuilder.PropertyId.MAX_LENGTH));
-        args.put(PropertyBuilder.PropertyId.MINIMUM, getDouble(node, PropertyBuilder.PropertyId.MINIMUM));
-        args.put(PropertyBuilder.PropertyId.MAXIMUM, getDouble(node, PropertyBuilder.PropertyId.MAXIMUM));
-        args.put(PropertyBuilder.PropertyId.EXCLUSIVE_MINIMUM, getBoolean(node, PropertyBuilder.PropertyId.EXCLUSIVE_MINIMUM));
-        args.put(PropertyBuilder.PropertyId.EXCLUSIVE_MAXIMUM, getBoolean(node, PropertyBuilder.PropertyId.EXCLUSIVE_MAXIMUM));
-        args.put(PropertyBuilder.PropertyId.UNIQUE_ITEMS, getBoolean(node, PropertyBuilder.PropertyId.UNIQUE_ITEMS));
-        args.put(PropertyBuilder.PropertyId.READ_ONLY, getBoolean(node, PropertyBuilder.PropertyId.READ_ONLY));
-        args.put(PropertyBuilder.PropertyId.VENDOR_EXTENSIONS, getVendorExtensions(node));
+
+        Map<PropertyBuilder.PropertyId, Object> args = argsFromNode(node);
         Property output = PropertyBuilder.build(type, format, args);
         if (output == null) {
             LOGGER.warn("no property from " + type + ", " + format + ", " + args);
             return null;
         }
         output.setDescription(description);
-        
+
         return output;
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
@@ -2,6 +2,9 @@ package io.swagger.util;
 
 import io.swagger.TestUtils;
 import io.swagger.models.*;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -83,6 +86,50 @@ public class JsonDeserializationTest {
             assertEquals(oauth2.get(0), "hello");
             assertEquals(oauth2.get(1), "world");
         }
+    }
+
+    @Test (description = "should deserialize a string property with constraints")
+    public void testDeserializeConstrainedStringProperty() throws Exception {
+
+        Swagger swagger = TestUtils.deserializeJsonFileFromClasspath("specFiles/propertiesWithConstraints.json", Swagger.class);
+
+        StringProperty property = (StringProperty) swagger.getDefinitions().get("Health").getProperties().get("string_with_constraints");
+
+        assertEquals(property.getMinLength(), Integer.valueOf(10));
+        assertEquals(property.getMaxLength(), Integer.valueOf(100));
+        assertEquals(property.getPattern(), "apattern");
+    }
+
+    @Test (description = "should deserialize an array property with constraints")
+    public void testDeserializeConstrainedArrayProperties() throws Exception {
+
+        Swagger swagger = TestUtils.deserializeJsonFileFromClasspath("specFiles/propertiesWithConstraints.json", Swagger.class);
+
+        Map<String, Property> properties = swagger.getDefinitions().get("Health").getProperties();
+
+        ArrayProperty withMin = (ArrayProperty) properties.get("array_with_min");
+
+        assertEquals(withMin.getMinItems(), Integer.valueOf(5));
+        assertNull(withMin.getMaxItems());
+        assertNull(withMin.getUniqueItems());
+
+        ArrayProperty withMax = (ArrayProperty) properties.get("array_with_max");
+
+        assertNull(withMax.getMinItems());
+        assertEquals(withMax.getMaxItems(), Integer.valueOf(10));
+        assertNull(withMax.getUniqueItems());
+
+        ArrayProperty withUnique = (ArrayProperty) properties.get("array_with_unique");
+
+        assertNull(withUnique.getMinItems());
+        assertNull(withUnique.getMaxItems());
+        assertEquals(withUnique.getUniqueItems(), Boolean.TRUE);
+
+        ArrayProperty withAll = (ArrayProperty) properties.get("array_with_all");
+
+        assertEquals(withAll.getMinItems(), Integer.valueOf(1));
+        assertEquals(withAll.getMaxItems(), Integer.valueOf(10));
+        assertEquals(withAll.getUniqueItems(), Boolean.TRUE);
     }
 
     @Test (description = "should deserialize a property with vendor extensions of different types")

--- a/modules/swagger-core/src/test/resources/specFiles/propertiesWithConstraints.json
+++ b/modules/swagger-core/src/test/resources/specFiles/propertiesWithConstraints.json
@@ -1,0 +1,59 @@
+{
+    "swagger": "2.0",
+    "paths": {
+        "/health": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "schema": {
+                            "$ref": "#/definitions/Health"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Health": {
+            "properties": {
+                "array_with_min": {
+                    "type": "array",
+                    "minItems": 5,
+                    "items": {
+                        "$ref": "#/definitions/Health"
+                    }
+                },
+                "array_with_max": {
+                    "type": "array",
+                    "maxItems": 10,
+                    "items": {
+                        "$ref": "#/definitions/Health"
+                    }
+                },
+                "array_with_unique": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/Health"
+                    }
+                },
+                "array_with_all": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 10,
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/definitions/Health"
+                    }
+                },
+                "string_with_constraints": {
+                  "type": "string",
+                  "minLength": 10,
+                  "maxLength": 100,
+                  "pattern": "apattern"
+                }
+            }
+        }
+    }
+}

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -564,6 +564,10 @@ public class PropertyBuilder {
                         final Integer value = PropertyId.MAX_ITEMS.findValue(args);
                         resolved.setMaxItems(value);
                     }
+                    if (args.containsKey(PropertyId.UNIQUE_ITEMS)) {
+                        final Boolean value = PropertyId.UNIQUE_ITEMS.findValue(args);
+                        resolved.setUniqueItems(value);
+                    }
                 }
 
                 return property;
@@ -771,7 +775,7 @@ public class PropertyBuilder {
                               catch(Exception e) {
                                 // continue
                               }
-                            }                            
+                            }
                         }
                         if(property instanceof LongProperty) {
                           LongProperty p = (LongProperty) property;
@@ -782,7 +786,7 @@ public class PropertyBuilder {
                             catch(Exception e) {
                               // continue
                             }
-                          }                            
+                          }
                         }
                         if(property instanceof DoubleProperty) {
                             DoubleProperty p = (DoubleProperty) property;
@@ -793,7 +797,7 @@ public class PropertyBuilder {
                               catch(Exception e) {
                                 // continue
                               }
-                            }                            
+                            }
                         }
                         if(property instanceof FloatProperty) {
                           FloatProperty p = (FloatProperty) property;
@@ -804,7 +808,7 @@ public class PropertyBuilder {
                             catch(Exception e) {
                               // continue
                             }
-                          }                            
+                          }
                        }
                        if(property instanceof DateProperty) {
                           DateProperty p = (DateProperty) property;
@@ -815,7 +819,7 @@ public class PropertyBuilder {
                             catch(Exception e) {
                               // continue
                             }
-                          }                            
+                          }
                        }
                        if(property instanceof DateTimeProperty) {
                          DateTimeProperty p = (DateTimeProperty) property;
@@ -826,7 +830,7 @@ public class PropertyBuilder {
                            catch(Exception e) {
                              // continue
                            }
-                         }                            
+                         }
                        }
                        if(property instanceof UUIDProperty) {
                          UUIDProperty p = (UUIDProperty) property;
@@ -837,7 +841,7 @@ public class PropertyBuilder {
                            catch(Exception e) {
                              // continue
                            }
-                         }                            
+                         }
                        }
                     }
                 }


### PR DESCRIPTION
Small fix for #1201 (missing deserialisation of ArrayProperty constraints (`minItems`, `maxItems` and `uniqueItems`).
