### PR TITLE
Add parameter 'replace' to annotation @ApiImplicitParam

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParam.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParam.java
@@ -111,6 +111,11 @@ public @interface ApiImplicitParam {
     String paramType() default "";
 
     /**
+     * The name of another parameter to replace, such as a parameter specified with JAX-RX annotation @QueryParam.
+     */
+    String replace() default "";
+
+    /**
      * a single example for non-body type parameters
      *
      * @since 1.5.4

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiParam.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiParam.java
@@ -94,6 +94,11 @@ public @interface ApiParam {
     boolean hidden() default false;
 
     /**
+     * The name of another parameter to replace, such as a parameter specified with JAX-RX annotation @QueryParam.
+     */
+    String replace() default "";
+
+    /**
      * a single example for non-body type parameters
      *
      * @since 1.5.4

--- a/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
@@ -79,6 +79,9 @@ public class ParameterProcessor {
             if (helper.isRequired() != null) {
                 p.setRequired(true);
             }
+            if (StringUtils.isNotEmpty(param.getReplace())) {
+                p.setReplace(param.getReplace());
+            }
 
             AllowableValues allowableValues = AllowableValuesUtils.create(param.getAllowableValues());
 
@@ -249,6 +252,8 @@ public class ParameterProcessor {
         T getAnnotation();
 
         boolean isHidden();
+
+        String getReplace();
 
         String getExample();
     }
@@ -440,7 +445,10 @@ public class ParameterProcessor {
             return apiParam.example();
         }
 
-        ;
+        @Override
+        public String getReplace() {
+            return apiParam.replace();
+        }
 
         public Example getExamples() {
             return apiParam.examples();
@@ -514,6 +522,9 @@ public class ParameterProcessor {
         public boolean isHidden() {
             return false;
         }
+
+        @Override
+        public String getReplace() { return apiParam.replace(); }
 
         @Override
         public String getExample() {

--- a/modules/swagger-core/src/test/java/io/swagger/ParameterProcessorTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ParameterProcessorTest.java
@@ -43,7 +43,7 @@ public class ParameterProcessorTest {
 
     @ApiImplicitParams({
             @ApiImplicitParam(name = "paramName1", value = "paramValue1", dataType = "string", paramType = "path",
-                    allowMultiple = true, allowableValues = ",,,"),
+                    allowMultiple = true, allowableValues = ",,,", replace="paramName3"),
             @ApiImplicitParam(value = "paramValue2", dataType = "string", paramType = "body", access = "test",
                     defaultValue = "10")
     })
@@ -145,6 +145,7 @@ public class ParameterProcessorTest {
         assertEquals(param0.getDescription(), "paramValue1");
         Assert.assertNull(param0.getEnum());
         Assert.assertNotNull(param0.getItems());
+        assertEquals(param0.getReplace(), "paramName3");
 
         final BodyParameter param1 = (BodyParameter) ParameterProcessor.applyAnnotations(null, new BodyParameter(),
                 String.class, Collections.<Annotation>singletonList(params.value()[1]));
@@ -153,6 +154,7 @@ public class ParameterProcessorTest {
         assertEquals(param1.getName(), "body");
         assertEquals(param1.getDescription(), "paramValue2");
         assertEquals(param1.getAccess(), "test");
+        assertEquals(param1.getReplace(), null);
 
         final ModelImpl model = (ModelImpl) param1.getSchema();
         Assert.assertNotNull(model);

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractParameter.java
@@ -14,6 +14,7 @@ public abstract class AbstractParameter {
     protected boolean required = false;
     protected String access;
     protected String pattern;
+    protected String replace;
 
     public String getIn() {
         return in;
@@ -75,6 +76,14 @@ public abstract class AbstractParameter {
         }
     }
 
+    public String getReplace() {
+        return replace;
+    }
+
+    public void setReplace(final String replace) {
+        this.replace = replace;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -88,6 +97,7 @@ public abstract class AbstractParameter {
         result = prime * result + (required ? 1231 : 1237);
         result = prime * result
                 + ((vendorExtensions == null) ? 0 : vendorExtensions.hashCode());
+        result = prime * result + ((replace == null) ? 0 : replace.hashCode());
         return result;
     }
 
@@ -146,6 +156,13 @@ public abstract class AbstractParameter {
                 return false;
             }
         } else if (!vendorExtensions.equals(other.vendorExtensions)) {
+            return false;
+        }
+        if (replace == null) {
+            if (other.replace != null) {
+                return false;
+            }
+        } else if (!replace.equals(other.replace)) {
             return false;
         }
         return true;

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
@@ -101,6 +101,11 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
         return castThis();
     }
 
+    public T replace(String replace) {
+        this.setReplace(replace);
+        return castThis();
+    }
+
     public T example(String example) {
         this.setExample(example);
         return castThis();
@@ -461,6 +466,9 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
         if (defaultValue == null) {
             if (other.defaultValue != null) return false;
         } else if (!defaultValue.equals(other.defaultValue)) return false;
+        if (replace == null) {
+            if (other.replace != null) return false;
+        } else if (!replace.equals(other.replace)) return false;
         if (example == null) {
             if (other.example != null) return false;
         } else if (!example.equals(other.example)) return false;
@@ -516,6 +524,7 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
         result = prime * result + ((_enum == null) ? 0 : _enum.hashCode());
         result = prime * result + ((collectionFormat == null) ? 0 : collectionFormat.hashCode());
         result = prime * result + ((defaultValue == null) ? 0 : defaultValue.hashCode());
+        result = prime * result + ((replace == null) ? 0 : replace.hashCode());
         result = prime * result + ((example == null) ? 0 : example.hashCode());
         result = prime * result + ((exclusiveMaximum == null) ? 0 : exclusiveMaximum.hashCode());
         result = prime * result + ((exclusiveMinimum == null) ? 0 : exclusiveMinimum.hashCode());

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/Parameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/Parameter.java
@@ -31,5 +31,9 @@ public interface Parameter {
 
     void setPattern(String pattern);
 
+    String getReplace();
+
+    void setReplace(String replace);
+
     Map<String, Object> getVendorExtensions();
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/SerializableParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/SerializableParameter.java
@@ -73,4 +73,8 @@ public interface SerializableParameter extends Parameter {
 
     void setMinItems(Integer minItems);
 
+    String getReplace();
+
+    void setReplace(String replace);
+
 }


### PR DESCRIPTION
To make it possible to completely redefine a normal query/body/path/header parameter by replacing an existing parameter (when creating swagger.json/yaml). Example:

```java
@ApiImplicitParams({
        @ApiImplicitParam(name = "query", value = "A query in the form of JSON serialized Query.class",
                required = true, dataType = "Query", paramType = "query",
                example = "{\"max_decimals\":-1,\"page\":1,\"pageSize\":20,\"version\":false,\"store\":\"query-resource-test-store1\"}",
                replace = "query"
        )
})
public List<Map<String,Object>> queryGetV2(
        @ApiParam(value = "A Query object serialized as JSON.", name = "query", required = true, hidden = false)
        @QueryParam(value = "query")
        final Query query
) { }
```

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@iki.fi>