### PR TITLE
Use XmlElementWrapper name when wrapping repeated elements with JAXB XmlElementWrapper annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Swagger Core library
 
+** PS: This version is a fork from https://github.com/swagger-api/swagger-core and fixes the JAXB XmlElementWrapper annotation issue. **
+
 [![Build Status](https://travis-ci.org/swagger-api/swagger-core.svg?branch=master)](https://travis-ci.org/swagger-api/swagger-core)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.swagger/swagger-project/badge.svg?style=plastic)](https://maven-badges.herokuapp.com/maven-central/io.swagger/swagger-project)
 [![PR Stats](http://issuestats.com/github/swagger-api/swagger-core/badge/pr)](http://issuestats.com/github/swagger-api/swagger-core) [![Issue Stats](http://issuestats.com/github/swagger-api/swagger-core/badge/issue)](http://issuestats.com/github/swagger-api/swagger-core)

--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-project</artifactId>
-        <version>1.5.8</version>
+        <version>1.5.8-psuol</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-models</artifactId>
-            <version>${project.parent.version}</version>
+            <version>1.5.8</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/JAXBAnnotationsHelper.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/JAXBAnnotationsHelper.java
@@ -44,6 +44,10 @@ class JAXBAnnotationsHelper {
      * @param property property instance to be updated
      */
     private static void applyElement(AnnotatedMember member, Property property) {
+        final XmlElement element = member.getAnnotation(XmlElement.class);
+        if (element != null) {
+            setName(element.namespace(), element.name(), property);
+        }
         final XmlElementWrapper wrapper = member.getAnnotation(XmlElementWrapper.class);
         if (wrapper != null) {
             final Xml xml = getXml(property);
@@ -51,10 +55,6 @@ class JAXBAnnotationsHelper {
             if (!"##default".equals(wrapper.name()) && !wrapper.name().isEmpty()) {
                 xml.setName(wrapper.name());
             }
-        }
-        final XmlElement element = member.getAnnotation(XmlElement.class);
-        if (element != null) {
-            setName(element.namespace(), element.name(), property);
         }
     }
 

--- a/modules/swagger-core/src/test/java/io/swagger/jackson/XMLInfoTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/jackson/XMLInfoTest.java
@@ -39,7 +39,7 @@ public class XMLInfoTest extends SwaggerTestBase {
         final Xml propertyXml = property.getXml();
 
         assertNotNull(propertyXml);
-        assertEquals(propertyXml.getName(), "item");
+        assertEquals(propertyXml.getName(), "items");
         assertTrue(propertyXml.getWrapped());
 
         assertNotNull(impl.getProperties().get("elementC"));
@@ -92,7 +92,7 @@ public class XMLInfoTest extends SwaggerTestBase {
 
         final Property propertyA = impl.getProperties().get("a");
         assertNotNull(propertyA);
-        
+
         Property propertyB = impl.getProperties().get("b");
         assertNotNull(propertyB);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>swagger-project</artifactId>
     <packaging>pom</packaging>
     <name>swagger-project</name>
-    <version>1.5.8</version>
+    <version>1.5.8-psuol</version>
     <url>https://github.com/swagger-api/swagger-core</url>
     <scm>
         <connection>scm:git:git@github.com:swagger-api/swagger-core.git</connection>


### PR DESCRIPTION
The following model:

```java
@XmlRootElement(name = "monster")
public class Monster {
  public String name;
  @XmlElementWrapper(name = "children")
  @XmlElement(name = "child")
  public java.util.List<String> child;
}
```

produces the following swagger.json spec:

```json
{
  "properties" : {
    "name" : {
      "type" : "string"
    },
    "children" : {
      "type" : "array",
      "xml" : {
        "name" : "child",
        "wrapped" : true
      },
      "items" : {
        "type" : "string"
      }
    }
  },
  "xml" : {
    "name" : "monster"
  }
}
```

This pullrequest will fix the swagger.json spec to:

```json
{
  "properties" : {
    "name" : {
      "type" : "string"
    },
    "children" : {
      "type" : "array",
      "xml" : {
        "name" : "children",
        "wrapped" : true
      },
      "items" : {
        "type" : "string"
      }
    }
  },
  "xml" : {
    "name" : "monster"
  }
}
```
