### PR TITLE
Fix Empty model output

### DIFF
--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ConverterUtil.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ConverterUtil.scala
@@ -1,0 +1,22 @@
+package com.wordnik.swagger.converter
+
+object ConverterUtil {
+  /**
+    * @param cls
+    * @return - true if the class represents a value in an Enumeration
+    *         false otherwise
+    */
+  def isScalaEnumValue(cls: Class[_]): Boolean ={
+    cls.getName().compareTo("scala.Enumeration$Value") == 0
+  }
+
+  /**
+    * @param cls
+    * @return - true if the class represents an Enum or a Scala Enumeration Value
+    *         false otherwise
+    */
+  def isEnum(cls: Class[_]): Boolean ={
+    cls.isEnum || isScalaEnumValue(cls)
+  }
+
+}

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/ModelPropertyParser.scala
@@ -181,7 +181,7 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
       if(returnClass.isEnum) {
         Some(AllowableListValues((for (v <- returnClass.getEnumConstants) yield v.toString).toList))
       }
-      else if (isScalaEnumValue(returnClass)) {
+      else if (ConverterUtil.isScalaEnumValue(returnClass)) {
         // For Scala enumerations, set the dataType annotation to be the
         // fully qualified class name of the enumeration object (e.g., com.wordnik.MyEnum$)
         val enumValuesOpt = if (overrideDataType != null) getScalaEnumAllowableValues(overrideDataType) else None
@@ -277,15 +277,6 @@ class ModelPropertyParser(cls: Class[_], t: Map[String, String] = Map.empty) (im
     val o = typeMap.getOrElse(dataType.toLowerCase, dataType)
     LOGGER.debug("validating datatype " + dataType + " against " + typeMap.size + " keys, got " + o)
     o
-  }
-
-  /**
-   * @param cls
-   * @return - true if the class represents a value in an Enumeration
-   *         false otherwise
-   */
-  def isScalaEnumValue(cls: Class[_]): Boolean ={
-    cls.getName().compareTo("scala.Enumeration$Value") == 0
   }
 
   /**

--- a/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
+++ b/modules/swagger-core/src/main/scala/com/wordnik/swagger/converter/SwaggerSchemaConverter.scala
@@ -59,7 +59,7 @@ class SwaggerSchemaConverter
           else List()
         }
         sortedProperties.size match {
-          case 0 => None
+          case 0 if(ConverterUtil.isEnum(cls)) => None
           case _ => Some(Model(
             toName(cls),
             toName(cls),

--- a/modules/swagger-core/src/test/scala/converter/EmptyModelTest.scala
+++ b/modules/swagger-core/src/test/scala/converter/EmptyModelTest.scala
@@ -1,0 +1,18 @@
+package converter
+
+import com.wordnik.swagger.converter.ModelConverters
+import com.wordnik.swagger.core.util.JsonSerializer
+import org.junit.runner.RunWith
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class EmptyModelTest extends FlatSpec with Matchers {
+  it should "read an empty model" in {
+    val a = ModelConverters.readAll(classOf[EmptyModel])
+    JsonSerializer.asJson(a) should be ("""[{"id":"EmptyModel","properties":{}}]""")
+  }
+
+}
+
+case class EmptyModel()

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,15 @@
   </build>
   <profiles>
     <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
+    <profile>
       <id>release-profile</id>
       <properties>
         <skipTests>true</skipTests>


### PR DESCRIPTION
Currently while creating models, if the model object has no properties and is just a dummy response, the generated swagger json does not include the empty object model. 

This would fix such scenarios and always generate the model even if its an empty object