### PR TITLE
Added support for more bean validator annotations and corrected situa…

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -1,7 +1,18 @@
 package io.swagger.jackson;
 
-import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.annotation.JsonIdentityInfo;
+import com.fasterxml.jackson.annotation.JsonIdentityReference;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.ObjectIdGenerator;
+import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyMetadata;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
@@ -12,8 +23,20 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.converter.ModelConverter;
 import io.swagger.converter.ModelConverterContext;
-import io.swagger.models.*;
-import io.swagger.models.properties.*;
+import io.swagger.models.ComposedModel;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.RefModel;
+import io.swagger.models.Xml;
+import io.swagger.models.properties.AbstractNumericProperty;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.MapProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.PropertyBuilder;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.UUIDProperty;
 import io.swagger.util.AllowableValues;
 import io.swagger.util.AllowableValuesUtils;
 import io.swagger.util.PrimitiveType;
@@ -22,14 +45,28 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.validation.constraints.*;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class ModelResolver extends AbstractModelConverter implements ModelConverter {
     Logger LOGGER = LoggerFactory.getLogger(ModelResolver.class);
@@ -611,22 +648,16 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             DecimalMin min = (DecimalMin) annos.get("javax.validation.constraints.DecimalMin");
             if (property instanceof AbstractNumericProperty) {
                 AbstractNumericProperty ap = (AbstractNumericProperty) property;
-                if (min.inclusive()) {
-                    ap.setMinimum(new Double(min.value()));
-                } else {
-                    ap.setExclusiveMinimum(!min.inclusive());
-                }
+                ap.setMinimum(new Double(min.value()));
+                ap.setExclusiveMinimum(!min.inclusive());
             }
         }
         if (annos.containsKey("javax.validation.constraints.DecimalMax")) {
             DecimalMax max = (DecimalMax) annos.get("javax.validation.constraints.DecimalMax");
             if (property instanceof AbstractNumericProperty) {
                 AbstractNumericProperty ap = (AbstractNumericProperty) property;
-                if (max.inclusive()) {
-                    ap.setMaximum(new Double(max.value()));
-                } else {
-                    ap.setExclusiveMaximum(!max.inclusive());
-                }
+                ap.setMaximum(new Double(max.value()));
+                ap.setExclusiveMaximum(!max.inclusive());
             }
         }
         if (annos.containsKey("javax.validation.constraints.Pattern")) {

--- a/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
@@ -10,10 +10,12 @@ import io.swagger.models.Swagger;
 import io.swagger.models.parameters.AbstractSerializableParameter;
 import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.AbstractNumericProperty;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.FileProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.PropertyBuilder;
+import io.swagger.models.properties.StringProperty;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -348,7 +350,6 @@ public class ParameterProcessor {
          * @param annotations array or parameter annotations
          */
         public AnnotationsHelper(List<Annotation> annotations, Type type) {
-            Class<?> clazz = type instanceof Class ? (Class<?>) type : null;
             String rsDefault = null;
             Size size = null;
             for (Annotation item : annotations) {
@@ -390,11 +391,12 @@ public class ParameterProcessor {
                 }
             }
             if (size != null) {
-                boolean defaultToArray = clazz == null || (apiParam != null && apiParam.isAllowMultiple());
-                if (!defaultToArray && isAssignableToNumber(clazz)) {
+                Property property = ModelConverters.getInstance().readAsProperty(type);
+                boolean defaultToArray = apiParam != null && apiParam.isAllowMultiple();
+                if (!defaultToArray && property instanceof AbstractNumericProperty) {
                     min = (long) size.min();
                     max = (long) size.max();
-                } else if (!defaultToArray && String.class.isAssignableFrom(clazz)) {
+                } else if (!defaultToArray && property instanceof StringProperty) {
                     minLength = size.min();
                     maxLength = size.max();
                 } else {

--- a/modules/swagger-core/src/test/java/io/swagger/ParameterProcessorTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ParameterProcessorTest.java
@@ -9,27 +9,39 @@ import io.swagger.models.parameters.HeaderParameter;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.PathParameter;
 import io.swagger.models.parameters.QueryParameter;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.DoubleProperty;
 import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.LongProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
 import io.swagger.util.ParameterProcessor;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 public class ParameterProcessorTest {
+
+    private static final String TEST_PATTERN_REGXP = "^[A-Z]+$";
 
     private void parametrizedMethod(
             @ApiParam(name = "paramName1", value = "paramValue1", defaultValue = "value1", required = true,
@@ -42,7 +54,7 @@ public class ParameterProcessorTest {
             @ApiParam(name = "paramName4", hidden = true)
             @QueryParam("hiddenParam") String arg4,
             @ApiParam(name = "paramName4")
-            Integer arg5) {
+                    Integer arg5) {
     }
 
     @ApiImplicitParams({
@@ -68,6 +80,69 @@ public class ParameterProcessorTest {
     }
 
     private void arrayParametrizedMethod(@HeaderParam("ids") @Size(min = 5, max = 10) List<Long> ids) {
+
+    }
+
+    private void beanValidationSizeOnNumber(
+            @QueryParam("intValue") @Size(min = 5, max = 10) int intValue,
+            @QueryParam("shortValue") @Size(min = 5, max = 10) short shortValue,
+            @QueryParam("longValue") @Size(min = 5, max = 10) long longValue,
+            @QueryParam("floatValue") @Size(min = 5, max = 10) float floatValue,
+            @QueryParam("doubleValue") @Size(min = 5, max = 10) double doubleValue,
+            @QueryParam("intWrapperValue") @Size(min = 5, max = 10) Integer intWrapperValue,
+            @QueryParam("shortWrapperValue") @Size(min = 5, max = 10) Short shortWrapperValue,
+            @QueryParam("longWrapperValue") @Size(min = 5, max = 10) Long longWrapperValue,
+            @QueryParam("floatWrapperValue") @Size(min = 5, max = 10) Float floatWrapperValue,
+            @QueryParam("doubleWrapperValue") @Size(min = 5, max = 10) Double doubleWrapperValue,
+            @QueryParam("bigIntegerWrapperValue") @Size(min = 5, max = 10) BigInteger bigIntegerWrapperValue,
+            @QueryParam("bigDecimalWrapperValue") @Size(min = 5, max = 10) BigDecimal bigDecimalWrapperValue) {
+    }
+
+    private void beanValidationSizeOnString(
+            @QueryParam("stringValue") @Size(min = 5, max = 10) String stringValue) {
+    }
+
+    private void beanValidationMin(
+            @QueryParam("value") @Min(value = 5) int value) {
+    }
+
+    private void beanValidationMax(
+            @QueryParam("value") @Max(value = 10) int value) {
+    }
+
+    private void beanValidationDecimalMin(
+            @QueryParam("inclusiveValue") @DecimalMin(value = "5.5") double inclusiveValue,
+            @QueryParam("exclusiveValue") @DecimalMin(value = "5.5", inclusive = false) double exclusiveValue) {
+    }
+
+    private void beanValidationDecimalMax(
+            @QueryParam("inclusiveMax") @DecimalMax(value = "10.5") double inclusiveValue,
+            @QueryParam("exclusiveMax") @DecimalMax(value = "10.5", inclusive = false) double exclusiveValue) {
+    }
+
+    private void beanValidationPattern(
+            @QueryParam("patternValue") @Pattern(regexp = TEST_PATTERN_REGXP) String patternValue) {
+    }
+
+    private void beanValidationArrayParametrizedMethod(
+            @HeaderParam("intValues")
+            @Size(min = 5, max = 10)
+            @Min(value = 5)
+            @Max(value = 10) List<Integer> intValues,
+
+            @HeaderParam("doubleValues")
+            @Size(min = 5, max = 10)
+            @DecimalMin(value = "5.5", inclusive = false)
+            @DecimalMax(value = "10.5", inclusive = false) List<Double> doubleValues,
+
+            @HeaderParam("stringValues")
+            @Size(min = 5, max = 10)
+            @Pattern(regexp = TEST_PATTERN_REGXP) List<String> stringValues,
+
+            @ApiParam(allowMultiple = true)
+            @HeaderParam("allowMultipleValues")
+            @Size(min = 5, max = 10) String allowMultipleValues
+    ) {
 
     }
 
@@ -196,4 +271,186 @@ public class ParameterProcessorTest {
         Assert.assertEquals((int) param.getMinItems(), 5);
         Assert.assertEquals((int) param.getMaxItems(), 10);
     }
+
+    @Test
+    public void beanValidationSizeOnNumberTest() throws NoSuchMethodException {
+        final Method method = getClass().getDeclaredMethod("beanValidationSizeOnNumber",
+                int.class,
+                short.class,
+                long.class,
+                float.class,
+                double.class,
+                Integer.class,
+                Short.class,
+                Long.class,
+                Float.class,
+                Double.class,
+                BigInteger.class,
+                BigDecimal.class);
+        final Type[] genericParameterTypes = method.getGenericParameterTypes();
+        final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+        for (int i = 0; i < 12; i++) {
+            final QueryParameter param = (QueryParameter) ParameterProcessor.applyAnnotations(null, new QueryParameter(),
+                    genericParameterTypes[i], Arrays.asList(paramAnnotations[i]));
+            Assert.assertNotNull(param);
+            Assert.assertEquals(param.getMinimum(), 5d);
+            Assert.assertEquals(param.getMaximum(), 10d);
+        }
+    }
+
+    @Test
+    public void beanValidationSizeOnStringTest() throws NoSuchMethodException {
+        final Method method = getClass().getDeclaredMethod("beanValidationSizeOnString",
+                String.class);
+        final Type[] genericParameterTypes = method.getGenericParameterTypes();
+        final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+        final QueryParameter param = (QueryParameter) ParameterProcessor.applyAnnotations(null, new QueryParameter(),
+                genericParameterTypes[0], Arrays.asList(paramAnnotations[0]));
+        Assert.assertNotNull(param);
+        Assert.assertEquals(param.getMinLength(), new Integer(5));
+        Assert.assertEquals(param.getMaxLength(), new Integer(10));
+    }
+
+    @Test
+    public void beanValidationMinTest() throws NoSuchMethodException {
+        final Method method = getClass().getDeclaredMethod("beanValidationMin",
+                int.class);
+        final Type[] genericParameterTypes = method.getGenericParameterTypes();
+        final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+        final QueryParameter param = (QueryParameter) ParameterProcessor.applyAnnotations(null, new QueryParameter(),
+                genericParameterTypes[0], Arrays.asList(paramAnnotations[0]));
+        Assert.assertNotNull(param);
+        Assert.assertEquals(param.getMinimum(), 5d);
+    }
+
+    @Test
+    public void beanValidationMaxTest() throws NoSuchMethodException {
+        final Method method = getClass().getDeclaredMethod("beanValidationMax",
+                int.class);
+        final Type[] genericParameterTypes = method.getGenericParameterTypes();
+        final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+        final QueryParameter param = (QueryParameter) ParameterProcessor.applyAnnotations(null, new QueryParameter(),
+                genericParameterTypes[0], Arrays.asList(paramAnnotations[0]));
+        Assert.assertNotNull(param);
+        Assert.assertEquals(param.getMaximum(), 10d);
+    }
+
+    @Test
+    public void beanValidationDecimalMinTest() throws NoSuchMethodException {
+        final Method method = getClass().getDeclaredMethod("beanValidationDecimalMin",
+                double.class, double.class);
+        final Type[] genericParameterTypes = method.getGenericParameterTypes();
+        final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+        final QueryParameter inclusiveParam = (QueryParameter) ParameterProcessor.applyAnnotations(null, new QueryParameter(),
+                genericParameterTypes[0], Arrays.asList(paramAnnotations[0]));
+        Assert.assertNotNull(inclusiveParam);
+        Assert.assertEquals(inclusiveParam.getMinimum(), 5.5d);
+        Assert.assertNull(inclusiveParam.isExclusiveMinimum());
+
+        final QueryParameter exclusiveParam = (QueryParameter) ParameterProcessor.applyAnnotations(null, new QueryParameter(),
+                genericParameterTypes[1], Arrays.asList(paramAnnotations[1]));
+        Assert.assertNotNull(exclusiveParam);
+        Assert.assertEquals(exclusiveParam.getMinimum(), 5.5d);
+        Assert.assertTrue(exclusiveParam.isExclusiveMinimum());
+    }
+
+    @Test
+    public void beanValidationDecimalMaxTest() throws NoSuchMethodException {
+        final Method method = getClass().getDeclaredMethod("beanValidationDecimalMax",
+                double.class, double.class);
+        final Type[] genericParameterTypes = method.getGenericParameterTypes();
+        final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+        final QueryParameter inclusiveParam = (QueryParameter) ParameterProcessor.applyAnnotations(null, new QueryParameter(),
+                genericParameterTypes[0], Arrays.asList(paramAnnotations[0]));
+        Assert.assertNotNull(inclusiveParam);
+        Assert.assertEquals(inclusiveParam.getMaximum(), 10.5d);
+        Assert.assertNull(inclusiveParam.isExclusiveMaximum());
+
+        final QueryParameter exclusiveParam = (QueryParameter) ParameterProcessor.applyAnnotations(null, new QueryParameter(),
+                genericParameterTypes[1], Arrays.asList(paramAnnotations[1]));
+        Assert.assertNotNull(exclusiveParam);
+        Assert.assertEquals(exclusiveParam.getMaximum(), 10.5d);
+        Assert.assertTrue(exclusiveParam.isExclusiveMaximum());
+    }
+
+    @Test
+    public void beanValidationPatternTest() throws NoSuchMethodException {
+        final Method method = getClass().getDeclaredMethod("beanValidationPattern",
+                String.class);
+        final Type[] genericParameterTypes = method.getGenericParameterTypes();
+        final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+        final QueryParameter param = (QueryParameter) ParameterProcessor.applyAnnotations(null, new QueryParameter(),
+                genericParameterTypes[0], Arrays.asList(paramAnnotations[0]));
+        Assert.assertNotNull(param);
+        Assert.assertEquals(param.getPattern(), TEST_PATTERN_REGXP);
+    }
+
+    @Test
+    public void beanValidationArrayParametrizedMethodTest() throws NoSuchMethodException {
+        final Method method = getClass().getDeclaredMethod("beanValidationArrayParametrizedMethod",
+                List.class, List.class, List.class, String.class);
+        final Type[] genericParameterTypes = method.getGenericParameterTypes();
+        final Annotation[][] paramAnnotations = method.getParameterAnnotations();
+
+        //First param - items specified
+        HeaderParameter headerParam1 = new HeaderParameter().type(ArrayProperty.TYPE).items(new LongProperty());
+        HeaderParameter param1 = (HeaderParameter) ParameterProcessor.applyAnnotations(null, headerParam1,
+                genericParameterTypes[0], Arrays.asList(paramAnnotations[0]));
+        Assert.assertNotNull(param1);
+        Assert.assertEquals((int) param1.getMinItems(), 5);
+        Assert.assertEquals((int) param1.getMaxItems(), 10);
+        Property items1 = param1.getItems();
+        Assert.assertTrue(items1 instanceof LongProperty);
+        LongProperty longItems = (LongProperty) items1;
+        Assert.assertEquals(longItems.getMinimum(), 5d);
+        Assert.assertNull(longItems.getExclusiveMinimum());
+        Assert.assertEquals(longItems.getMaximum(), 10d);
+        Assert.assertNull(longItems.getExclusiveMaximum());
+
+        //Second param - items specified
+        HeaderParameter headerParam2 = new HeaderParameter().type(ArrayProperty.TYPE).items(new DoubleProperty());
+        HeaderParameter param2 = (HeaderParameter) ParameterProcessor.applyAnnotations(null, headerParam2,
+                genericParameterTypes[1], Arrays.asList(paramAnnotations[1]));
+        Assert.assertNotNull(param2);
+        Assert.assertEquals((int) param2.getMinItems(), 5);
+        Assert.assertEquals((int) param2.getMaxItems(), 10);
+        Property items2 = param2.getItems();
+        Assert.assertTrue(items2 instanceof DoubleProperty);
+        DoubleProperty doubleItems = (DoubleProperty) items2;
+        Assert.assertEquals(doubleItems.getMinimum(), 5.5d);
+        Assert.assertTrue(doubleItems.getExclusiveMinimum());
+        Assert.assertEquals(doubleItems.getMaximum(), 10.5d);
+        Assert.assertTrue(doubleItems.getExclusiveMaximum());
+
+        //Third param - items specified
+        HeaderParameter headerParam3 = new HeaderParameter().type(ArrayProperty.TYPE).items(new StringProperty());
+        HeaderParameter param3 = (HeaderParameter) ParameterProcessor.applyAnnotations(null, headerParam3,
+                genericParameterTypes[2], Arrays.asList(paramAnnotations[2]));
+        Assert.assertNotNull(param3);
+        Assert.assertEquals((int) param3.getMinItems(), 5);
+        Assert.assertEquals((int) param3.getMaxItems(), 10);
+        Property items3 = param3.getItems();
+        Assert.assertTrue(items3 instanceof StringProperty);
+        StringProperty stringItems = (StringProperty) items3;
+        Assert.assertEquals(stringItems.getPattern(), TEST_PATTERN_REGXP);
+
+        //Fourth param - items specified
+        HeaderParameter headerParam4 = new HeaderParameter().type(StringProperty.TYPE);
+        HeaderParameter param4 = (HeaderParameter) ParameterProcessor.applyAnnotations(null, headerParam4,
+                genericParameterTypes[3], Arrays.asList(paramAnnotations[3]));
+        Assert.assertNotNull(param4);
+        Assert.assertEquals(param4.getType(), ArrayProperty.TYPE);
+        Assert.assertEquals((int) param4.getMinItems(), 5);
+        Assert.assertEquals((int) param4.getMaxItems(), 10);
+        Property items4 = param4.getItems();
+        Assert.assertTrue(items4 instanceof StringProperty);
+    }
+
 }


### PR DESCRIPTION
Resolves [issue 1904](https://github.com/swagger-api/swagger-core/issues/1904). Please refer to this issue for more details.

Added support for the following bean validation annotations to io.swagger.util.ParameterProcessor (should closely resemble behaviour in io.swagger.jackson.ModelResolver):
- `@Min`
- `@Max`
- `@DecimalMin`
- `@DecimalMax`
- `@Pattern`

Also adjusted the processing of the @Size annotation to mimic io.swagger.jackson.ModelResolver as closely as possible.

Finally, corrected a situation where, where bean validation annotations were not applied if allowed values  were specified via an ApiParam annotation. Bean validation annotations are now applied first, and then overridden by allowed values if specified.
