### PR TITLE
Fix #1258 - Serialize/deserialize security in "security" instead of "…

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
@@ -51,7 +51,7 @@ public class JsonDeserializationTest {
     }
 
     @Test
-    public void testDeserializeSecurityRequirement() throws Exception {
+    public void testDeserializeSecurity() throws Exception {
         final Swagger swagger = TestUtils.deserializeJsonFileFromClasspath("specFiles/securityDefinitions.json", Swagger.class);
 
         final List<SecurityRequirement> security = swagger.getSecurity();

--- a/modules/swagger-core/src/test/java/io/swagger/util/JsonSerializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/JsonSerializationTest.java
@@ -64,6 +64,6 @@ public class JsonSerializationTest {
                 .security(new SecurityRequirement().requirement("api_key").requirement("basic_auth"))
                 .security(new SecurityRequirement().requirement("oauth2", Arrays.asList("hello", "world")));
         json = Json.mapper().writeValueAsString(swagger);
-        assertEquals(json, "{\"swagger\":\"2.0\",\"securityRequirement\":[{\"basic_auth\":[],\"api_key\":[]},{\"oauth2\":[\"hello\",\"world\"]}]}");
+        assertEquals(json, "{\"swagger\":\"2.0\",\"security\":[{\"basic_auth\":[],\"api_key\":[]},{\"oauth2\":[\"hello\",\"world\"]}]}");
     }
 }

--- a/modules/swagger-core/src/test/resources/specFiles/securityDefinitions.json
+++ b/modules/swagger-core/src/test/resources/specFiles/securityDefinitions.json
@@ -1,6 +1,6 @@
 {
   "swagger" : "2.0",
-  "securityRequirement" : [ {
+  "security" : [ {
     "basic_auth" : [ ],
     "api_key" : [ ]
   }, {

--- a/modules/swagger-models/src/main/java/io/swagger/models/Swagger.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Swagger.java
@@ -298,27 +298,37 @@ public class Swagger {
         this.securityDefinitions.put(name, securityDefinition);
     }
 
+    /**
+     * @deprecated Use {@link #getSecurity()}.
+     */
+    @JsonIgnore
     @Deprecated
     public List<SecurityRequirement> getSecurityRequirement() {
         return security;
     }
 
+    /**
+     * @deprecated Use {@link #setSecurity(List)}.
+     */
+    @JsonIgnore
     @Deprecated
     public void setSecurityRequirement(List<SecurityRequirement> securityRequirements) {
         this.security = securityRequirements;
     }
 
+    /**
+     * @deprecated Use {@link #addSecurity(SecurityRequirement)}.
+     */
+    @JsonIgnore
     @Deprecated
     public void addSecurityDefinition(SecurityRequirement securityRequirement) {
         this.addSecurity(securityRequirement);
     }
 
-    @JsonIgnore //remove JsonIgnore when getSecurityRequirement() method is deleted in next major version
     public List<SecurityRequirement> getSecurity() {
         return security;
     }
 
-    @JsonIgnore  //remove JsonIgnore when setSecurityRequirement() method is deleted in next major version
     public void setSecurity(List<SecurityRequirement> securityRequirements) {
         this.security = securityRequirements;
     }

--- a/modules/swagger-models/src/test/java/io/swagger/models/SwaggerTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/SwaggerTest.java
@@ -82,7 +82,7 @@ public class SwaggerTest {
         swagger.setSecurityRequirement(new ArrayList<SecurityRequirement>(Arrays.asList(requirement)));
 
         // then
-        assertTrue(swagger.getSecurityRequirement().contains(requirement),
+        assertTrue(swagger.getSecurity().contains(requirement),
                 "The newly added requiement must be contained in the requiement list");
     }
 
@@ -92,7 +92,7 @@ public class SwaggerTest {
         swagger.addSecurityDefinition(requirement);
 
         // then
-        assertTrue(swagger.getSecurityRequirement().contains(requirement),
+        assertTrue(swagger.getSecurity().contains(requirement),
                 "The newly added requiement must be contained in the requiement list");
     }
 


### PR DESCRIPTION
Fix #1258 - Serialize/deserialize security in `"security"` instead of `"securityRequierement"` to be spec compliant.
