### PR TITLE
parses minItems, maxItems and uniqueItems for array property

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -245,6 +245,9 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                         .items(subProperty)
                         .description(description)
                         .title(title);
+                arrayProperty.setMinItems(getInteger(node, PropertyBuilder.PropertyId.MIN_ITEMS));
+                arrayProperty.setMaxItems(getInteger(node, PropertyBuilder.PropertyId.MAX_ITEMS));
+                arrayProperty.setUniqueItems(getBoolean(node, PropertyBuilder.PropertyId.UNIQUE_ITEMS));
                 arrayProperty.setVendorExtensionMap(getVendorExtensions(node));
                 return arrayProperty;
             }

--- a/modules/swagger-core/src/test/java/io/swagger/deserialization/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/deserialization/JsonDeserializationTest.java
@@ -1,9 +1,11 @@
 package io.swagger.deserialization;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import io.swagger.models.Swagger;
+import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.util.Json;
@@ -97,5 +99,32 @@ public class JsonDeserializationTest {
 
         final Map<String, Property> secondLevelProperties = ((ObjectProperty) property3).getProperties();
         assertEquals(secondLevelProperties.size(), 1);
+    }
+
+    @Test
+    public void shouldDeserializeArrayPropertyMinItems() throws Exception {
+        String content = ResourceUtils.loadClassResource(getClass(), "schema-validation/array.json");
+        ArrayProperty property = (ArrayProperty) m.readValue(content, Property.class);
+
+        assertNotNull(property.getMinItems());
+        assertEquals(property.getMinItems().intValue(), 1);
+    }
+
+    @Test
+    public void shouldDeserializeArrayPropertyMaxItems() throws Exception {
+        String content = ResourceUtils.loadClassResource(getClass(), "schema-validation/array.json");
+        ArrayProperty property = (ArrayProperty) m.readValue(content, Property.class);
+
+        assertNotNull(property.getMaxItems());
+        assertEquals(property.getMaxItems().intValue(), 10);
+    }
+
+    @Test
+    public void shouldDeserializeArrayPropertyUniqueItems() throws Exception {
+        String content = ResourceUtils.loadClassResource(getClass(), "schema-validation/array.json");
+        ArrayProperty property = (ArrayProperty) m.readValue(content, Property.class);
+
+        assertNotNull(property.getUniqueItems());
+        assertTrue(property.getUniqueItems());
     }
 }

--- a/modules/swagger-core/src/test/resources/schema-validation/array.json
+++ b/modules/swagger-core/src/test/resources/schema-validation/array.json
@@ -1,0 +1,9 @@
+{
+  "type": "array",
+  "items": {
+    "type": "string"
+  },
+  "minItems": 1,
+  "maxItems": 10,
+  "uniqueItems": true
+}


### PR DESCRIPTION
Fixes a bug with parsing of validation properties for an array property.  I tried following your conversions, but if they are any fixes required please let me know.