### PR TITLE
Remove unused deps in swagger-jersey-jaxrs

### DIFF
--- a/modules/swagger-jersey-jaxrs/pom.xml
+++ b/modules/swagger-jersey-jaxrs/pom.xml
@@ -69,25 +69,7 @@
         </dependency>
         <dependency>
             <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-servlet</artifactId>
-            <version>${jersey-version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${jersey-version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-core</artifactId>
-            <version>${jersey-version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-server</artifactId>
             <version>${jersey-version}</version>
             <scope>compile</scope>
         </dependency>


### PR DESCRIPTION
There was unnecessary dependencies on both `jersey-server` and `jersey-client` in `swagger-jersey-jaxrs`.
