### PR TITLE
Make ApiImplicitParams available for annotation types

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParams.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParams.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  *
  * @see ApiImplicitParam
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD,ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiImplicitParams {
     /**


### PR DESCRIPTION
When using ApiImplicitParams on a custom annotation you can avoid duplicating repeated parameter definitions.
##### Example:

``` java
@Api(value = "lots of API endpoints here...")
public class LotsOfMethodsController{

  @ApiOperation(value = "Method1")
  @MySwaggerImplicitSecurityHeader
  public void ApiMethod1(){}

  @ApiOperation(value = "Method2")
  @MySwaggerImplicitSecurityHeader
  public void ApiMethod2(){}
  //...with more of these ApiMethods down the line

  @Retention(value = RetentionPolicy.RUNTIME)
  @ApiImplicitParams({@ApiImplicitParam(name = "x-my-custom-auth-header-that-keeps-repeating", required = true, dataType = "string", paramType = "header",defaultValue = "SOME_TEST_TOKEN_VALUE")})
  public @interface MySwaggerImplicitSecurityHeader { }

}
```
