### PR TITLE
#1896 Fixed io.swagger.jackson.ModelResolver - Composition model when resolving child type

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContextImpl.java
+++ b/modules/swagger-core/src/main/java/io/swagger/converter/ModelConverterContextImpl.java
@@ -1,5 +1,6 @@
 package io.swagger.converter;
 
+import io.swagger.models.ComposedModel;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.properties.Property;
@@ -100,8 +101,13 @@ public class ModelConverterContextImpl implements ModelConverterContext {
         }
         if (resolved != null) {
             modelByType.put(type, resolved);
-            if (resolved instanceof ModelImpl) {
-                ModelImpl impl = (ModelImpl) resolved;
+
+            Model resolvedImpl = resolved;
+            if (resolvedImpl instanceof ComposedModel) {
+                resolvedImpl = ((ComposedModel) resolved).getChild();
+            }
+            if (resolvedImpl instanceof ModelImpl) {
+                ModelImpl impl = (ModelImpl) resolvedImpl;
                 if (impl.getName() != null) {
                     modelByName.put(impl.getName(), resolved);
                 }

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.fasterxml.jackson.databind.BeanDescription;

--- a/modules/swagger-core/src/test/java/io/swagger/jackson/InheritedBeanTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/jackson/InheritedBeanTest.java
@@ -1,72 +1,208 @@
 package io.swagger.jackson;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
-
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.swagger.annotations.ApiModel;
 import io.swagger.converter.ModelConverterContextImpl;
 import io.swagger.models.ComposedModel;
 import io.swagger.models.Model;
 import io.swagger.models.properties.Property;
-
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
 public class InheritedBeanTest extends SwaggerTestBase {
 
-	private final ModelResolver modelResolver = new ModelResolver(new ObjectMapper());
-	private final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+    private ModelResolver modelResolver;
+    private ModelConverterContextImpl context;
 
-	@Test
-	public void testInheritedBean() throws Exception {
-		final Model baseModel = context.resolve(BaseBean.class);
+    @BeforeTest
+    public void setup() {
+        modelResolver = new ModelResolver(new ObjectMapper());
+        context = new ModelConverterContextImpl(modelResolver);
+    }
 
-		assertNotNull(baseModel);
-		Map<String, Property> baseProperites = baseModel.getProperties();
-		assertEquals(baseProperites.size(), 3);
-		for (Map.Entry<String, Property> entry : baseProperites.entrySet()) {
-			final String name = entry.getKey();
-			final Property prop = entry.getValue();
-			if ("type".equals(name)) {
-				assertEquals(prop.getType(), "string");
-			} else if ("a".equals(name)) {
-				assertEquals(prop.getType(), "integer");
-				assertEquals(prop.getFormat(), "int32");
-			} else if ("b".equals(name)) {
-				assertEquals(prop.getType(), "string");
-			}
-		}
+    @Test
+    public void testInheritedBean() throws Exception {
+        final Model baseModel = context.resolve(BaseBean.class);
 
-		final Model subModel = context.getDefinedModels().get("Sub1Bean");
-		assertNotNull(subModel);
-		// make sure child points at parent
-		assertTrue(subModel instanceof ComposedModel);
-		ComposedModel cm = (ComposedModel) subModel;
-		assertEquals(cm.getParent().getReference(), "#/definitions/BaseBean");
+        assertNotNull(baseModel);
+        assertBasePropertiesValid(baseModel.getProperties());
 
-		// make sure parent properties are filtered out of subclass
-		Map<String, Property> subProperties = cm.getChild().getProperties();
-		assertEquals(subProperties.size(), 1);
-	}
+        final Model subModel = context.getDefinedModels().get("Sub1Bean");
+        assertNotNull(subModel);
+        // make sure child points at parent
+        assertTrue(subModel instanceof ComposedModel);
+        ComposedModel cm = (ComposedModel) subModel;
+        assertEquals(cm.getParent().getReference(), "#/definitions/BaseBean");
 
-	@JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
-	@JsonSubTypes({ @JsonSubTypes.Type(value = Sub1Bean.class, name = "sub1") })
-	@ApiModel(description = "BaseBean", discriminator = "type", subTypes = { Sub1Bean.class })
-	static class BaseBean {
-		public String type;
-		public int a;
-		public String b;
-	}
+        // make sure parent properties are filtered out of subclass
+        assertSub1PropertiesValid(cm.getChild().getProperties());
+    }
 
-	@ApiModel(description = "Sub1Bean")
-	static class Sub1Bean extends BaseBean {
-		public int c;
-	}
+    @Test
+    public void testInheritedChildBean() throws Exception {
+        final Model subModel = context.resolve(Sub1Bean.class);
+        assertNotNull(subModel);
+        // make sure child points at parent
+        assertTrue(subModel instanceof ComposedModel);
+        ComposedModel cm = (ComposedModel) subModel;
+        assertEquals(cm.getParent().getReference(), "#/definitions/BaseBean");
+
+        // make sure parent properties are filtered out of subclass
+        assertSub1PropertiesValid(cm.getChild().getProperties());
+
+        final Model baseModel = context.getDefinedModels().get("BaseBean");
+        assertNotNull(baseModel);
+        assertBasePropertiesValid(baseModel.getProperties());
+    }
+
+    private void assertBasePropertiesValid(Map<String, Property> baseProperites) {
+        assertEquals(baseProperites.size(), 3);
+        for (Map.Entry<String, Property> entry : baseProperites.entrySet()) {
+            final String name = entry.getKey();
+            final Property prop = entry.getValue();
+            if ("type".equals(name)) {
+                assertEquals(prop.getType(), "string");
+            } else if ("a".equals(name)) {
+                assertEquals(prop.getType(), "integer");
+                assertEquals(prop.getFormat(), "int32");
+            } else if ("b".equals(name)) {
+                assertEquals(prop.getType(), "string");
+            }
+        }
+    }
+
+    private void assertSub1PropertiesValid(Map<String, Property> subProperties) {
+        assertEquals(subProperties.size(), 1);
+        for (Map.Entry<String, Property> entry : subProperties.entrySet()) {
+            final String name = entry.getKey();
+            final Property prop = entry.getValue();
+            if ("c".equals(name)) {
+                assertEquals(prop.getType(), "integer");
+                assertEquals(prop.getFormat(), "int32");
+            }
+        }
+    }
+
+    @JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+    @JsonSubTypes({@JsonSubTypes.Type(value = Sub1Bean.class, name = "sub1")})
+    @ApiModel(description = "BaseBean", discriminator = "type", subTypes = {Sub1Bean.class})
+    static class BaseBean {
+        public String type;
+        public int a;
+        public String b;
+    }
+
+    @ApiModel(description = "Sub1Bean", parent = BaseBean.class)
+    static class Sub1Bean extends BaseBean {
+        public int c;
+    }
+
+    @Test
+    public void testMultipleInheritedBean() throws Exception {
+        final Model baseModel = context.resolve(MultipleBaseBean.class);
+
+        assertNotNull(baseModel);
+        assertBasePropertiesValid(baseModel.getProperties());
+
+        final Model sub1Model = context.getDefinedModels().get("MultipleSub1Bean");
+        assertNotNull(sub1Model);
+        // make sure child points at parent
+        assertTrue(sub1Model instanceof ComposedModel);
+        ComposedModel cm1 = (ComposedModel) sub1Model;
+        assertEquals(cm1.getParent().getReference(), "#/definitions/MultipleBaseBean");
+
+        // make sure parent properties are filtered out of subclass
+        assertSub1PropertiesValid(cm1.getChild().getProperties());
+
+        final Model sub2Model = context.getDefinedModels().get("MultipleSub2Bean");
+        assertNotNull(sub2Model);
+        // make sure child points at parent
+        assertTrue(sub2Model instanceof ComposedModel);
+        ComposedModel cm2 = (ComposedModel) sub2Model;
+        assertEquals(cm2.getParent().getReference(), "#/definitions/MultipleBaseBean");
+
+        // make sure parent properties are filtered out of subclass
+        assertSub2PropertiesValid(cm2.getChild().getProperties());
+    }
+
+    @Test
+    public void testMultipleInheritedChildBean() throws Exception {
+        final Model subModel = context.resolve(MultipleSub1Bean.class);
+        assertNotNull(subModel);
+        // make sure child points at parent
+        assertTrue(subModel instanceof ComposedModel);
+        ComposedModel cm = (ComposedModel) subModel;
+        assertEquals(cm.getParent().getReference(), "#/definitions/MultipleBaseBean");
+
+        // make sure parent properties are filtered out of subclass
+        assertSub1PropertiesValid(cm.getChild().getProperties());
+
+        final Model baseModel = context.getDefinedModels().get("MultipleBaseBean");
+        assertNotNull(baseModel);
+        assertBasePropertiesValid(baseModel.getProperties());
+
+        final Model sub1Model = context.getDefinedModels().get("MultipleSub1Bean");
+        assertNotNull(sub1Model);
+        // make sure child points at parent
+        assertTrue(sub1Model instanceof ComposedModel);
+        ComposedModel cm1 = (ComposedModel) sub1Model;
+        assertEquals(cm1.getParent().getReference(), "#/definitions/MultipleBaseBean");
+
+        // make sure parent properties are filtered out of subclass
+        assertSub1PropertiesValid(cm1.getChild().getProperties());
+
+        final Model sub2Model = context.getDefinedModels().get("MultipleSub2Bean");
+        assertNotNull(sub2Model);
+        // make sure child points at parent
+        assertTrue(sub2Model instanceof ComposedModel);
+        ComposedModel cm2 = (ComposedModel) sub2Model;
+        assertEquals(cm2.getParent().getReference(), "#/definitions/MultipleBaseBean");
+
+        // make sure parent properties are filtered out of subclass
+        assertSub2PropertiesValid(cm2.getChild().getProperties());
+    }
+
+    private void assertSub2PropertiesValid(Map<String, Property> subProperties) {
+        assertEquals(subProperties.size(), 1);
+        for (Map.Entry<String, Property> entry : subProperties.entrySet()) {
+            final String name = entry.getKey();
+            final Property prop = entry.getValue();
+            if ("d".equals(name)) {
+                assertEquals(prop.getType(), "integer");
+                assertEquals(prop.getFormat(), "int32");
+            }
+        }
+    }
+
+    @JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = MultipleSub1Bean.class, name = "multipleSub1"),
+            @JsonSubTypes.Type(value = MultipleSub2Bean.class, name = "multipleSub2")
+    })
+    @ApiModel(description = "MultipleBaseBean", discriminator = "type", subTypes = {MultipleSub1Bean.class,
+            MultipleSub2Bean.class})
+    static class MultipleBaseBean {
+        public String type;
+        public int a;
+        public String b;
+    }
+
+    @ApiModel(description = "MultipleSub1Bean", parent = MultipleBaseBean.class)
+    static class MultipleSub1Bean extends MultipleBaseBean {
+        public int c;
+    }
+
+    @ApiModel(description = "MultipleSub2Bean", parent = MultipleBaseBean.class)
+    static class MultipleSub2Bean extends MultipleBaseBean {
+        public int d;
+    }
 
 }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ChildTypeTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ChildTypeTest.java
