### PR TITLE
Use null Instead of false When No Default Value is Provided

### DIFF
--- a/modules/swagger-core/src/test/resources/Animal.json
+++ b/modules/swagger-core/src/test/resources/Animal.json
@@ -54,8 +54,7 @@
                     },
                     "isDomestic": {
                         "type": "boolean",
-                        "position": 3,
-                        "default": false
+                        "position": 3
                     }
                 }
             }

--- a/modules/swagger-core/src/test/resources/Cat.json
+++ b/modules/swagger-core/src/test/resources/Cat.json
@@ -23,8 +23,7 @@
             },
             "isDomestic": {
                 "type": "boolean",
-                "position": 3,
-                "default": false
+                "position": 3
             }
         }
     }

--- a/modules/swagger-core/src/test/resources/Pet.json
+++ b/modules/swagger-core/src/test/resources/Pet.json
@@ -19,8 +19,7 @@
             },
             "isDomestic": {
                 "type": "boolean",
-                "position": 3,
-                "default": false
+                "position": 3
             }
         }
     }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/BooleanProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/BooleanProperty.java
@@ -34,10 +34,12 @@ public class BooleanProperty extends AbstractProperty implements Property {
     }
 
     public BooleanProperty _default(String _default) {
-        try {
-            this.setDefault(Boolean.parseBoolean(_default));
-        } catch (Exception e) {
-            //continue
+        if(_default != null) {
+            try {
+                this.setDefault(Boolean.parseBoolean(_default));
+            } catch (Exception e) {
+                //continue
+            }
         }
         return this;
     }


### PR DESCRIPTION
Code for parseBoolean:
```
   public static boolean parseBoolean(String s) {
        return ((s != null) && s.equalsIgnoreCase("true"));
    }
```
So when the BooleanProperty has no default value (e.g. s == null), we are setting the default value as false.

One of the problems caused by this issue:
https://github.com/kongchen/swagger-maven-plugin/issues/284