### PR TITLE
Bump versions

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/Json.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/Json.java
@@ -14,7 +14,7 @@ public class Json {
         }
         return mapper;
     }
-    public static ObjectWriter pretty() {
+    private static ObjectWriter pretty() {
         return mapper().writer(new DefaultPrettyPrinter());
     }
 
@@ -50,7 +50,7 @@ public class Json {
     private static ObjectMapper responseMapper;
 
 
-    protected static ObjectMapper pathMapper() {
+    static ObjectMapper pathMapper() {
         if (pathMapper == null) {
             pathMapper = ObjectMapperFactory.createJson(false, true);
         }
@@ -58,7 +58,7 @@ public class Json {
         return pathMapper;
     }
 
-    protected static ObjectMapper responseMapper() {
+    static ObjectMapper responseMapper() {
         if (responseMapper == null) {
             responseMapper = ObjectMapperFactory.createJson(false, false);
         }

--- a/modules/swagger-core/src/main/java/io/swagger/util/Json.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/Json.java
@@ -14,7 +14,7 @@ public class Json {
         }
         return mapper;
     }
-    private static ObjectWriter pretty() {
+    public static ObjectWriter pretty() {
         return mapper().writer(new DefaultPrettyPrinter());
     }
 
@@ -50,7 +50,7 @@ public class Json {
     private static ObjectMapper responseMapper;
 
 
-    static ObjectMapper pathMapper() {
+    protected static ObjectMapper pathMapper() {
         if (pathMapper == null) {
             pathMapper = ObjectMapperFactory.createJson(false, true);
         }
@@ -58,7 +58,7 @@ public class Json {
         return pathMapper;
     }
 
-    static ObjectMapper responseMapper() {
+    protected static ObjectMapper responseMapper() {
         if (responseMapper == null) {
             responseMapper = ObjectMapperFactory.createJson(false, false);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                egroupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>2.1</version>
             </plugin>
@@ -493,7 +493,7 @@
         <jersey2-version>2.1</jersey2-version>
         <jackson-version>2.8.5</jackson-version>
         <logback-version>1.0.1</logback-version>
-        <reflections-version>0.9.10</reflections-version>
+        <reflections-version>0.9.11</reflections-version>
         <guava-version>20.0</guava-version>
 
         <testng-version>6.10</testng-version>

--- a/pom.xml
+++ b/pom.xml
@@ -484,14 +484,14 @@
         </dependencies>
     </dependencyManagement>
     <properties>
-        <joda-version>1.2</joda-version>
-        <joda-time-version>2.7</joda-time-version>
+        <joda-version>1.8.1</joda-version>
+        <joda-time-version>2.9.1</joda-time-version>
 
         <felix-version>2.3.7</felix-version>
         <servlet-api-version>2.5</servlet-api-version>
         <jersey-version>1.13</jersey-version>
         <jersey2-version>2.25.1</jersey2-version>
-        <jackson-version>2.8.5</jackson-version>
+        <jackson-version>2.8.7</jackson-version>
         <logback-version>1.0.1</logback-version>
         <reflections-version>0.9.11</reflections-version>
         <guava-version>20.0</guava-version>

--- a/pom.xml
+++ b/pom.xml
@@ -490,7 +490,7 @@
         <felix-version>2.3.7</felix-version>
         <servlet-api-version>2.5</servlet-api-version>
         <jersey-version>1.13</jersey-version>
-        <jersey2-version>2.1</jersey2-version>
+        <jersey2-version>2.25.1</jersey2-version>
         <jackson-version>2.8.5</jackson-version>
         <logback-version>1.0.1</logback-version>
         <reflections-version>0.9.11</reflections-version>

--- a/pom.xml
+++ b/pom.xml
@@ -481,6 +481,12 @@
                 <artifactId>guava</artifactId>
                 <version>${guava-version}</version>
             </dependency>
+            <dependency>
+                <!-- resolve reflections 0.9.11 vs jersey-common 2.2.25 conflict -->
+                <groupId>org.javassist</groupId>
+                <artifactId>javassist</artifactId>
+                <version>${javassist-version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <properties>
@@ -495,6 +501,7 @@
         <logback-version>1.0.1</logback-version>
         <reflections-version>0.9.11</reflections-version>
         <guava-version>20.0</guava-version>
+        <javassist-version>3.21.0-GA</javassist-version>
 
         <testng-version>6.10</testng-version>
         <mockito-version>1.9.5</mockito-version>

--- a/pom.xml
+++ b/pom.xml
@@ -482,7 +482,7 @@
                 <version>${guava-version}</version>
             </dependency>
             <dependency>
-                <!-- resolve reflections 0.9.11 vs jersey-common 2.2.25 conflict -->
+                <!-- resolve reflections 0.9.11 vs jersey-common 2.25.1 conflict -->
                 <groupId>org.javassist</groupId>
                 <artifactId>javassist</artifactId>
                 <version>${javassist-version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                egroupId>org.apache.maven.plugins</groupId>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>2.1</version>
             </plugin>


### PR DESCRIPTION
Where I work we're strict about maven version conflicts. Would there be any problem with bumping some of the swagger dependencies.

Full disclosure: These versions have been chosen to line up with dropwizard 1.1.0. The reflections one is the main one to update as the current version pulls in a defunct google annotations jar, the others are just nice-to-have.