### PR TITLE
Fixes 1107 - allow non-strings in x-examples field inside body parameters

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/deserialization/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/deserialization/JsonDeserializationTest.java
@@ -4,6 +4,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import io.swagger.models.Swagger;
+import io.swagger.models.parameters.BodyParameter;
+import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.util.Json;
@@ -30,6 +32,50 @@ public class JsonDeserializationTest {
         final String json = ResourceUtils.loadClassResource(getClass(), "specFiles/compositionTest.json");
         final Object swagger = m.readValue(json, Swagger.class);
         assertTrue(swagger instanceof Swagger);
+    }
+
+    @Test(description = "it should deserialize a field x-examples if it is an object")
+    public void testObjectXExample() throws IOException {
+        final String json = "{\n" +
+                "   \"name\":\"body\",\n" +
+                "   \"in\":\"body\",\n" +
+                "   \"description\":\"body param with example\",\n" +
+                "   \"required\":true,\n" +
+                "   \"schema\": {\n" +
+                "     \"$ref\": \"#/definitions/Pet\"\n" +
+                "   },\n" +
+                "   \"x-examples\":{\n" +
+                "      \"application/json\": {\n" +
+                "        \"sampleKey\":\"samplevalue\"\n" +
+                "      }\n" +
+                "   }\n" +
+                "}";
+        final Parameter result = m.readValue(json, Parameter.class);
+        assertTrue(result instanceof BodyParameter);
+        assertEquals(1, ((BodyParameter) result).getExamples().size());
+        assertTrue(((BodyParameter) result).getExamples().get("application/json") instanceof Map);
+    }
+
+    @Test(description = "it should deserialize a field x-examples if it is a string")
+    public void tesStringXExample() throws IOException {
+        final String json = "{\n" +
+                "   \"name\":\"body\",\n" +
+                "   \"in\":\"body\",\n" +
+                "   \"description\":\"body param with example\",\n" +
+                "   \"required\":true,\n" +
+                "   \"schema\": {\n" +
+                "     \"$ref\": \"#/definitions/Pet\"\n" +
+                "   },\n" +
+                "   \"x-examples\":{\n" +
+                "      \"application/json\": \"{" +
+                "        \\\"sampleKey\\\":\\\"samplevalue\\\"" +
+                "      }\"\n" +
+                "   }\n" +
+                "}";
+        final Parameter result = m.readValue(json, Parameter.class);
+        assertTrue(result instanceof BodyParameter);
+        assertEquals(1, ((BodyParameter) result).getExamples().size());
+        assertTrue(((BodyParameter) result).getExamples().get("application/json") instanceof String);
     }
 
     @Test(description = "it should deserialize a simple ObjectProperty")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -598,7 +598,7 @@ public class SimpleReaderTest {
         BodyParameter bp = (BodyParameter) param;
         assertNotNull(bp.getExamples());
         assertTrue(bp.getExamples().size() == 1);
-        String value = bp.getExamples().get("application/json");
+        String value = (String) bp.getExamples().get("application/json");
         assertEquals("[\"a\",\"b\"]", value);
     }
 
@@ -609,7 +609,7 @@ public class SimpleReaderTest {
         BodyParameter bp = (BodyParameter) param;
         assertNotNull(bp.getExamples());
         assertTrue(bp.getExamples().size() == 1);
-        String value = bp.getExamples().get("application/json");
+        String value = (String) bp.getExamples().get("application/json");
         assertEquals("[\"a\",\"b\"]", value);
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/BodyParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/BodyParameter.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class BodyParameter extends AbstractParameter implements Parameter {
     Model schema;
-    Map<String, String> examples;
+    Map<String, Object> examples;
 
     public BodyParameter() {
         super.setIn("body");
@@ -44,17 +44,17 @@ public class BodyParameter extends AbstractParameter implements Parameter {
 
     public void addExample(String mediaType, String value) {
         if(examples == null) {
-            examples = new LinkedHashMap<String, String>();
+            examples = new LinkedHashMap<String, Object>();
         }
         examples.put(mediaType, value);
     }
 
     @JsonProperty("x-examples")
-    public Map<String, String> getExamples() {
+    public Map<String, Object> getExamples() {
         return examples;
     }
 
-    public void setExamples(Map<String, String> examples) {
+    public void setExamples(Map<String, Object> examples) {
         this.examples = examples;
     }
 


### PR DESCRIPTION
Fixes 1107, originally a fix for 1983.  This simply makes x-examples Map<String,Object> instead of Map<String, String>.  Unfortunately this does break API compatibility in BodyParam.   The original pull request for 1983, preserved API compatibility of BodyParam (i.e. examples remained Map<String,String>) however that approach was rejected.  Let me know if these API changes are OK, unclear of the potential downstream impact.