### PR TITLE
Pretty print is handled by AbstractScanner

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/DefaultJaxrsScanner.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/config/DefaultJaxrsScanner.java
@@ -6,8 +6,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class DefaultJaxrsScanner extends AbstractScanner implements JaxrsScanner {
-    private boolean prettyPrint = false;
-
     @Override
     public Set<Class<?>> classesFromContext(Application app, ServletConfig sc) {
         Set<Class<?>> output = new HashSet<Class<?>>();
@@ -32,11 +30,6 @@ public class DefaultJaxrsScanner extends AbstractScanner implements JaxrsScanner
     }
 
     public boolean prettyPrint() {
-        return prettyPrint;
-    }
-
-    @Override
-    public void setPrettyPrint(boolean shouldPrettyPrint) {
-        this.prettyPrint = shouldPrettyPrint;
+        return getPrettyPrint();
     }
 }


### PR DESCRIPTION
Handling pretty print is not necessary in DefaultJaxrsScanner because it's handled by AbstractScanner.
This own handling causes io.swagger.jaxrs.listing.ApiListingResource to read the wrong pretty print state.
With the proposed fix it will work correct.