@@ -1,0 +1,51 @@
+package io.swagger;
+
+import io.swagger.jaxrs.Reader;
+import io.swagger.models.Model;
+import io.swagger.models.Operation;
+import io.swagger.models.RefModel;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.resources.ResourceWithChildType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * This class test that refs are setup correctly when a child type is referenced.
+ */
+public class ChildTypeTest {
+    private final Swagger swagger = new Reader(new Swagger()).read(ResourceWithChildType.class);
+
+    private BodyParameter getBodyParameter(Operation op, int index) {
+        return (BodyParameter) op.getParameters().get(index);
+    }
+
+    @Test(description = "Tests child type response schema ref is correctly set up")
+    public void testChildTypeResponse() {
+        Operation op = swagger.getPath("/childType/testChildTypeResponse").getGet();
+        Property schema = op.getResponses().get("200").getSchema();
+        assertEquals(schema.getClass().getName(), RefProperty.class.getName());
+        assertEquals(((RefProperty) schema).getSimpleRef(), "Sub1Bean");
+    }
+
+    @Test(description = "Tests child type response schema ref is correctly set up when specified on the operation")
+    public void testChildTypeResponseOnOperation() {
+        Operation op = swagger.getPath("/childType/testChildTypeResponseOnOperation").getGet();
+        Property schema = op.getResponses().get("200").getSchema();
+        assertEquals(schema.getClass().getName(), RefProperty.class.getName());
+        assertEquals(((RefProperty) schema).getSimpleRef(), "Sub1Bean");
+    }
+
+    @Test(description = "Tests schema ref is correctly set up for child type parameter")
+    public void testChildTypeParameter() {
+        Operation op = swagger.getPath("/childType/testChildTypeParameter").getPost();
+        BodyParameter parameter = getBodyParameter(op, 0);
+        Model schema = parameter.getSchema();
+        assertEquals(schema.getClass().getName(), RefModel.class.getName());
+        assertEquals(((RefModel) schema).getSimpleRef(), "Sub1Bean");
+    }
+
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/models/BaseBean.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/models/BaseBean.java
@@ -1,0 +1,21 @@
+package io.swagger.models;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.annotations.ApiModel;
+
+/**
+ * <p>Provides ...</p>
+ * <p>
+ * <p>Created on 25/08/2016 by willows_s</p>
+ *
+ * @author <a href="mailto:willows_s@iblocks.co.uk">willows_s</a>
+ */
+@JsonTypeInfo(include = JsonTypeInfo.As.PROPERTY, use = JsonTypeInfo.Id.NAME, property = "type", visible = true)
+@JsonSubTypes({@JsonSubTypes.Type(value = Sub1Bean.class, name = "sub1")})
+@ApiModel(description = "BaseBean", discriminator = "type", subTypes = {Sub1Bean.class})
+public class BaseBean {
+    public String type;
+    public int a;
+    public String b;
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/models/Sub1Bean.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/models/Sub1Bean.java
@@ -1,0 +1,15 @@
+package io.swagger.models;
+
+import io.swagger.annotations.ApiModel;
+
+/**
+ * <p>Provides ...</p>
+ * <p>
+ * <p>Created on 25/08/2016 by willows_s</p>
+ *
+ * @author <a href="mailto:willows_s@iblocks.co.uk">willows_s</a>
+ */
+@ApiModel(description = "Sub1Bean", parent = BaseBean.class)
+public class Sub1Bean extends BaseBean {
+    public int c;
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithChildType.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithChildType.java
@@ -1,0 +1,35 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.models.Sub1Bean;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@Api
+@Path("/childType")
+public interface ResourceWithChildType {
+
+    @GET
+    @Path("/testChildTypeResponse")
+    @ApiOperation("Tests child type response schema ref is correctly set up")
+    @ApiResponses({@ApiResponse(code = 200, message = "Success", response = Sub1Bean.class)})
+    Response testChildTypeResponse();
+
+    @GET
+    @Path("/testChildTypeResponseOnOperation")
+    @ApiOperation(value = "Tests child type response schema ref is correctly set up when specified on the operation", response = Sub1Bean.class)
+    Response testChildTypeResponseOnOperation();
+
+    @POST
+    @Path("/testChildTypeParameter")
+    @ApiOperation("Tests schema ref is correctly set up for child type parameter")
+    void testChildTypeParameter(@ApiParam(value = "A child type parameter", required = true) Sub1Bean testParam);
+
+}


### PR DESCRIPTION
Resolves [issue 1896](https://github.com/swagger-api/swagger-core/issues/1896). 

**Issue Summary**
(Please refer to the issue for more details and examples)

When the io.swagger.jackson.ModelResolver's resolve method is called with a parent type, the ModelResolver will create a parent model, as well as a child composition model that references that parent model and does not contain the parent properties. However, when called with a child type, the ModelResolver will create a single model containing both the parent and child properties. 

...details from issue omitted here...

I have updated ModelResolver so that, when presented with the child class as its starting point, the resolve method will define the same set of models in the ModelConverterContext that it would define when presented with the parent class as its starting point. It will still return the child model, but this will be a composition model that references the parent model. The resolve method will only define models for the child class in this manner if three conditions are met. The conditions under which the above will occur include the following:
1.     The child type must have an ApiModel annotation specifying its parent type in the parent property of the annotation.
2.     The child type must in fact be a child of the parent type, as determined by the AnnotationIntrospector instance (_intr) in the parent AbstractModelConverter class.
3.     The ApiModel annotation in the parent class must specify a subTypes property containing the child type.
