### PR TITLE
Update jackson from 2.8.4 to 2.8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -491,7 +491,7 @@
         <servlet-api-version>2.5</servlet-api-version>
         <jersey-version>1.13</jersey-version>
         <jersey2-version>2.1</jersey2-version>
-        <jackson-version>2.8.4</jackson-version>
+        <jackson-version>2.8.5</jackson-version>
         <logback-version>1.0.1</logback-version>
         <reflections-version>0.9.10</reflections-version>
         <guava-version>18.0</guava-version>


### PR DESCRIPTION
Just a bugfix release. Changelog found [here](https://github.com/FasterXML/jackson-databind/blob/master/release-notes/VERSION#L69-L84).