### PR TITLE
Add support for @ApiImplicitParams at class level

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParams.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParams.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  *
  * @see ApiImplicitParam
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiImplicitParams {
     /**

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParams.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParams.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  *
  * @see ApiImplicitParam
  */
-@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiImplicitParams {
     /**

--- a/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
@@ -185,6 +185,12 @@ public class ReflectionUtils {
     public static <A extends Annotation> A getAnnotation(Method method, Class<A> annotationClass) {
         A annotation = method.getAnnotation(annotationClass);
         if (annotation == null) {
+            for (Annotation metaAnnotation : method.getAnnotations()) {
+                annotation = metaAnnotation.annotationType().getAnnotation(annotationClass);
+                if (annotation != null) {
+                    return annotation;
+                }
+            }
             Method superclassMethod = getOverriddenMethod(method);
             if (superclassMethod != null) {
                 annotation = getAnnotation(superclassMethod, annotationClass);

--- a/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
@@ -202,6 +202,12 @@ public class ReflectionUtils {
     public static <A extends Annotation> A getAnnotation(Class<?> cls, Class<A> annotationClass) {
         A annotation = cls.getAnnotation(annotationClass);
         if (annotation == null) {
+            for (Annotation metaAnnotation : cls.getAnnotations()) {
+                annotation = metaAnnotation.annotationType().getAnnotation(annotationClass);
+                if (annotation != null) {
+                    return annotation;
+                };
+            }
             Class<?> superClass = cls.getSuperclass();
             if (superClass != null && !(superClass.equals(Object.class))) {
                 annotation = getAnnotation(superClass, annotationClass);
@@ -209,6 +215,12 @@ public class ReflectionUtils {
         }
         if (annotation == null) {
             for (Class<?> anInterface : cls.getInterfaces()) {
+                for (Annotation metaAnnotation : anInterface.getAnnotations()) {
+                    annotation = metaAnnotation.annotationType().getAnnotation(annotationClass);
+                    if (annotation != null) {
+                        return annotation;
+                    };
+                }
                 annotation = getAnnotation(anInterface, annotationClass);
                 if (annotation != null) {
                     return annotation;

--- a/modules/swagger-core/src/test/java/io/swagger/ReflectionUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ReflectionUtilsTest.java
@@ -129,4 +129,14 @@ public class ReflectionUtilsTest {
         final Method method = Child.class.getMethod("indirectAnnotationMethod");
         Assert.assertNotNull(ReflectionUtils.getAnnotation(method, ApiImplicitParams.class));
     }
+
+    @Test
+    public void getIndirectAnnotationFromClass() throws NoSuchMethodException {
+        Assert.assertNotNull(ReflectionUtils.getAnnotation(Parent.class, ApiImplicitParams.class));
+    }
+
+    @Test
+    public void getIndirectAnnotationFromInterface() throws NoSuchMethodException {
+        Assert.assertNotNull(ReflectionUtils.getAnnotation(Child.class, ApiImplicitParams.class));
+    }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/ReflectionUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ReflectionUtilsTest.java
@@ -1,5 +1,6 @@
 package io.swagger;
 
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.reflection.Child;
@@ -121,5 +122,11 @@ public class ReflectionUtilsTest {
     public void getDeclaredFieldsFromInterfaceTest() throws NoSuchMethodException {
         final Class cls = IParent.class;
         Assert.assertEquals(Collections.emptyList(), ReflectionUtils.getDeclaredFields(cls));
+    }
+
+    @Test
+    public void getIndirectAnnotation() throws NoSuchMethodException {
+        final Method method = Child.class.getMethod("indirectAnnotationMethod");
+        Assert.assertNotNull(ReflectionUtils.getAnnotation(method, ApiImplicitParams.class));
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/reflection/Child.java
+++ b/modules/swagger-core/src/test/java/io/swagger/reflection/Child.java
@@ -40,4 +40,10 @@ public class Child extends Parent<Integer> implements IParent<Long> {
     public void injectableMethod() {
 
     }
+
+    @IndirectAnnotation
+    public void indirectAnnotationMethod() {
+
+    }
+
 }

--- a/modules/swagger-core/src/test/java/io/swagger/reflection/IParent.java
+++ b/modules/swagger-core/src/test/java/io/swagger/reflection/IParent.java
@@ -3,6 +3,7 @@ package io.swagger.reflection;
 import javax.ws.rs.Path;
 
 @Path("parentInterfacePath")
+@IndirectAnnotation
 public interface IParent<T extends Number> {
 
     public String parametrizedMethod2(T arg);

--- a/modules/swagger-core/src/test/java/io/swagger/reflection/IndirectAnnotation.java
+++ b/modules/swagger-core/src/test/java/io/swagger/reflection/IndirectAnnotation.java
@@ -1,0 +1,18 @@
+package io.swagger.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+
+@ApiImplicitParams(value = {
+        @ApiImplicitParam
+})
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IndirectAnnotation {
+
+}

--- a/modules/swagger-core/src/test/java/io/swagger/reflection/Parent.java
+++ b/modules/swagger-core/src/test/java/io/swagger/reflection/Parent.java
@@ -3,6 +3,7 @@ package io.swagger.reflection;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponses;
 
+@IndirectAnnotation
 public class Parent<T extends Number> {
 
     public T parametrizedMethod1(T arg) {

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -408,7 +408,11 @@ public class Reader {
     }
 
     private void readImplicitParameters(Method method, Operation operation) {
-        ApiImplicitParams implicitParams = ReflectionUtils.getAnnotation(method, ApiImplicitParams.class);
+        processImplicitParams(ReflectionUtils.getAnnotation(method, ApiImplicitParams.class), operation);
+        processImplicitParams(ReflectionUtils.getAnnotation(method.getDeclaringClass(), ApiImplicitParams.class), operation);
+    }
+
+    private void processImplicitParams(ApiImplicitParams implicitParams, Operation operation) {
         if (implicitParams != null) {
             for (ApiImplicitParam param : implicitParams.value()) {
                 Parameter p = readImplicitParam(param);

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -157,6 +157,20 @@ public class ReaderTest {
         assertNotNull(swagger.getPath("/v1/users/{id}").getGet());
     }
 
+    @Test(description = "scan indirect implicit params from interface")
+    public void scanImplicitParamInterfaceTest() {
+        final Swagger swagger = new Reader(new Swagger()).read(IndirectImplicitParamsImpl.class);
+        assertNotNull(swagger);
+        assertEquals(swagger.getPath("/v1/users/{id}").getGet().getParameters().size(), 2);
+    }
+
+    @Test(description = "scan indirect implicit params from overridden method")
+    public void scanImplicitParamOverriddenMethodTest() {
+        final Swagger swagger = new Reader(new Swagger()).read(IndirectImplicitParamsImpl.class);
+        assertNotNull(swagger);
+        assertEquals(swagger.getPath("/v1/users").getPost().getParameters().size(), 2);
+    }
+
     @Test(description = "scan implicit params")
     public void scanImplicitParam() {
         Swagger swagger = getSwagger(ResourceWithImplicitParams.class);

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/IndirectAnnotation.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/IndirectAnnotation.java
@@ -1,4 +1,4 @@
-package io.swagger.reflection;
+package io.swagger.resources;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,7 +9,11 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 
 @ApiImplicitParams(value = {
-        @ApiImplicitParam
+        @ApiImplicitParam(
+                paramType = "header",
+                name = "myHeader",
+                dataType = "java.lang.String;"
+        )
 })
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/IndirectImplicitParams.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/IndirectImplicitParams.java
@@ -1,0 +1,45 @@
+package io.swagger.resources;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Path("/v1/users")
+@IndirectAnnotation
+public interface IndirectImplicitParams {
+
+    @ApiImplicitParams(value = {
+            @ApiImplicitParam(
+                    paramType = "query",
+                    name = "myQuery",
+                    dataType = "java.lang.String;"
+            )
+    })
+    @Target({ElementType.METHOD, ElementType.TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface IndirectImplicitQueryParam {
+
+    }
+
+    @POST
+    @IndirectImplicitQueryParam
+    void createUser();
+
+    @GET
+    @Path("/{id}")
+    String findById(@PathParam("id") String id);
+
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/IndirectImplicitParamsImpl.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/IndirectImplicitParamsImpl.java
@@ -1,0 +1,21 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Api(value = "/v1/users", tags = "annotatedInterface")
+public class IndirectImplicitParamsImpl implements IndirectImplicitParams {
+
+    @Override
+    @ApiOperation(value = "create user")
+    public void createUser() {
+
+    }
+
+    @Override
+    @ApiOperation(value = "Load by userId")
+    public String findById(String id) {
+        return "";
+    }
+
+}


### PR DESCRIPTION
This builds upon #1925, and allows for `@ApiImplicitParams` at class level, as well as meta-annotations which use `@ApiImplicitParams` at class level. For example (adapted from #1867) :

```
@Retention(value = RetentionPolicy.RUNTIME)
@ApiImplicitParams({@ApiImplicitParam(name = "x-my-custom-auth-header-that-keeps-repeating", required = true, dataType = "string", paramType = "header",defaultValue = "SOME_TEST_TOKEN_VALUE")})
public @interface MySwaggerImplicitSecurityHeader { }

@Api(value = "lots of API endpoints here...")
@MySwaggerImplicitSecurityHeader
public class LotsOfMethodsController {

  @ApiOperation(value = "Method1")
  public void ApiMethod1(){}

  @ApiOperation(value = "Method2")
  public void ApiMethod2(){}

  //...with more of these ApiMethods down the line

} 
```
