### PR TITLE
#2141 add support for min- and maxLength for base64 encoded strings

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/JsonDeserializationTest.java
@@ -3,7 +3,7 @@ package io.swagger.util;
 import io.swagger.TestUtils;
 import io.swagger.models.*;
 import io.swagger.models.properties.ArrayProperty;
-
+import io.swagger.models.properties.ByteArrayProperty;
 import io.swagger.models.properties.MapProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
@@ -101,6 +101,19 @@ public class JsonDeserializationTest {
         assertEquals(property.getMinLength(), Integer.valueOf(10));
         assertEquals(property.getMaxLength(), Integer.valueOf(100));
         assertEquals(property.getPattern(), "apattern");
+    }
+
+    @Test(description = "should deserialize a base64 encoded string property with constraints")
+    public void testDeserializeConstrainedBase64StringProperty() throws Exception {
+
+        Swagger swagger = TestUtils.deserializeJsonFileFromClasspath("specFiles/propertiesWithConstraints.json", Swagger.class);
+
+        ByteArrayProperty property = (ByteArrayProperty) swagger.getDefinitions().get("Health").getProperties().get("string_base64_encoded");
+
+        assertEquals(property.getMinLength(), Integer.valueOf(5));
+        assertEquals(property.getMaxLength(), Integer.valueOf(50));
+        assertEquals(property.getPattern(), "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$");
+        assertNull(property.getEnum());
     }
 
     @Test (description = "should deserialize an array property with constraints")

--- a/modules/swagger-core/src/test/resources/specFiles/propertiesWithConstraints.json
+++ b/modules/swagger-core/src/test/resources/specFiles/propertiesWithConstraints.json
@@ -52,6 +52,17 @@
                   "minLength": 10,
                   "maxLength": 100,
                   "pattern": "apattern"
+                },
+                "string_base64_encoded": {
+                    "type": "string",
+                    "format": "byte",
+                    "minLength": 5,
+                    "maxLength": 50,
+                    "pattern": "ignored_pattern",
+                    "enum": [
+                        "IGNORED",
+                        "ENUM"
+                    ]
                 }
             }
         }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/ByteArrayProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/ByteArrayProperty.java
@@ -2,7 +2,7 @@ package io.swagger.models.properties;
 
 import io.swagger.models.Xml;
 
-public class ByteArrayProperty extends AbstractProperty implements Property {
+public class ByteArrayProperty extends StringProperty implements Property {
 
 
     public ByteArrayProperty() {

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -158,6 +158,30 @@ public class PropertyBuilder {
             protected ByteArrayProperty create() {
                 return new ByteArrayProperty();
             }
+
+            @Override
+            public Property merge(final Property property, final Map<PropertyId, Object> args) {
+                super.merge(property, args);
+                if (property instanceof ByteArrayProperty) {
+                    final ByteArrayProperty resolved = (ByteArrayProperty) property;
+                    mergeString(resolved, args);
+                    // the string properties for pattern and enum will be ignored, they doesn't make sense for
+                    // base64 encoded strings - instead an appropriate base64 pattern is set
+                    resolved.setEnum(null);
+                    resolved.setPattern("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$");
+                }
+
+                return property;
+            }
+
+            @Override
+            public Model toModel(final Property property) {
+                if (isType(property)) {
+                    return createStringModel((StringProperty) property);
+                }
+
+                return null;
+            }
         },
         BINARY(BinaryProperty.class) {
             @Override


### PR DESCRIPTION
A base64 encoded string (type: "string", format: "byte") is correctly identified as byte array but lacks support for min- and max length. This pull request adds this support.

Additionally the base64 string should follow a regex pattern that roughly ensures a real base64 encoded string. "ABC" is not a base64 encoded string and therefore should fail the schema validation.