### PR TITLE
#1894 Fixed Reflection.isOverriddenMethod to detect interface inheritance

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/ReflectionUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ReflectionUtilsTest.java
@@ -6,16 +6,14 @@ import io.swagger.reflection.Child;
 import io.swagger.reflection.IParent;
 import io.swagger.reflection.Parent;
 import io.swagger.util.ReflectionUtils;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import javax.ws.rs.Path;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
-
-import javax.ws.rs.Path;
 
 public class ReflectionUtilsTest {
 
@@ -46,6 +44,16 @@ public class ReflectionUtilsTest {
         for (Method method : Object.class.getMethods()) {
             if ("equals".equals(method.getName())) {
                 Assert.assertFalse(ReflectionUtils.isOverriddenMethod(method, Object.class));
+            }
+        }
+
+        for (Method method: IParent.class.getMethods()){
+            if("parametrizedMethod5".equals(method.getName())){
+                Assert.assertTrue(ReflectionUtils.isOverriddenMethod(method, IParent.class));
+            }else if("parametrizedMethod2".equals(method.getName())){
+                Assert.assertFalse(ReflectionUtils.isOverriddenMethod(method, IParent.class));
+            }else{
+                Assert.fail("Method not expected");
             }
         }
     }

--- a/modules/swagger-core/src/test/java/io/swagger/reflection/Child.java
+++ b/modules/swagger-core/src/test/java/io/swagger/reflection/Child.java
@@ -31,6 +31,11 @@ public class Child extends Parent<Integer> implements IParent<Long> {
     }
 
     @Override
+    public String parametrizedMethod5(Long arg) {
+        return null;
+    }
+
+    @Override
     public void annotationHolder() {
 
     }

--- a/modules/swagger-core/src/test/java/io/swagger/reflection/IGrandparent.java
+++ b/modules/swagger-core/src/test/java/io/swagger/reflection/IGrandparent.java
@@ -1,0 +1,5 @@
+package io.swagger.reflection;
+
+public interface IGrandparent<T extends Number> {
+    String parametrizedMethod5(T arg);
+}

--- a/modules/swagger-core/src/test/java/io/swagger/reflection/IParent.java
+++ b/modules/swagger-core/src/test/java/io/swagger/reflection/IParent.java
@@ -3,7 +3,11 @@ package io.swagger.reflection;
 import javax.ws.rs.Path;
 
 @Path("parentInterfacePath")
-public interface IParent<T extends Number> {
+public interface IParent<T extends Number> extends IGrandparent<T> {
 
     public String parametrizedMethod2(T arg);
+
+    @Override
+    String parametrizedMethod5(T arg);
+
 }


### PR DESCRIPTION
Issue 1894 identified an issue where Reflection.isOverriddenMethod could not tell if the method was over ridden in another interface.
This now looks for interfaces & any superclass and then loops through them all, performing the same logic as before
