### PR TITLE
#1873 fixed output convertion for long data type.

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
@@ -12,6 +12,7 @@ import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.FileProperty;
+import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.PropertyBuilder;
 
@@ -65,8 +66,9 @@ public class ParameterProcessor {
             if (StringUtils.isNotEmpty(param.getDataType())) {
                 if("java.io.File".equalsIgnoreCase(param.getDataType())) {
                     p.setProperty(new FileProperty());
-                }
-                else {
+                } else if("long".equalsIgnoreCase(param.getDataType())) {
+                    p.setProperty(new LongProperty());
+                } else {
                     p.setType(param.getDataType());
                 }
             }

--- a/modules/swagger-core/src/test/java/io/swagger/ParameterProcessorTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ParameterProcessorTest.java
@@ -210,4 +210,25 @@ public class ParameterProcessorTest {
         assertEquals((int) param.getMinItems(), 5);
         assertEquals((int) param.getMaxItems(), 10);
     }
+
+    @ApiImplicitParams(value = {
+            @ApiImplicitParam(name = "id", dataType = "long", paramType = "path", required = true)
+    })
+    private void implicitParametrizedMethodLongType() {
+    }
+
+    @Test(description = "test for issue #1873 fixing.")
+    public void implicitParameterLongTypeProcessorTest() throws NoSuchMethodException {
+        final ApiImplicitParams params = getClass().getDeclaredMethod("implicitParametrizedMethodLongType")
+                .getAnnotation(ApiImplicitParams.class);
+        final PathParameter param0 = (PathParameter) ParameterProcessor.applyAnnotations(null, new PathParameter(),
+                String.class, Collections.<Annotation>singletonList(params.value()[0]));
+
+        assertEquals(param0.getName(), "id");
+        assertEquals(param0.getIn(), "path");
+        assertEquals(param0.getRequired(), true);
+        assertEquals(param0.getType(), "integer");
+        assertEquals(param0.getFormat(), "int64");
+
+    }
 }


### PR DESCRIPTION
According to #1873  the path parameters are ignoring the data type input, except for file data type, so in order to fix this issue the path parameter must be set with the right property according primitive data type.

note: I must say that in this change, issue is fixed only for long primitive, since at this moment i'm ignoring the input/output matching for data types.
