### PR TITLE
#1983 - allow non-strings in x-examples field inside body paramers

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/deserialization/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/deserialization/JsonDeserializationTest.java
@@ -4,6 +4,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import io.swagger.models.Swagger;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.util.Json;
@@ -30,6 +32,28 @@ public class JsonDeserializationTest {
         final String json = ResourceUtils.loadClassResource(getClass(), "specFiles/compositionTest.json");
         final Object swagger = m.readValue(json, Swagger.class);
         assertTrue(swagger instanceof Swagger);
+    }
+
+    @Test(description = "it should deserialize a field x-examples if it is an object")
+    public void testObjectXExample() throws IOException {
+        final String json = "{\n" +
+                "   \"name\":\"body\",\n" +
+                "   \"in\":\"body\",\n" +
+                "   \"description\":\"body param with example\",\n" +
+                "   \"required\":true,\n" +
+                "   \"schema\": {\n" +
+                "     \"$ref\": \"#/definitions/Pet\"\n" +
+                "   },\n" +
+                "   \"x-examples\":{\n" +
+                "      \"application/json\": {\n" +
+                "        \"sampleKey\":\"samplevalue\"\n" +
+                "      }\n" +
+                "   }\n" +
+                "}";
+        final Parameter result = m.readValue(json, Parameter.class);
+        assertTrue(result instanceof BodyParameter);
+        assertEquals(1, ((BodyParameter) result).getExamples().size());
+        assertTrue(((BodyParameter) result).getVendorExtensions().get("x-examples") instanceof Map);
     }
 
     @Test(description = "it should deserialize a simple ObjectProperty")

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/BodyParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/BodyParameter.java
@@ -1,6 +1,5 @@
 package io.swagger.models.parameters;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.models.Model;
 
 import java.util.HashMap;
@@ -8,7 +7,6 @@ import java.util.Map;
 
 public class BodyParameter extends AbstractParameter implements Parameter {
     Model schema;
-    Map<String, String> examples;
 
     public BodyParameter() {
         super.setIn("body");
@@ -43,19 +41,23 @@ public class BodyParameter extends AbstractParameter implements Parameter {
     }
 
     public void addExample(String mediaType, String value) {
-        if(examples == null) {
-            examples = new HashMap<String, String>();
+        Object examples = getVendorExtensions().get("x-examples");
+        if (examples == null) {
+            examples = new HashMap<String,String>();
+            setVendorExtension("x-examples", examples);
         }
-        examples.put(mediaType, value);
+        if (!(examples instanceof Map)) {
+           throw new InternalError("Cannot call addExamples if x-examples is not an object"); 
+        }
+        ((Map)examples).put(mediaType, value);
     }
 
-    @JsonProperty("x-examples")
     public Map<String, String> getExamples() {
-        return examples;
+        return (Map<String, String>) getVendorExtensions().get("x-examples");
     }
 
     public void setExamples(Map<String, String> examples) {
-        this.examples = examples;
+        setVendorExtension("x-examples", examples);
     }
 
     @Override


### PR DESCRIPTION
Fixes #1983 and adds support for non-string values for x-examples field inside body parameters.