### PR TITLE
support @ApiImplicitParam dataTypeClass

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParam.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParam.java
@@ -104,9 +104,17 @@ public @interface ApiImplicitParam {
     String dataType() default "";
 
     /**
+     * The class of the parameter.
+     * <p>
+     * Overrides {@code dataType} if provided.
+     */
+    Class<?> dataTypeClass() default Void.class;
+
+    /**
      * The parameter type of the parameter.
      * <p>
-     * Valid values are {@code path}, {@code query}, {@code body}, {@code header} or {@code form}.
+     * Valid values are {@code path}, {@code query}, {@code body},
+     * {@code header} or {@code form}.
      */
     String paramType() default "";
 

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -472,7 +472,8 @@ public class Reader {
             LOGGER.warn("Unknown implicit parameter type: [{}]", param.paramType());
             return null;
         }
-        final Type type = ReflectionUtils.typeFromString(param.dataType());
+        final Type type = param.dataTypeClass() == Void.class ? ReflectionUtils.typeFromString(param.dataType())
+                : param.dataTypeClass();
         return ParameterProcessor.applyAnnotations(swagger, p, (type == null) ? String.class : type,
                 Arrays.<Annotation>asList(param));
     }
@@ -1002,7 +1003,7 @@ public class Reader {
         Map<String, Property> responseHeaders = parseResponseHeaders(apiResponse.responseHeaders());
 
         Response response = new Response()
-.description(apiResponse.message()).headers(responseHeaders);
+        .description(apiResponse.message()).headers(responseHeaders);
 
         if (apiResponse.code() == 0) {
             operation.defaultResponse(response);

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -28,6 +28,7 @@ import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 import io.swagger.resources.ClassWithExamplePost;
+import io.swagger.resources.ClassWithExamplePostClass;
 import io.swagger.resources.HiddenResource;
 import io.swagger.resources.Issue1979Resource;
 import io.swagger.resources.NicknamedOperation;
@@ -626,6 +627,48 @@ public class SimpleReaderTest {
     @Test(description = "scan a resource with implicit operation query example")
     public void scanClassWithImplicitExampleQuery() {
         Swagger swagger = getSwagger(ClassWithExamplePost.class);
+        Parameter param = swagger.getPaths().get("/external/info2").getGet().getParameters().get(0);
+        QueryParameter bp = (QueryParameter) param;
+        assertNotNull(bp.getExample());
+        Object value = bp.getExample();
+        assertEquals("77", value);
+    }
+
+    @Test(description = "scan a resource with operation post example (dataTypeClass)")
+    public void scanClassWithExamplePostClass() {
+        Swagger swagger = getSwagger(ClassWithExamplePostClass.class);
+        Parameter param = swagger.getPaths().get("/external/info").getPost().getParameters().get(0);
+        BodyParameter bp = (BodyParameter) param;
+        assertNotNull(bp.getExamples());
+        assertTrue(bp.getExamples().size() == 1);
+        String value = bp.getExamples().get("application/json");
+        assertEquals("[\"a\",\"b\"]", value);
+    }
+
+    @Test(description = "scan a resource with operation implicit post example (dataTypeClass)")
+    public void scanClassWithImplicitExamplePostClass() {
+        Swagger swagger = getSwagger(ClassWithExamplePostClass.class);
+        Parameter param = swagger.getPaths().get("/external/info2").getPost().getParameters().get(0);
+        BodyParameter bp = (BodyParameter) param;
+        assertNotNull(bp.getExamples());
+        assertTrue(bp.getExamples().size() == 1);
+        String value = bp.getExamples().get("application/json");
+        assertEquals("[\"a\",\"b\"]", value);
+    }
+
+    @Test(description = "scan a resource with query param example (dataTypeClass)")
+    public void scanClassWithExampleClassQuery() {
+        Swagger swagger = getSwagger(ClassWithExamplePostClass.class);
+        Parameter param = swagger.getPaths().get("/external/info").getGet().getParameters().get(0);
+        QueryParameter bp = (QueryParameter) param;
+        assertNotNull(bp.getExample());
+        Object value = bp.getExample();
+        assertEquals("a,b,c", value);
+    }
+
+    @Test(description = "scan a resource with implicit operation query example (dataTypeClass)")
+    public void scanClassWithImplicitExampleClassQuery() {
+        Swagger swagger = getSwagger(ClassWithExamplePostClass.class);
         Parameter param = swagger.getPaths().get("/external/info2").getGet().getParameters().get(0);
         QueryParameter bp = (QueryParameter) param;
         assertNotNull(bp.getExample());

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ClassWithExamplePostClass.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ClassWithExamplePostClass.java
@@ -1,0 +1,59 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.*;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import java.util.ArrayList;
+
+@Api("/external/info/")
+@Path("/")
+public class ClassWithExamplePostClass {
+    @ApiOperation(value = "test")
+    @POST
+    @Path("external/info")
+    public void postTest(@ApiParam(value = "test",
+    examples = @Example(value = {
+            @ExampleProperty(mediaType="application/json", value="[\"a\",\"b\"]")
+    })) ArrayList<String> tenantId) {
+        return;
+    }
+
+    @ApiOperation(value = "test")
+    @POST
+    @Path("external/info2")
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+                paramType = "body",
+                name = "myPody",
+                dataTypeClass = String[].class,
+                examples = @Example(value = {
+                        @ExampleProperty(mediaType="application/json", value="[\"a\",\"b\"]")}))
+    })
+    public void implicitPostTest() {
+        return;
+    }
+
+    @ApiOperation(value = "test")
+    @GET
+    @Path("external/info")
+    public void queryExample(@ApiParam(value = "test",
+    example = "a,b,c") @QueryParam("tenantId") ArrayList<String> tenantId) {
+        return;
+    }
+
+    @ApiOperation(value = "test")
+    @GET
+    @Path("external/info2")
+    @ApiImplicitParams({
+        @ApiImplicitParam(
+                paramType = "query",
+                name = "myId",
+                dataTypeClass = Long.class,
+                example = "77") })
+    public void implicitQueryExample() {
+        return;
+    }
+}


### PR DESCRIPTION
https://github.com/swagger-api/swagger-core/issues/1564

I'm sure there is a bit more needed here but it would be nice to support classes directly like in other swagger annotations. In my dev team, the most common error with swagger is to not properly fully reference the class names in @ApiImplicitParam dataType.
