### PR TITLE
Now Using operationPath to override the nature of actual path

### DIFF
--- a/modules/swagger-servlet/src/main/java/io/swagger/servlet/extensions/ServletReaderExtension.java
+++ b/modules/swagger-servlet/src/main/java/io/swagger/servlet/extensions/ServletReaderExtension.java
@@ -222,7 +222,7 @@ public class ServletReaderExtension implements ReaderExtension {
         final String operationPath = apiOperation == null ? null : apiOperation.nickname();
         return PathUtils.collectPath(context.getParentPath(),
                 apiAnnotation == null ? null : apiAnnotation.value(),
-                method.getName());
+                StringUtils.isBlank(operationPath) ? method.getName() : operationPath);
     }
 
     @Override

--- a/modules/swagger-servlet/src/test/java/io/swagger/servlet/ReaderTest.java
+++ b/modules/swagger-servlet/src/test/java/io/swagger/servlet/ReaderTest.java
@@ -43,12 +43,12 @@ public class ReaderTest {
 
         Assert.assertEquals(swagger.getHost(), "host");
         Assert.assertEquals(swagger.getBasePath(), "/api");
-        Assert.assertNotNull(swagger.getPath("/resources/testMethod3"));
+        Assert.assertNotNull(swagger.getPath("/resources/users"));
         Assert.assertNotNull(swagger.getDefinitions().get("SampleData"));
         Assert.assertEquals(swagger.getExternalDocs().getDescription(), "docs");
         Assert.assertEquals(swagger.getExternalDocs().getUrl(), "url_to_docs");
 
-        Path path = swagger.getPath("/resources/testMethod3");
+        Path path = swagger.getPath("/resources/users");
         Assert.assertNotNull(path);
         Operation get = path.getGet();
         Assert.assertNotNull( get );

--- a/modules/swagger-servlet/src/test/java/io/swagger/servlet/extensions/PathGetterTest.java
+++ b/modules/swagger-servlet/src/test/java/io/swagger/servlet/extensions/PathGetterTest.java
@@ -13,7 +13,7 @@ public class PathGetterTest extends BaseServletReaderExtensionTest {
         return new Object[][]{
                 {"testMethod1", "/tests/resources/testMethod1"},
                 {"testMethod2", "/tests/resources/testMethod2"},
-                {"testMethod3", "/tests/resources/testMethod3"},
+                {"testMethod3", "/tests/resources/users"},
                 {"testMethod4", "/tests/resources/testMethod4"},
         };
     }
@@ -23,7 +23,7 @@ public class PathGetterTest extends BaseServletReaderExtensionTest {
         return new Object[][]{
                 {"testMethod1", "/tests/testMethod1"},
                 {"testMethod2", "/tests/testMethod2"},
-                {"testMethod3", "/tests/testMethod3"},
+                {"testMethod3", "/tests/users"},
                 {"testMethod4", "/tests/testMethod4"},
         };
     }


### PR DESCRIPTION
problem : Earlier method name was postfixed in the api path, if Nick name is being provided then the nickname should have higher priority over method name
Proposed Fix : added StringBlank check on field operationPath and setting operationPath in the api path if operationPath is not blank, by doing so i am setting the priority of nick name over method name.