### PR TITLE
2061-Validation-added

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/SwaggerAnnotationIntrospector.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/SwaggerAnnotationIntrospector.java
@@ -19,7 +19,6 @@ public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
 	private static final long serialVersionUID = 1L;
 	private boolean isThereAHiddenField = false;
 
-
 	@Override
 	public Version version() {
 		return PackageVersion.VERSION;

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/SwaggerAnnotationIntrospector.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/SwaggerAnnotationIntrospector.java
@@ -1,5 +1,6 @@
 package io.swagger.jackson;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.introspect.Annotated;
@@ -15,78 +16,86 @@ import java.util.Collections;
 import java.util.List;
 
 public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
+	private boolean isThereAHiddenField = false;
 
-    @Override
-    public Version version() {
-        return PackageVersion.VERSION;
-    }
 
-    @Override
-    public boolean hasIgnoreMarker(AnnotatedMember m) {
-        ApiModelProperty ann = m.getAnnotation(ApiModelProperty.class);
-        if (ann != null && ann.hidden()) {
-            return true;
-        }
-        return false;
-    }
+	@Override
+	public Version version() {
+		return PackageVersion.VERSION;
+	}
 
-    @Override
-    public Boolean hasRequiredMarker(AnnotatedMember m) {
-        ApiModelProperty ann = m.getAnnotation(ApiModelProperty.class);
-        if (ann != null) {
-            return ann.required();
-        }
-        XmlElement elem = m.getAnnotation(XmlElement.class);
-        if (elem != null) {
-            if (elem.required()) {
-                return true;
-            }
-        }
-        return null;
-    }
+	@Override
+	public boolean hasIgnoreMarker(AnnotatedMember m) {
+		ApiModelProperty ann = m.getAnnotation(ApiModelProperty.class);
+		if (ann != null && ann.hidden()) {
+			isThereAHiddenField = true;
+			return true;
+		}
+		// Add a Ignore Marker when there's a Constructor with JsonCreator and also if there's any Hidden Field
+		JsonCreator constructor = m.getAnnotation(JsonCreator.class);
+		if (constructor != null && isThereAHiddenField) {
+			return true;
+		}
+		return false;
+	}
 
-    @Override
-    public String findPropertyDescription(Annotated a) {
-        ApiModel model = a.getAnnotation(ApiModel.class);
-        if (model != null && !"".equals(model.description())) {
-            return model.description();
-        }
-        ApiModelProperty prop = a.getAnnotation(ApiModelProperty.class);
-        if (prop != null) {
-            return prop.value();
-        }
-        return null;
-    }
+	@Override
+	public Boolean hasRequiredMarker(AnnotatedMember m) {
+		ApiModelProperty ann = m.getAnnotation(ApiModelProperty.class);
+		if (ann != null) {
+			return ann.required();
+		}
+		XmlElement elem = m.getAnnotation(XmlElement.class);
+		if (elem != null) {
+			if (elem.required()) {
+				return true;
+			}
+		}
+		return null;
+	}
 
-    @Override
-    public Integer findPropertyIndex(Annotated a) {
-        ApiModelProperty prop = a.getAnnotation(ApiModelProperty.class);
-        if (prop != null && prop.position() != 0) {
-            return prop.position();
-        }
-        return null;
-    }
+	@Override
+	public String findPropertyDescription(Annotated a) {
+		ApiModel model = a.getAnnotation(ApiModel.class);
+		if (model != null && !"".equals(model.description())) {
+			return model.description();
+		}
+		ApiModelProperty prop = a.getAnnotation(ApiModelProperty.class);
+		if (prop != null) {
+			return prop.value();
+		}
+		return null;
+	}
 
-    @Override
-    public List<NamedType> findSubtypes(Annotated a) {
-        final ApiModel api = a.getAnnotation(ApiModel.class);
-        if (api != null) {
-            final Class<?>[] classes = api.subTypes();
-            final List<NamedType> names = new ArrayList<NamedType>(classes.length);
-            for (Class<?> subType : classes) {
-                names.add(new NamedType(subType));
-            }
-            if (!names.isEmpty()) {
-                return names;
-            }
-        }
+	@Override
+	public Integer findPropertyIndex(Annotated a) {
+		ApiModelProperty prop = a.getAnnotation(ApiModelProperty.class);
+		if (prop != null && prop.position() != 0) {
+			return prop.position();
+		}
+		return null;
+	}
 
-        return Collections.emptyList();
-    }
+	@Override
+	public List<NamedType> findSubtypes(Annotated a) {
+		final ApiModel api = a.getAnnotation(ApiModel.class);
+		if (api != null) {
+			final Class<?>[] classes = api.subTypes();
+			final List<NamedType> names = new ArrayList<NamedType>(classes.length);
+			for (Class<?> subType : classes) {
+				names.add(new NamedType(subType));
+			}
+			if (!names.isEmpty()) {
+				return names;
+			}
+		}
 
-    @Override
-    public String findTypeName(AnnotatedClass ac) {
-        return null;
-    }
+		return Collections.emptyList();
+	}
+
+	@Override
+	public String findTypeName(AnnotatedClass ac) {
+		return null;
+	}
 }


### PR DESCRIPTION
The Bugfix was added

The solution was implemented in the SwaggerAnnotationIntrospector adding a new validation in the hasIgnoreMarker method, when there's a Hidden field and the constructor is treated with a JsonCreated it mark the Constructor as ignored. So, when it try to remove the property it doesn't have any trouble to do it.

The Tests weren't added because we don't want to add the Lombok annotations to our projects. 

@fehguy 
