### PR TITLE
SpecFilter throws NPE on invalid definition reference #1929

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
@@ -171,7 +171,8 @@ public class SpecFilter {
             Set<String> nestedReferencedDefinitions =  new TreeSet<String>();
             for (String ref : referencedDefinitions){
                 Model m = swagger.getDefinitions().get(ref);
-                locateNestedReferencedDefinitions (m.getProperties(), nestedReferencedDefinitions, swagger);
+                if(m != null)
+                    locateNestedReferencedDefinitions (m.getProperties(), nestedReferencedDefinitions, swagger);
             }
             referencedDefinitions.addAll(nestedReferencedDefinitions);
             swagger.getDefinitions().keySet().retainAll(referencedDefinitions);

--- a/modules/swagger-core/src/test/java/io/swagger/filter/NoValueResolveFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/filter/NoValueResolveFilter.java
@@ -1,0 +1,14 @@
+package io.swagger.filter;
+
+import io.swagger.core.filter.AbstractSpecFilter;
+
+/**
+ * Sample filter if there is no value to resolve to.
+ **/
+public class NoValueResolveFilter extends AbstractSpecFilter {
+
+    @Override
+    public boolean isRemovingUnreferencedDefinitions() {
+        return true;
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/filter/SpecFilterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/filter/SpecFilterTest.java
@@ -275,6 +275,12 @@ public class SpecFilterTest {
         final Swagger filtered = new SpecFilter().filter(swagger, filter, null, null, null);
         assertNotNull(filtered);
     }
+    @Test(description = "it should not through NPE exception if there is no value to resolve")
+    public void shouldNotThroughNPEIfThereIsNoValueToResolve() throws IOException {
+        final Swagger swagger = getSwagger("specFiles/noValueForGetRequest.json");
+        final Swagger filtered = new SpecFilter().filter(swagger,new NoValueResolveFilter(), null, null, null);
+        assertNotNull(filtered);
+    }
 
     private Set getTagNames(Swagger swagger) {
         Set<String> result = new HashSet<String>();

--- a/modules/swagger-core/src/test/resources/specFiles/noValueForGetRequest.json
+++ b/modules/swagger-core/src/test/resources/specFiles/noValueForGetRequest.json
@@ -1,0 +1,35 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at <a href=\"http://swagger.io\">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample, you can use the api key \"special-key\" to test the authorization filters",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    }
+  },
+  "paths": {
+    "/pet": {
+      "get": {
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ResponseModel"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Foo": {
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
Getting NPE when there is no value to resolve and definitions value is null. So in order to resolve it, I have to put null check condition at SpecFilter at line 174 and allow to locateNestedReferencedDefinitions if it is not null. 

To test it I have created noValueForGetRequest.json at test/java/resources/specFiles and added a test case  shouldNotThroughNPEIfThereIsNoValueToResolve()  to test the condition at SpecFilterTest 
