### PR TITLE
Refs #1636, applies Option 4 scanning model

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -186,11 +186,15 @@ public class Reader {
         boolean hasApiAnnotation = (api != null);
         boolean isApiHidden = hasApiAnnotation && api.hidden();
 
-        // class readable only if annotated with @Path or isSubresource, or and @Api not hidden
-        boolean classReadable = (hasPathAnnotation || isSubresource) && !isApiHidden;
+        // class readable only if annotated with ((@Path and @Api) or isSubresource ) - and @Api not hidden
+        boolean classReadable = ((hasPathAnnotation && hasApiAnnotation)|| isSubresource) && !isApiHidden;
 
-        // readable if classReadable or (scanAllResources true in config and @Api not hidden)
-        boolean readable = classReadable || (!isApiHidden && config.isScanAllResources());
+        // with scanAllResources true in config and @Api not hidden scan only if it has also @Path annotation or is subresource
+        boolean scanAll = !isApiHidden && config.isScanAllResources() && (hasPathAnnotation || isSubresource);
+
+        // readable if classReadable or scanAll
+        boolean readable = classReadable || scanAll;
+
 
         if (!readable) {
             return swagger;

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -30,6 +30,7 @@ import io.swagger.models.properties.StringProperty;
 import io.swagger.resources.ClassWithExamplePost;
 import io.swagger.resources.HiddenResource;
 import io.swagger.resources.NicknamedOperation;
+import io.swagger.resources.NotValidRootResource;
 import io.swagger.resources.Resource1041;
 import io.swagger.resources.Resource1073;
 import io.swagger.resources.Resource1085;
@@ -307,6 +308,11 @@ public class SimpleReaderTest {
     @Test(description = "not scan a hidden resource")
     public void notScanHiddenResource() {
         assertNull(getSwagger(HiddenResource.class).getPaths());
+    }
+
+    @Test(description = "not scan a resource without @Api annotation")
+    public void notScanNotValidRootResourcee() {
+        assertNull(getSwagger(NotValidRootResource.class).getPaths());
     }
 
     @Test(description = "correctly model an empty model per 499")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/NotValidRootResource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/NotValidRootResource.java
@@ -1,0 +1,19 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+
+@Path("fun")
+public class NotValidRootResource {
+    @GET
+    @ApiOperation(value = "this", tags = "tag1")
+    @Path("/this")
+    public Response getThis(@ApiParam(value = "test") ArrayList<String> tenantId) {
+        return Response.ok().build();
+    }
+}


### PR DESCRIPTION
in v1.5.8 JAX-RS scan behaviour was updated to mandate @Path annotation at class level to have the class scanned, also without any @Api annotation; This patch applies instead behaviour as in Option 4 table of #1636, therefore "in standard mode" (no scanAllResources, no hidden) both annotation need to be present for the class to be scanned.