### PR TITLE
Update ModelResolver.java

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -243,10 +243,18 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             PropertyMetadata md = propDef.getMetadata();
 
             boolean hasSetter = false, hasGetter = false;
-            if (propDef.getSetter() == null) {
-                hasSetter = false;
-            } else {
-                hasSetter = true;
+            try{
+                if (propDef.getSetter() == null) {
+                    hasSetter = false;
+                } else {
+                    hasSetter = true;
+                }
+            }catch(IllegalArgumentException e){
+                //com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder would throw IllegalArgumentException
+                // if there are overloaded setters. If we only want to know whether a set method exists, suppress the exception
+                // is reasonable.
+                // More logs might be added here
+            	hasSetter = true;
             }
             if (propDef.getGetter() != null) {
                 JsonProperty pd = propDef.getGetter().getAnnotation(JsonProperty.class);


### PR DESCRIPTION
As I posted at https://groups.google.com/forum/#!topic/swagger-swaggersocket/FfJ3dJetmEA

In 1.5.0, io.swagger.jackson.ModelResolver is the default ModelConverter that analyse the bean structure. In the 

  public Model resolve(JavaType type, ModelConverterContext context, Iterator<ModelConverter> next) method around lines 263-280, there is a block of code to determine whether the field is readOnly as follows.

```
        boolean hasSetter = false, hasGetter = false;

        if (propDef.getSetter() == null) {

            hasSetter = false;

        } else {

            hasSetter = true;

        }

        if (propDef.getGetter() != null) {

            JsonProperty pd = propDef.getGetter().getAnnotation(JsonProperty.class);

            if (pd != null) {

                hasGetter = true;

            }

        }

        Boolean isReadOnly = null;

        if (!hasSetter & hasGetter) {

            isReadOnly = Boolean.TRUE;

        } else {

            isReadOnly = Boolean.FALSE;

        }
```

Note that propDef.getSetter() would throw exception if there are overloading setters. However, overloaded setters are very useful, and we want to keep them. 

Consider a user case that we already implemented Apis with JaxRS, and would like to add swagger-jaxRS annotations to generate swagger.json using the bottom-up approach. Our data model contains more than one setters for some fields (overload setters), and uur Api uses Gson or customized serialization tools (not use jackson) to handle the serialization/deserialization of the data model without any problem. However, request swagger.json would fail because jackson throws conflict setters exception and io.swagger.jackson.ModelResolver does not suppress the exception. 

It would be very useful it io.swagger.jackson.ModelResolver added try-catch block on    if (propDef.getSetter() == null) to suppress the exception. 
