### PR TITLE
Use varargs instead of arrays when possible

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/BaseReaderUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/BaseReaderUtils.java
@@ -23,7 +23,7 @@ public final class BaseReaderUtils {
      * @param extensions is an array of extensions
      * @return the map with extensions
      */
-    public static Map<String, Object> parseExtensions(Extension[] extensions) {
+    public static Map<String, Object> parseExtensions(Extension... extensions) {
         final Map<String, Object> map = new HashMap<String, Object>();
         for (Extension extension : extensions) {
             final String name = extension.name();

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/BeanConfig.java
@@ -73,7 +73,7 @@ public class BeanConfig extends AbstractScanner implements Scanner, SwaggerConfi
         return schemes;
     }
 
-    public void setSchemes(String[] schemes) {
+    public void setSchemes(String... schemes) {
         this.schemes = schemes;
     }
 

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/ReaderUtils.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/utils/ReaderUtils.java
@@ -109,7 +109,7 @@ public class ReaderUtils {
      * @param strings is the provided array of strings
      * @return the resulted array of strings
      */
-    public static String[] splitContentValues(String[] strings) {
+    public static String[] splitContentValues(String... strings) {
         final Set<String> result = new LinkedHashSet<String>();
 
         for (String string : strings) {


### PR DESCRIPTION
Hi,

I'd like to suggest this minor modification to use varargs instead of arrays. This change is binary compatible with the previous releases and makes the API slightly easier to use (`setSchemes("http", "https")` instead of `setSchemes(new String[] {"http", "https"})`).

Thank you
