### PR TITLE
Update logback version to 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -492,7 +492,7 @@
         <jersey-version>1.13</jersey-version>
         <jersey2-version>2.1</jersey2-version>
         <jackson-version>2.8.5</jackson-version>
-        <logback-version>1.0.1</logback-version>
+        <logback-version>1.2.3</logback-version>
         <reflections-version>0.9.10</reflections-version>
         <guava-version>20.0</guava-version>
 


### PR DESCRIPTION
Update to logback v1.2.3 addresses threat CVE-2017-5929.   Ref issue #2182 

Unit tests not run/created as I am not a developer or have the tools.  