### PR TITLE
Get namespace from package-info #2150

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -52,23 +52,11 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class ModelResolver extends AbstractModelConverter implements ModelConverter {
     Logger LOGGER = LoggerFactory.getLogger(ModelResolver.class);
@@ -272,6 +260,16 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             Xml xml = new Xml().name(rootAnnotation.name());
             if (rootAnnotation.namespace() != null && !"".equals(rootAnnotation.namespace()) && !"##default".equals(rootAnnotation.namespace())) {
                 xml.namespace(rootAnnotation.namespace());
+            }
+            else {
+                // If namespace was not given in the annotation, look for it in package-info
+                Package pkg = type.getRawClass().getPackage();
+                if(pkg != null) {
+                    XmlSchema xmlSchma = pkg.getAnnotation(XmlSchema.class);
+                    if(xmlSchma != null) {
+                        xml.namespace(xmlSchma.namespace());
+                    }
+                }
             }
             model.xml(xml);
         }

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -52,11 +52,24 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import javax.xml.bind.annotation.*;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSchema;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class ModelResolver extends AbstractModelConverter implements ModelConverter {
     Logger LOGGER = LoggerFactory.getLogger(ModelResolver.class);

--- a/modules/swagger-core/src/test/java/io/swagger/jackson/ModelResolverTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/jackson/ModelResolverTest.java
@@ -1,0 +1,54 @@
+package io.swagger.jackson;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.converter.ModelConverterContextImpl;
+import io.swagger.models.Link;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.Xml;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import static org.testng.Assert.*;
+
+public class ModelResolverTest extends SwaggerTestBase {
+
+    @Test(dataProvider = "testXmlNamespaceData")
+    public void testXmlNamespace(Class clazz, String name, String namespace) throws Exception {
+        final ObjectMapper mapper = mapper();
+        final ModelResolver modelResolver = new ModelResolver(mapper);
+        final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        final JavaType javaType = mapper.constructType(clazz);
+
+        final Model model = modelResolver.resolve(javaType, context, null);
+
+        assertTrue(model instanceof ModelImpl);
+
+        final Xml xml = ((ModelImpl) model).getXml();
+        assertNotNull(xml);
+        assertEquals(xml.getName(), name);
+        assertEquals(xml.getNamespace(), namespace);
+    }
+
+    @DataProvider
+    private Object[][] testXmlNamespaceData() {
+        return new Object[][]{
+                {Link.class, "link", null},
+                {TypeWithNamespace.class, "TypeWithNamespace", "http://io.swagger/jackson"},
+                {TypeWithoutNamespace.class, "TypeWithOutNamespace", "http://io.swagger/jackson/package"}
+        };
+    }
+
+    @XmlRootElement(name = "TypeWithNamespace", namespace = "http://io.swagger/jackson")
+    public static class TypeWithNamespace {
+    }
+
+    @XmlRootElement(name = "TypeWithOutNamespace")
+    public static class TypeWithoutNamespace {
+    }
+
+}

--- a/modules/swagger-core/src/test/java/io/swagger/jackson/package-info.java
+++ b/modules/swagger-core/src/test/java/io/swagger/jackson/package-info.java
@@ -1,0 +1,2 @@
+@javax.xml.bind.annotation.XmlSchema(namespace = "http://io.swagger/jackson/package")
+package io.swagger.jackson;


### PR DESCRIPTION
This PR addresses [Issue 2150](https://github.com/swagger-api/swagger-core/issues/2150).  When resolving a `JavaType` to a Swagger `Model`, if the type is annotated with `XmlRootElement` and no `namespace` is specified, the resolver will look in `package-info` for an package-level annotation.