### PR TITLE
Use In.forValue instead of In.valueOf in SwaggerDefinition reader

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -489,7 +489,7 @@ public class Reader {
             io.swagger.models.auth.ApiKeyAuthDefinition apiKeyAuthDefinition = new io.swagger.models.auth.ApiKeyAuthDefinition();
 
             apiKeyAuthDefinition.setName(apiKeyAuthConfig.name());
-            apiKeyAuthDefinition.setIn(In.valueOf(apiKeyAuthConfig.in().toValue()));
+            apiKeyAuthDefinition.setIn(In.forValue(apiKeyAuthConfig.in().toValue()));
             apiKeyAuthDefinition.setDescription(apiKeyAuthConfig.description());
 
             swagger.addSecurityDefinition(apiKeyAuthConfig.key(), apiKeyAuthDefinition);


### PR DESCRIPTION
Fixes failure when reading an `ApiKeyAuthDefinition` inside a `SwaggerDefinition`