### PR TITLE
Allow @Api annotations be part of meta-annotations

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/Api.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/Api.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * with {@code @Api} and will ignore other resources (JAX-RS endpoints, Servlets and
  * so on).
  */
-@Target(ElementType.TYPE)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface Api {

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParam.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiImplicitParam.java
@@ -34,7 +34,7 @@ import java.lang.annotation.Target;
  *
  * @see ApiImplicitParams
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiImplicitParam {
     /**

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModel.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModel.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * Classes will be introspected automatically as they are used as types in operations,
  * but you may want to manipulate the structure of the models.
  */
-@Target({ElementType.TYPE})
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface ApiModel {

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModelProperty.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModelProperty.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 /**
  * Adds and manipulates data of a model property.
  */
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiModelProperty {
     /**

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiOperation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiOperation.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * Operations with equivalent paths are grouped in a single Operation Object.
  * A combination of a HTTP method and a path creates a unique operation.
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiOperation {
     /**

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiParam.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiParam.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * <p>
  * This annotation can be used only in combination of JAX-RS 1.x/2.x annotations.
  */
-@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiParam {
     /**

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponse.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponse.java
@@ -43,7 +43,7 @@ import java.lang.annotation.Target;
  * @see ApiOperation
  * @see ApiResponses
  */
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiResponse {
     /**

--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponses.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiResponses.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  *
  * @see ApiResponse
  */
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ApiResponses {
     /**


### PR DESCRIPTION
I'd like to use `@ApiModelProperty` and other `@Api*` annotations on Spring [meta-annotations](
https://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html#beans-meta-annotations).

It's a simple code change, that improves Spring integration.