### PR TITLE
Stack overflow in SpecFilter when asked to remove unused definitions …

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
@@ -183,22 +183,11 @@ public class SpecFilter {
         if (props == null) return;
         for (String keyProp: props.keySet()) {
             Property p = props.get(keyProp);
-            if (p instanceof ArrayProperty) {
-                ArrayProperty ap = (ArrayProperty) p;
-                if (ap.getItems() != null && ap.getItems() instanceof RefProperty) {
-                    RefProperty rp = (RefProperty) ap.getItems();
-                    locateReferencedDefinitions(rp, nestedReferencedDefinitions, swagger);
-                }
-            } else if (p instanceof RefProperty) {
-                RefProperty rp = (RefProperty) p;
-                locateReferencedDefinitions(rp, nestedReferencedDefinitions, swagger);
+            String ref = getPropertyRef(p);
+            if (ref != null) {
+                locateReferencedDefinitions(ref, nestedReferencedDefinitions, swagger);
             }
         }
-    }
-
-    private void locateReferencedDefinitions(RefProperty rp, Set<String> nestedReferencedDefinitions, Swagger swagger) {
-        String simpleRef = rp.getSimpleRef();
-        locateReferencedDefinitions(simpleRef, nestedReferencedDefinitions, swagger);
     }
 
     private void locateReferencedDefinitions(String ref, Set<String> nestedReferencedDefinitions, Swagger swagger) {

--- a/modules/swagger-core/src/test/java/io/swagger/filter/SpecFilterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/filter/SpecFilterTest.java
@@ -234,6 +234,26 @@ public class SpecFilterTest {
 
     }
 
+    @Test(description = "recursive models, e.g. A-> A or A-> B and B -> A should not result in stack overflow")
+    public void removeUnreferencedDefinitionsOfRecuriveModels() throws IOException {
+        final Swagger swagger = getSwagger("specFiles/recursivemodels.json");
+        final RemoveUnreferencedDefinitionsFilter remover = new RemoveUnreferencedDefinitionsFilter();
+        final Swagger filtered = new SpecFilter().filter(swagger, remover, null, null, null);
+
+        assertNotNull(filtered.getDefinitions().get("SelfReferencingModel"));
+        assertNotNull(filtered.getDefinitions().get("IndirectRecursiveModelA"));
+        assertNotNull(filtered.getDefinitions().get("IndirectRecursiveModelB"));
+    }
+
+    @Test(description = "broken references should not result in NPE")
+    public void removeUnreferencedModelOverride() throws IOException {
+        final Swagger swagger = getSwagger("specFiles/brokenrefmodel.json");
+        final RemoveUnreferencedDefinitionsFilter remover = new RemoveUnreferencedDefinitionsFilter();
+        final Swagger filtered = new SpecFilter().filter(swagger, remover, null, null, null);
+
+        assertNotNull(filtered.getDefinitions().get("RootModel"));
+    }
+
     @Test(description = "it should filter models where some fields have no properties")
     public void filterNoPropertiesModels() throws IOException {
         final String modelName = "Array";

--- a/modules/swagger-core/src/test/resources/specFiles/additionalpropsmodel.json
+++ b/modules/swagger-core/src/test/resources/specFiles/additionalpropsmodel.json
@@ -1,0 +1,50 @@
+{
+  "swagger" : "2.0",
+  "tags" : [ {
+    "name" : "Test Api"
+  } ],
+  "paths" : {
+    "/test" : {
+      "get" : {
+        "tags" : [ "Test Api" ],
+        "operationId" : "getA",
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/A"
+            },
+            "headers" : { }
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "A" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "aggregates" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "$ref" : "#/definitions/B"
+          }
+        }
+      }
+    },
+    "B" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "integer",
+          "format" : "int32"
+        }
+      }
+    }
+  }
+}

--- a/modules/swagger-core/src/test/resources/specFiles/brokenrefmodel.json
+++ b/modules/swagger-core/src/test/resources/specFiles/brokenrefmodel.json
@@ -1,0 +1,53 @@
+{
+  "swagger" : "2.0",
+  "tags" : [ {
+    "name" : "Broken References Resource"
+  } ],
+  "paths" : {
+    "/r/nested" : {
+      "get" : {
+        "tags" : [ "Broken References Resource" ],
+        "operationId" : "getNestedModel",
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/refname"
+            },
+            "headers" : { }
+          }
+        }
+      }
+    },
+    "/r/root" : {
+      "get" : {
+        "tags" : [ "Broken References Resource" ],
+        "operationId" : "getRootModel",
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/RootModel"
+            },
+            "headers" : { }
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "RootModel" : {
+      "type" : "object",
+      "properties" : {
+        "nested" : {
+          "$ref" : "#/definitions/refname"
+        }
+      }
+    },
+    "NestedModel" : {
+      "type" : "object"
+    }
+  }
+}

--- a/modules/swagger-core/src/test/resources/specFiles/recursivemodels.json
+++ b/modules/swagger-core/src/test/resources/specFiles/recursivemodels.json
@@ -1,0 +1,81 @@
+{
+  "swagger" : "2.0",
+  "tags" : [ {
+    "name" : "Recursive Model Resource"
+  } ],
+  "paths" : {
+    "/r/indirect" : {
+      "get" : {
+        "tags" : [ "Recursive Model Resource" ],
+        "operationId" : "getIndirectRecursiveModel",
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/IndirectRecursiveModelA"
+            },
+            "headers" : { }
+          }
+        }
+      }
+    },
+    "/r/self" : {
+      "get" : {
+        "tags" : [ "Recursive Model Resource" ],
+        "operationId" : "getSelfReferencingModel",
+        "parameters" : [ ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "schema" : {
+              "$ref" : "#/definitions/SelfReferencingModel"
+            },
+            "headers" : { }
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "SelfReferencingModel" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "children" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/SelfReferencingModel"
+          }
+        }
+      }
+    },
+    "IndirectRecursiveModelA" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "indirectRecursiveModelB" : {
+          "$ref" : "#/definitions/IndirectRecursiveModelB"
+        }
+      }
+    },
+    "IndirectRecursiveModelB" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "integer",
+          "format" : "int32"
+        },
+        "indirectRecursiveModelA" : {
+          "$ref" : "#/definitions/IndirectRecursiveModelA"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
…and presented with recursive models. #1945 

Additionally, an attempt is made to deal with broken references, by skipping those from processing. Previously, the presence of a broken reference would result in a NPE. Although the NPE and the stack-overflow issues are distinct, I felt a fix for the latter would be incomplete without the former.