### PR TITLE
Allow overriding of BaseApiListingResource.process method.

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/BaseApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/BaseApiListingResource.java
@@ -91,7 +91,7 @@ public abstract class BaseApiListingResource {
         return swagger;
     }
 
-    private Swagger process(
+    protected Swagger process(
             Application app,
             ServletContext servletContext,
             ServletConfig sc,


### PR DESCRIPTION
This allows to customize lookup logic above of provided Swagger api. This solves #1887.
