### PR TITLE
Added conversion from type `number` to BigDecimal

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PrimitiveType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PrimitiveType.java
@@ -125,7 +125,7 @@ public enum PrimitiveType {
     /**
      * Generic decimal number without specific format.
      */
-    DECIMAL(java.math.BigDecimal.class) {
+    DECIMAL(java.math.BigDecimal.class, "number") {
         @Override
         public DecimalProperty createProperty() {
             return new DecimalProperty();

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -6,7 +6,6 @@ import io.swagger.models.Swagger;
 import io.swagger.models.Tag;
 import io.swagger.models.parameters.*;
 import io.swagger.resources.*;
-import io.swagger.util.Json;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.*;
@@ -359,7 +358,8 @@ public class ReaderTest {
         Swagger swagger = getSwagger(Resource1970.class);
         assertNotNull(swagger);
 
-        Json.prettyPrint(swagger);
+        PathParameter parameter = (PathParameter)swagger.getPath("/v1/{param1}").getGet().getParameters().get(0);
+        assertEquals(parameter.getType(), "number");
     }
 
     private Swagger getSwagger(Class<?> cls) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -6,6 +6,7 @@ import io.swagger.models.Swagger;
 import io.swagger.models.Tag;
 import io.swagger.models.parameters.*;
 import io.swagger.resources.*;
+import io.swagger.util.Json;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.*;
@@ -336,6 +337,14 @@ public class ReaderTest {
         assertNotNull(parameters);
         assertEquals(parameters.size(), 1);
         assertEquals(parameters.get(0).getName(), "petImplicitIdParam");
+    }
+
+    @Test(description = "scan resource per #1970")
+    public void scanBigDecimal() {
+        Swagger swagger = getSwagger(Resource1970.class);
+        assertNotNull(swagger);
+
+        Json.prettyPrint(swagger);
     }
 
     private Swagger getSwagger(Class<?> cls) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/Resource1970.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/Resource1970.java
@@ -1,0 +1,21 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@Path("/v1")
+@Api(value = "root")
+public class Resource1970 {
+    @GET
+    @Path("/{dbkey}")
+    @ApiOperation(value = "Retrieve a database resource")
+    @ApiImplicitParams({@ApiImplicitParam(name = "param1", dataType = "java.math.BigDecimal", paramType = "path", required = true)})
+    public void numberInput() throws Exception {
+        return;
+    }
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/Resource1970.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/Resource1970.java
@@ -12,9 +12,9 @@ import javax.ws.rs.Path;
 @Api(value = "root")
 public class Resource1970 {
     @GET
-    @Path("/{dbkey}")
+    @Path("/{param1}")
     @ApiOperation(value = "Retrieve a database resource")
-    @ApiImplicitParams({@ApiImplicitParam(name = "param1", dataType = "java.math.BigDecimal", paramType = "path", required = true)})
+    @ApiImplicitParams({@ApiImplicitParam(name = "param1", dataType = "number", paramType = "path", required = true)})
     public void numberInput() throws Exception {
         return;
     }


### PR DESCRIPTION
For issue #1970, there was no way to override the dataType for implicit parameters to `BigDecimal`, otherwise `number` in the system.

With this patch, you can use the following annotation:

```
@ApiImplicitParams({@ApiImplicitParam(name = "param1", dataType = "number", paramType = "path", required = true)})
```

And the parameter type will be correctly reported as `number`