### PR TITLE
Do not serialize null values in path

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/Path.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Path.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 @JsonPropertyOrder({"get", "head", "post", "put", "delete", "options", "patch"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Path {
 
     private Map<String, Object> vendorExtensions = new LinkedHashMap<String, Object>();


### PR DESCRIPTION
Hi everyone,

when trying to set up swagger with dropwizard, I stumbled over [this line](https://github.com/swagger-api/swagger-samples/blob/master/java/java-dropwizard/src/main/java/io/swagger/sample/SwaggerSampleApplication.java#L31). I do understand that it is required by the [spec](https://github.com/swagger-api/swagger-js/issues/268) to not serialize null values to the swagger.json file. I do however not really want to globally disable null serialization for my whole application.

I therefore feel that this should directly be annotated at the `io.swagger.models.Path` class instead of requiring users to change their whole application's config. Please tell me if there is more classes  where this change might make sense, I am happy to change them as well.

I ran all tests locally and they passed.

Regards,

Tobi