### PR TITLE
Modify Reader.java to support APIs with superclasses as the body

### DIFF
--- a/modules/swagger-jaxrs/src/test/java/io/swagger/GenericsTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/GenericsTest.java
@@ -4,22 +4,13 @@ import com.google.common.base.Functions;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Sets;
 import io.swagger.jaxrs.Reader;
-import io.swagger.models.ArrayModel;
-import io.swagger.models.Model;
-import io.swagger.models.Operation;
-import io.swagger.models.RefModel;
-import io.swagger.models.Swagger;
-import io.swagger.models.TestEnum;
+import io.swagger.models.*;
 import io.swagger.models.parameters.BodyParameter;
 import io.swagger.models.parameters.QueryParameter;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
-import io.swagger.models.properties.UUIDProperty;
+import io.swagger.models.properties.*;
 import io.swagger.resources.ResourceWithGenerics;
 import io.swagger.resources.generics.UserApiRoute;
-
+import io.swagger.resources.generics.UserApiRouteImpl;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -27,10 +18,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class GenericsTest {
     private final Swagger swagger = new Reader(new Swagger()).read(ResourceWithGenerics.class);
@@ -227,5 +215,13 @@ public class GenericsTest {
         assertEquals(properties.size(), 2);
         assertNotNull(properties.get("id"));
         assertNotNull(properties.get("name"));
+    }
+
+    @Test(description = "scan model implementing interface with Generic Type")
+    public void scanModelImplInterfaceWithGenericType() {
+        final Swagger swagger = new Reader(new Swagger()).read(UserApiRouteImpl.class);
+        assertNotNull(swagger);
+        assertEquals(((BodyParameter) swagger.getPath("/api/users2").getPost().getParameters().get(0))
+                .getSchema().getReference(), "#/definitions/UserEntity");
     }
 }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ResourceWithSchemeTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ResourceWithSchemeTest.java
@@ -5,6 +5,7 @@ import io.swagger.models.Scheme;
 import io.swagger.models.Swagger;
 import io.swagger.resources.ResourceWithScheme;
 import io.swagger.resources.ResourceWithoutScheme;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -14,7 +15,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 public class ResourceWithSchemeTest {
-    private final Reader reader = new Reader(new Swagger());
+    private Reader reader;
 
     private Swagger getSwagger(Class<?> resource) {
         return reader.read(resource);
@@ -22,6 +23,11 @@ public class ResourceWithSchemeTest {
 
     private List<Scheme> loadSchemes(Swagger swagger, String path) {
         return swagger.getPaths().get(path).getGet().getSchemes();
+    }
+
+    @BeforeMethod
+    private void resetReader() {
+        reader = new Reader(new Swagger());
     }
 
     @Test(description = "scan another resource with subresources")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/generics/CrudInterface.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/generics/CrudInterface.java
@@ -1,0 +1,12 @@
+package io.swagger.resources.generics;
+
+import io.swagger.models.Response;
+
+/**
+ * Created on 4/24/17
+ *
+ * @author Jason Bau (jbau@wavefront.com).
+ */
+public interface CrudInterface<T extends AbstractEntity> {
+    Response doCreate(T entity) throws Exception;
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/generics/UserApiRouteImpl.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/generics/UserApiRouteImpl.java
@@ -1,0 +1,29 @@
+package io.swagger.resources.generics;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.models.Response;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import java.util.List;
+
+/**
+ * Created on 4/24/17
+ *
+ * @author Jason Bau (jbau@wavefront.com).
+ */
+@Path("/api/users2")
+@Api(value = "/users2")
+public class UserApiRouteImpl implements CrudInterface<UserEntity> {
+    protected List<UserEntity> service;
+
+    @POST
+    @ApiOperation(value = "Create")
+    public Response doCreate(
+            @ApiParam(value = "Create object", required = true) UserEntity entity) throws Exception {
+        service.add(entity);
+        return new Response();
+    }
+}


### PR DESCRIPTION
Opening this PR to get discussion started.  Tips appreciated on how to merge (if you want this behind a flag, e.g) so that we don't have to maintain our own fork.

This issue this is trying to address is that we are using Java interfaces just to standardize concrete APIs with Body parameters (e.g. say they must provide CRUD functions of a particular signature), but we _don't_ want to have any supertype/subtype relationships between the JSON representations of these Body parameters or use any discriminant properties within the interface.

e.g. we have an interface:
```JAVA
public interface RestfulWebResource<T extends StandardizedDTO> {

  ResponseDTO<PaginatedResponseContentDTO<T>> getAll(User user, int offset, int limit);

  ResponseDTO<T> create(User user, T entityToCreate);
}
```
with specific implementation like

```JAVA
@Path("/api/v2/dashboard")
@Api(value = "Dashboard")
@Produces(APPLICATION_JSON)
public class DashboardWebResource implements RestfulWebResource<DashboardDTO> {

  @ApiOperation(value = "Get all dashboards for a customer", nickname = "getAllDashboard")
  @Authenticated(BusinessFunction.VIEW_DASHBOARDS)
  @GET
  @Override
  public ResponseDTO<PaginatedResponseContentDTO<DashboardDTO>> getAll(@ApiParam(hidden = true) @Authenticated User user,
                                                                       @QueryParam("offset") @DefaultValue("0") int offset,
                                                                       @QueryParam("limit") @DefaultValue("100") int limit)

  @ApiOperation(value = "Create a specific dashboard", nickname = "createDashboard")
  @Consumes({MediaType.APPLICATION_JSON})
  @POST
  @Override
  public ResponseDTO<DashboardDTO> create(@ApiParam(hidden = true) @Authenticated User user,
                                          @ApiParam("Dashboard JSON") DashboardDTO entityToCreate)
}
```

In this case `DashboardDTO` extends `StandardizedDTO`

In our use case the Java interface are really only there to enforce the structure of the implementing API classes.  The signatures and documentation of the implementing classes should ALWAYS win.  The Java interfaces really aren't annotated at all.

But we found that it is possible for introspection to find multiple operation definitions corresponding to the same url path, basically picking up the Interface version of the method rather than the concrete version, so that e.g. the resultant documentation generated for `createDashboard` contains, as the Body parameter, the class definition for `StandardizedDTO` rather than `DashboardDTO`.  The existing behavior just lets whichever of the interface / concrete methods that gets introspected last "win", and I don't think we can control the introspection order.  So, this is not what we want.

Thus, as a heuristic to solve that case, we implemented code that chooses the operation that has the most properties defined on the body parameter, as this is most likely to have resulted from the concrete implementation.  That's included in this PR.  Please review and let us know what you think.  Thanks!