### PR TITLE
Allow scanning of split resources (#1800)

### DIFF
--- a/modules/swagger-jaxrs/.gitignore
+++ b/modules/swagger-jaxrs/.gitignore
@@ -1,0 +1,1 @@
+/test-output/

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
@@ -1,5 +1,24 @@
 package io.swagger.jaxrs.config;
 
+import java.lang.annotation.Annotation;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.ServletConfig;
+import javax.ws.rs.Path;
+
+import org.apache.commons.lang3.StringUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.ResourcesScanner;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.reflect.TypeToken;
+
 import io.swagger.annotations.Api;
 import io.swagger.annotations.SwaggerDefinition;
 import io.swagger.config.FilterFactory;
@@ -12,19 +31,6 @@ import io.swagger.models.Info;
 import io.swagger.models.License;
 import io.swagger.models.Scheme;
 import io.swagger.models.Swagger;
-import org.apache.commons.lang3.StringUtils;
-import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.scanners.TypeAnnotationsScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.servlet.ServletConfig;
-import java.util.HashSet;
-import java.util.Set;
 
 public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfig {
     private static final Logger LOGGER = LoggerFactory.getLogger(BeanConfig.class);
@@ -269,9 +275,24 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
 
         final Reflections reflections = new Reflections(config);
         Set<Class<?>> classes = reflections.getTypesAnnotatedWith(javax.ws.rs.Path.class);
-        classes.addAll(reflections.getTypesAnnotatedWith(SwaggerDefinition.class));
-        classes.addAll(reflections.getTypesAnnotatedWith(Api.class));
-
+        Set<Class<?>> typesAnnotatedWith = reflections.getTypesAnnotatedWith(SwaggerDefinition.class);
+				classes.addAll(typesAnnotatedWith);
+        
+        /*
+         * Find concrete types annotated with @Api, but with a supertype annotated with @Path.
+         * This would handle split resources where the interface has jax-rs annotations
+         * and the implementing class has Swagger annotations 
+         */
+        for (Class<?> cls : reflections.getTypesAnnotatedWith(Api.class)) {
+        	for (Class<?> intfc : TypeToken.of(cls).getTypes().interfaces().rawTypes()) {
+        		Annotation ann = intfc.getAnnotation(javax.ws.rs.Path.class);
+        		if (ann != null) {
+        			classes.add(cls);
+        			break;
+        		}
+					}
+				}
+        
         Set<Class<?>> output = new HashSet<Class<?>>();
         for (Class<?> cls : classes) {
             if (allowAllPackages) {
@@ -287,6 +308,19 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
         return output;
     }
 
+    private boolean hasAnnotatedGraph(Class<?> cls, Class<?> annotation) {
+    	boolean result = false;
+    	Class<?>[] interfaces = cls.getInterfaces();
+			for (Class<?> class1 : interfaces) {
+				if (interfaces != null && interfaces.length > 0) {
+					result = true;
+				} else {
+					result = hasAnnotatedGraph(class1, annotation);
+				}
+			}
+    	return result;
+    }
+       
     private void updateInfoFromConfig() {
         info = getSwagger().getInfo();
         if (info == null) {

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
@@ -1,5 +1,6 @@
 package io.swagger.jaxrs.config;
 
+import io.swagger.annotations.Api;
 import io.swagger.annotations.SwaggerDefinition;
 import io.swagger.config.FilterFactory;
 import io.swagger.config.Scanner;
@@ -269,6 +270,7 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
         final Reflections reflections = new Reflections(config);
         Set<Class<?>> classes = reflections.getTypesAnnotatedWith(javax.ws.rs.Path.class);
         classes.addAll(reflections.getTypesAnnotatedWith(SwaggerDefinition.class));
+        classes.addAll(reflections.getTypesAnnotatedWith(Api.class));
 
         Set<Class<?>> output = new HashSet<Class<?>>();
         for (Class<?> cls : classes) {

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
@@ -307,19 +307,6 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
         }
         return output;
     }
-
-    private boolean hasAnnotatedGraph(Class<?> cls, Class<?> annotation) {
-    	boolean result = false;
-    	Class<?>[] interfaces = cls.getInterfaces();
-			for (Class<?> class1 : interfaces) {
-				if (interfaces != null && interfaces.length > 0) {
-					result = true;
-				} else {
-					result = hasAnnotatedGraph(class1, annotation);
-				}
-			}
-    	return result;
-    }
        
     private void updateInfoFromConfig() {
         info = getSwagger().getInfo();

--- a/modules/swagger-jaxrs/src/test/java/com/splitresourcesTest/SplitResource.java
+++ b/modules/swagger-jaxrs/src/test/java/com/splitresourcesTest/SplitResource.java
@@ -1,0 +1,17 @@
+package com.splitresourcesTest;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+/**
+ * Created by KangoV on 2016-05-22
+ * #1800
+ */
+@Path("/api/1.0")
+public interface SplitResource {
+	
+  @GET
+	public Response getChildren();
+	
+}

--- a/modules/swagger-jaxrs/src/test/java/com/splitresourcesTestImpl/SplitResourceImpl.java
+++ b/modules/swagger-jaxrs/src/test/java/com/splitresourcesTestImpl/SplitResourceImpl.java
@@ -1,0 +1,25 @@
+package com.splitresourcesTestImpl;
+
+import javax.ws.rs.core.Response;
+
+import com.splitresourcesTest.SplitResource;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+/**
+ * Created by KangoV on 2016-05-22
+ * #1800
+ */
+@Api(tags = "children")
+public class SplitResourceImpl implements SplitResource {
+
+    @ApiOperation(value = "Get Child by id")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Success") })
+    public Response getChildren() {
+        return Response.ok().entity("Hello World").build();
+    }
+    
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/BeanConfigTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/BeanConfigTest.java
@@ -1,5 +1,6 @@
 package io.swagger;
 
+import com.splitresourcesTestImpl.SplitResourceImpl;
 import com.subresourcesTest.RootResource;
 import io.swagger.jaxrs.config.BeanConfig;
 import io.swagger.models.Scheme;
@@ -16,7 +17,8 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class BeanConfigTest {
-    private final Set expectedKeys = new HashSet<String>(Arrays.asList("/packageA", "/packageB"));
+	
+    private final Set<?> expectedKeys = new HashSet<String>(Arrays.asList("/packageA", "/packageB"));
     private final Set<Scheme> expectedSchemas = EnumSet.of(Scheme.HTTP, Scheme.HTTPS);
 
     private BeanConfig createBeanConfig(String rp) {
@@ -60,5 +62,16 @@ public class BeanConfigTest {
 
         assertEquals(classes.size(), 1, "BeanConfig should only pick up the root resource because it has a @Path annotation at the class level");
         assertTrue(classes.contains(RootResource.class));
+    }
+
+    @Test
+    public void testBeanConfigScansSplitResourcesAnnoatedWithPathAndApi() throws Exception {
+        BeanConfig bc = new BeanConfig();
+        bc.setResourcePackage("com.splitresourcesTestImpl");
+
+        Set<Class<?>> classes = bc.classes();
+
+        assertEquals(classes.size(), 1, "BeanConfig should pick up implementations annotated with @Api that have a superinterface with @Path");
+        assertTrue(classes.contains(SplitResourceImpl.class));
     }
 }


### PR DESCRIPTION
Modification to allow inclusion of a concrete resource classes annotated with @Api combined with superinterfaces of the concreate class annotated with @Path.

Detailed in : #1800 
