### PR TITLE
refs #1765 - numeric enums in parameter

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/parameter/ParameterSerializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/parameter/ParameterSerializationTest.java
@@ -7,6 +7,7 @@ import io.swagger.matchers.SerializationMatchers;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.RefModel;
+import io.swagger.models.Swagger;
 import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.HeaderParameter;
 import io.swagger.models.parameters.Parameter;
@@ -19,6 +20,7 @@ import io.swagger.models.properties.StringProperty;
 import io.swagger.util.Json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.util.Yaml;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -335,6 +337,48 @@ public class ParameterSerializationTest {
         assertEquals(((PathParameter) p).getEnum(), Arrays.asList("a", "b", "c"));
     }
 
+    @Test(description = "it should deserialize a number path parameter with enum")
+    public void deserializeNumberEnumPathParameter() throws IOException {
+        final String json = "{" +
+                "   \"in\":\"path\"," +
+                "   \"required\":true," +
+                "   \"items\":{" +
+                "      \"type\":\"integer\"" +
+                "   }," +
+                "   \"enum\":[1,2,3]" +
+                "}";
+        final Parameter p = m.readValue(json, Parameter.class);
+        SerializationMatchers.assertEqualsToJson(p, json);
+
+        assertEquals(((PathParameter) p).getEnumValue(), Arrays.asList(1,2,3));
+    }
+
+    @Test(description = "should serialize correctly typed numeric enums")
+    public void testIssue1765() throws Exception {
+        String yaml =
+                "swagger: '2.0'\n" +
+                        "paths:\n" +
+                        "  /test:\n" +
+                        "    get:\n" +
+                        "      parameters:\n" +
+                        "      - name: \"days\"\n" +
+                        "        in: \"path\"\n" +
+                        "        required: true\n" +
+                        "        type: \"integer\"\n" +
+                        "        format: \"int32\"\n" +
+                        "        enum:\n" +
+                        "        - 1\n" +
+                        "        - 2\n" +
+                        "        - 3\n" +
+                        "        - 4\n" +
+                        "        - 5\n" +
+                        "      responses:\n" +
+                        "        default:\n" +
+                        "          description: great";
+
+        Swagger swagger = Yaml.mapper().readValue(yaml, Swagger.class);
+        SerializationMatchers.assertEqualsToYaml(swagger, yaml);
+    }
     @Test(description = "should serialize string value")
     public void testStringValue() {
         final QueryParameter param = new QueryParameter();

--- a/modules/swagger-core/src/test/java/io/swagger/properties/PropertySerializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/properties/PropertySerializationTest.java
@@ -254,6 +254,18 @@ public class PropertySerializationTest {
         assertEquals(m.writeValueAsString(p), json);
     }
 
+    @Test(description = "it should deserialize an IntegerProperty with enums")
+    public void deserializeEnumIntegerProperty() throws IOException {
+        final String json = "{\"type\":\"integer\",\"format\":\"int32\",\"enum\":[1,2]}";
+        final Property p = m.readValue(json, Property.class);
+        assertEquals(p.getType(), "integer");
+        List<Integer> _enum = ((IntegerProperty) p).getEnum();
+        assertNotNull(_enum);
+        assertEquals(_enum, Arrays.asList(1, 2));
+        assertEquals(p.getClass(), IntegerProperty.class);
+        assertEquals(m.writeValueAsString(p), json);
+    }
+
     @Test(description = "it should serialize a string array property")
     public void serializeArrayStringProperty() throws IOException {
         final ArrayProperty p = new ArrayProperty().items(new StringProperty());

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/SerializableParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/SerializableParameter.java
@@ -25,6 +25,10 @@ public interface SerializableParameter extends Parameter {
 
     void setEnum(List<String> _enum);
 
+    List<Object> getEnumValue();
+
+    void setEnumValue(List<?> enumValue);
+
     Integer getMaxLength();
 
     void setMaxLength(Integer maxLength);


### PR DESCRIPTION
Fixes #1765, implements additional "enumValue" of type Object to correctly handle numeric values

This replaces  PR #1807 maintaining backward compatibility (as much as possible: enum for numeric parameters are serialized in Json/Yaml as numbers and not any more strings). It implements a solution similar to "defaultValue" as suggested by @tomtit. 

@tomit can you please have a look and let me know if you think this is ok?
update: discussed with tomit and updated according to suggestions (fall back to string at item level)