### PR TITLE
use custom object mapper to serialize json in order to avoid null values

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/AcceptHeaderApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/AcceptHeaderApiListingResource.java
@@ -1,5 +1,6 @@
 package io.swagger.jaxrs.listing;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.annotations.ApiOperation;
 
 import javax.servlet.ServletConfig;
@@ -25,7 +26,7 @@ public class AcceptHeaderApiListingResource extends BaseApiListingResource {
             @Context Application app,
             @Context ServletConfig sc,
             @Context HttpHeaders headers,
-            @Context UriInfo uriInfo) {
+            @Context UriInfo uriInfo) throws JsonProcessingException {
         return getListingJsonResponse(app, context, sc, headers, uriInfo);
     }
 

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
@@ -1,5 +1,6 @@
 package io.swagger.jaxrs.listing;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.annotations.ApiOperation;
 import org.apache.commons.lang3.StringUtils;
 
@@ -25,7 +26,7 @@ public class ApiListingResource extends BaseApiListingResource {
             @Context ServletConfig sc,
             @Context HttpHeaders headers,
             @Context UriInfo uriInfo,
-            @PathParam("type") String type) {
+            @PathParam("type") String type) throws JsonProcessingException {
         if (StringUtils.isNotBlank(type) && type.trim().equalsIgnoreCase("yaml")) {
             return getListingYamlResponse(app, context, sc, headers, uriInfo);
         } else {

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/BaseApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/BaseApiListingResource.java
@@ -1,5 +1,6 @@
 package io.swagger.jaxrs.listing;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.config.FilterFactory;
 import io.swagger.config.Scanner;
 import io.swagger.config.SwaggerConfig;
@@ -10,6 +11,7 @@ import io.swagger.jaxrs.config.JaxrsScanner;
 import io.swagger.jaxrs.config.ReaderConfigUtils;
 import io.swagger.jaxrs.config.SwaggerContextService;
 import io.swagger.models.Swagger;
+import io.swagger.util.Json;
 import io.swagger.util.Yaml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,11 +163,11 @@ public abstract class BaseApiListingResource {
             ServletContext servletContext,
             ServletConfig servletConfig,
             HttpHeaders headers,
-            UriInfo uriInfo) {
+            UriInfo uriInfo) throws JsonProcessingException {
         Swagger swagger = process(app, servletContext, servletConfig, headers, uriInfo);
 
         if (swagger != null) {
-            return Response.ok().entity(swagger).build();
+            return Response.ok().entity(Json.mapper().writeValueAsString(swagger)).type(MediaType.APPLICATION_JSON_TYPE).build();
         } else {
             return Response.status(404).build();
         }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ApiListingResourceTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ApiListingResourceTest.java
@@ -1,5 +1,6 @@
 package io.swagger;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.jaxrs.Reader;
 import io.swagger.jaxrs.listing.ApiListingResource;
 import io.swagger.models.Swagger;
@@ -24,7 +25,7 @@ public class ApiListingResourceTest {
     }
 
     @Test
-    public void shouldHandleNullServletConfig_issue1689() {
+    public void shouldHandleNullServletConfig_issue1689() throws JsonProcessingException {
         ApiListingResource a = new ApiListingResource();
         try {
             a.getListing(null, null, null, null, "json");
@@ -38,7 +39,7 @@ public class ApiListingResourceTest {
 
     }
     @Test
-    public void shouldHandleErrorServletConfig_issue1691() {
+    public void shouldHandleErrorServletConfig_issue1691() throws JsonProcessingException {
 
         ServletConfig sc = new ServletConfig() {
             @Override


### PR DESCRIPTION
As discussed in #2105 

I decided to let the `JsonProcessingException` just go all the way up, as this is closest to what would happen if a JsonProcessingException was thrown when Jackson tries to serialize the object.