### PR TITLE
Extracting generic return type's actual runtime type

### DIFF
--- a/modules/swagger-jaxrs/pom.xml
+++ b/modules/swagger-jaxrs/pom.xml
@@ -32,8 +32,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/swagger-jaxrs/pom.xml
+++ b/modules/swagger-jaxrs/pom.xml
@@ -111,6 +111,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml</groupId>
+            <artifactId>classmate</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${jackson-version}</version>

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -310,7 +310,7 @@ public class SimpleReaderTest {
         DefaultReaderConfig config = new DefaultReaderConfig();
         config.setScanAllResources(true);
         Swagger swagger = new Reader(new Swagger(), config).read(SimpleResourceInheritanceSubWithoutAnnotations.class);
-        assertEquals(swagger.getPaths().size(), 2);
+        assertEquals(swagger.getPaths().size(), 3);
 
         Operation get = getGet(swagger, "/{id}");
         assertNotNull(get);
@@ -331,6 +331,12 @@ public class SimpleReaderTest {
 
         assertEquals(get.getResponses().size(), 1);
         assertEquals(get.getResponses().get("200").getSchema().getType(), "ref");
+
+        Operation getArray = getGet(swagger, "/");
+        assertNotNull(getArray);
+
+        assertEquals(getArray.getResponses().size(), 1);
+        assertEquals(getArray.getResponses().get("200").getSchema().getType(), "array");
     }
 
     @Test(description = "scan a simple resource inheritance without annotations")
@@ -338,7 +344,7 @@ public class SimpleReaderTest {
         DefaultReaderConfig config = new DefaultReaderConfig();
         config.setScanAllResources(true);
         Swagger swagger = new Reader(new Swagger(), config).read(SimpleResourceInheritanceSubSubWithoutAnnotations.class);
-        assertEquals(swagger.getPaths().size(), 2);
+        assertEquals(swagger.getPaths().size(), 3);
 
         Operation get = getGet(swagger, "/{id}");
         assertNotNull(get);
@@ -359,6 +365,12 @@ public class SimpleReaderTest {
 
         assertEquals(get.getResponses().size(), 1);
         assertEquals(get.getResponses().get("200").getSchema().getType(), "ref");
+
+        Operation getArray = getGet(swagger, "/");
+        assertNotNull(getArray);
+
+        assertEquals(getArray.getResponses().size(), 1);
+        assertEquals(getArray.getResponses().get("200").getSchema().getType(), "array");
     }
 
     @Test(description = "scan a simple self-referencing subresource")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -6,55 +6,10 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.jaxrs.Reader;
 import io.swagger.jaxrs.config.DefaultReaderConfig;
-import io.swagger.models.ArrayModel;
-import io.swagger.models.Model;
-import io.swagger.models.ModelImpl;
-import io.swagger.models.Operation;
-import io.swagger.models.Path;
-import io.swagger.models.RefModel;
-import io.swagger.models.Response;
-import io.swagger.models.Swagger;
-import io.swagger.models.Tag;
-import io.swagger.models.TestEnum;
-import io.swagger.models.parameters.BodyParameter;
-import io.swagger.models.parameters.Parameter;
-import io.swagger.models.parameters.PathParameter;
-import io.swagger.models.parameters.QueryParameter;
-import io.swagger.models.parameters.SerializableParameter;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.IntegerProperty;
-import io.swagger.models.properties.MapProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
-import io.swagger.resources.ClassWithExamplePost;
-import io.swagger.resources.HiddenResource;
-import io.swagger.resources.NicknamedOperation;
-import io.swagger.resources.NotValidRootResource;
-import io.swagger.resources.Resource1041;
-import io.swagger.resources.Resource1073;
-import io.swagger.resources.Resource1085;
-import io.swagger.resources.Resource653;
-import io.swagger.resources.Resource841;
-import io.swagger.resources.Resource877;
-import io.swagger.resources.Resource937;
-import io.swagger.resources.ResourceWithApiOperationCode;
-import io.swagger.resources.ResourceWithApiResponseResponseContainer;
-import io.swagger.resources.ResourceWithBodyParams;
-import io.swagger.resources.ResourceWithCustomHTTPMethodAnnotations;
-import io.swagger.resources.ResourceWithEmptyModel;
-import io.swagger.resources.ResourceWithEnums;
-import io.swagger.resources.ResourceWithInnerClass;
-import io.swagger.resources.ResourceWithMapReturnValue;
-import io.swagger.resources.ResourceWithRanges;
-import io.swagger.resources.ResourceWithResponse;
-import io.swagger.resources.ResourceWithResponseHeaders;
-import io.swagger.resources.ResourceWithTypedResponses;
-import io.swagger.resources.ResourceWithVoidReturns;
-import io.swagger.resources.SimpleResource;
-import io.swagger.resources.SimpleResourceWithoutAnnotations;
-import io.swagger.resources.SimpleSelfReferencingSubResource;
-import io.swagger.resources.TaggedResource;
+import io.swagger.models.*;
+import io.swagger.models.parameters.*;
+import io.swagger.models.properties.*;
+import io.swagger.resources.*;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -348,6 +303,62 @@ public class SimpleReaderTest {
         assertEquals(param2.getName(), "limit");
         assertFalse(param2.getRequired());
         assertNull(param2.getDescription());
+    }
+
+    @Test(description = "scan a simple resource inheritance without annotations")
+    public void scanSimpleResourceInheritanceWithoutAnnotations() {
+        DefaultReaderConfig config = new DefaultReaderConfig();
+        config.setScanAllResources(true);
+        Swagger swagger = new Reader(new Swagger(), config).read(SimpleResourceInheritanceSubWithoutAnnotations.class);
+        assertEquals(swagger.getPaths().size(), 2);
+
+        Operation get = getGet(swagger, "/{id}");
+        assertNotNull(get);
+        assertEquals(get.getParameters().size(), 2);
+
+        PathParameter param1 = (PathParameter) get.getParameters().get(0);
+        assertEquals(param1.getIn(), "path");
+        assertEquals(param1.getName(), "id");
+        assertTrue(param1.getRequired());
+        assertNull(param1.getDescription());
+        assertEquals(param1.getDefaultValue(), "5");
+
+        Parameter param2 = get.getParameters().get(1);
+        assertEquals(param2.getIn(), "query");
+        assertEquals(param2.getName(), "limit");
+        assertFalse(param2.getRequired());
+        assertNull(param2.getDescription());
+
+        assertEquals(get.getResponses().size(), 1);
+        assertEquals(get.getResponses().get("200").getSchema().getType(), "ref");
+    }
+
+    @Test(description = "scan a simple resource inheritance without annotations")
+    public void scanSimpleResourceDeeperInheritanceWithoutAnnotations() {
+        DefaultReaderConfig config = new DefaultReaderConfig();
+        config.setScanAllResources(true);
+        Swagger swagger = new Reader(new Swagger(), config).read(SimpleResourceInheritanceSubSubWithoutAnnotations.class);
+        assertEquals(swagger.getPaths().size(), 2);
+
+        Operation get = getGet(swagger, "/{id}");
+        assertNotNull(get);
+        assertEquals(get.getParameters().size(), 2);
+
+        PathParameter param1 = (PathParameter) get.getParameters().get(0);
+        assertEquals(param1.getIn(), "path");
+        assertEquals(param1.getName(), "id");
+        assertTrue(param1.getRequired());
+        assertNull(param1.getDescription());
+        assertEquals(param1.getDefaultValue(), "5");
+
+        Parameter param2 = get.getParameters().get(1);
+        assertEquals(param2.getIn(), "query");
+        assertEquals(param2.getName(), "limit");
+        assertFalse(param2.getRequired());
+        assertNull(param2.getDescription());
+
+        assertEquals(get.getResponses().size(), 1);
+        assertEquals(get.getResponses().get("200").getSchema().getType(), "ref");
     }
 
     @Test(description = "scan a simple self-referencing subresource")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceInheritanceBaseWithoutAnnotations.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceInheritanceBaseWithoutAnnotations.java
@@ -18,4 +18,15 @@ public abstract class SimpleResourceInheritanceBaseWithoutAnnotations<R> {
         return (R)out;
     }
 
+    @GET
+    public R[] getArrayTest(
+            @QueryParam("limit") Integer limit
+    ) throws WebApplicationException {
+        Sample out = new Sample();
+        out.setName("foo");
+        out.setValue("bar");
+        R[] ret = (R[]) new Sample[] {out};
+        return ret;
+    }
+
 }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceInheritanceBaseWithoutAnnotations.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceInheritanceBaseWithoutAnnotations.java
@@ -1,0 +1,21 @@
+package io.swagger.resources;
+
+import io.swagger.models.Sample;
+
+import javax.ws.rs.*;
+
+public abstract class SimpleResourceInheritanceBaseWithoutAnnotations<R> {
+    @GET
+    @Path("/{id}")
+    public R getTest(
+            @DefaultValue("5")
+            @PathParam("id") String id,
+            @QueryParam("limit") Integer limit
+    ) throws WebApplicationException {
+        Sample out = new Sample();
+        out.setName("foo");
+        out.setValue("bar");
+        return (R)out;
+    }
+
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceInheritanceSubSubWithoutAnnotations.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceInheritanceSubSubWithoutAnnotations.java
@@ -1,0 +1,13 @@
+package io.swagger.resources;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Produces({"application/xml"})
+@Path("/")
+public class SimpleResourceInheritanceSubSubWithoutAnnotations extends SimpleResourceInheritanceSubWithoutAnnotations {
+
+
+
+
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceInheritanceSubWithoutAnnotations.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/SimpleResourceInheritanceSubWithoutAnnotations.java
@@ -1,0 +1,29 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.ApiParam;
+import io.swagger.models.Sample;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+@Produces({"application/xml"})
+@Path("/")
+public class SimpleResourceInheritanceSubWithoutAnnotations extends SimpleResourceInheritanceBaseWithoutAnnotations<Sample> {
+
+    @GET
+    @Path("/{id}/value")
+    @Produces({"text/plain"})
+    public Response getStringValue() throws WebApplicationException {
+        return Response.ok().entity("ok").build();
+    }
+
+    @PUT
+    @Path("/{id}")
+    public Response updateTest(
+            @ApiParam(value = "sample param data", required = true) Sample sample,
+            @HeaderParam(value = "Authorization") String authorization,
+            @QueryParam(value = "dateUpdated") java.util.Date dateUpdated,
+            @CookieParam(value = "X-your-cookie") String cookieId) {
+        return Response.ok().build();
+    }
+}

--- a/modules/swagger-jersey-jaxrs/pom.xml
+++ b/modules/swagger-jersey-jaxrs/pom.xml
@@ -34,8 +34,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/swagger-jersey2-jaxrs/pom.xml
+++ b/modules/swagger-jersey2-jaxrs/pom.xml
@@ -38,8 +38,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,13 @@
     </reporting>
     <dependencyManagement>
         <dependencies>
+            <!-- https://mvnrepository.com/artifact/com.fasterxml/classmate -->
+            <dependency>
+                <groupId>com.fasterxml</groupId>
+                <artifactId>classmate</artifactId>
+                <version>1.3.3</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-tools-api</artifactId>
@@ -513,6 +520,6 @@
         <enforcer-plugin-version>1.4</enforcer-plugin-version>
         <failsafe-plugin-version>2.19.1</failsafe-plugin-version>
 
-        <java.version>1.8</java.version>
+        <java.version>1.6</java.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -151,8 +151,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -512,5 +512,7 @@
         <commons-io-version>2.4</commons-io-version>
         <enforcer-plugin-version>1.4</enforcer-plugin-version>
         <failsafe-plugin-version>2.19.1</failsafe-plugin-version>
+
+        <java.version>1.8</java.version>
     </properties>
 </project>


### PR DESCRIPTION
With this change, extracting the actual return type of the generic super class's methods generic return type became possible.
The java version is 1.6.