### PR TITLE
Bugfix/2280 apioperation links

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/oas/annotations/Operation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/oas/annotations/Operation.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 
 /**
  * Operation Annotation
- * <p>
+ *
  * TODO: longer description
  **/
 
@@ -81,7 +81,6 @@ public @interface Operation {
      *
      **/
     ApiResponse[] responses() default @ApiResponse();
-
 
     /**
      * allows an operation to be marked as deprecated.  Alternatively use the @Deprecated annotation

--- a/modules/swagger-annotations/src/main/java/io/swagger/oas/annotations/Operation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/oas/annotations/Operation.java
@@ -16,7 +16,6 @@
 
 package io.swagger.oas.annotations;
 
-import io.swagger.oas.annotations.links.Link;
 import io.swagger.oas.annotations.parameters.RequestBody;
 import io.swagger.oas.annotations.responses.ApiResponse;
 import io.swagger.oas.annotations.servers.Server;
@@ -29,73 +28,69 @@ import java.lang.annotation.Target;
 
 /**
  * Operation Annotation
- *
+ * <p>
  * TODO: longer description
  **/
 
 
-@Target({ ElementType.METHOD })
+@Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface Operation {
-  /**
-   * the HTTP method for this operation
-   **/
-  String method() default "";
+    /**
+     * the HTTP method for this operation
+     **/
+    String method() default "";
 
-  /**
-   * Tags can be used for logical grouping of operations by resources or any other qualifier.
-   **/
-  String[] tags() default "";
+    /**
+     * Tags can be used for logical grouping of operations by resources or any other qualifier.
+     **/
+    String[] tags() default "";
 
-  /**
-   * Provides a brief description of this operation. Should be 120 characters or less for proper visibility in Swagger-UI.
-   **/
-  String summary() default "";
+    /**
+     * Provides a brief description of this operation. Should be 120 characters or less for proper visibility in Swagger-UI.
+     **/
+    String summary() default "";
 
-  /**
-   * A verbose description of the operation.
-   **/
-  String description() default "";
+    /**
+     * A verbose description of the operation.
+     **/
+    String description() default "";
 
-  /**
-   * 
-   **/
-  ExternalDocumentation externalDocs() default @ExternalDocumentation();
+    /**
+     *
+     **/
+    ExternalDocumentation externalDocs() default @ExternalDocumentation();
 
-  /**
-   * The operationId is used by third-party tools to uniquely identify this operation.
-   **/
-  String operationId() default "";
+    /**
+     * The operationId is used by third-party tools to uniquely identify this operation.
+     **/
+    String operationId() default "";
 
-  /**
-   * An optional array of parameters which will be added to any automatically detected parameters in the method itself
-   **/
-  Parameter[] parameters() default @Parameter();
+    /**
+     * An optional array of parameters which will be added to any automatically detected parameters in the method itself
+     **/
+    Parameter[] parameters() default @Parameter();
 
-  /**
-   * 
-   **/
-  RequestBody requestBody() default @RequestBody();
+    /**
+     *
+     **/
+    RequestBody requestBody() default @RequestBody();
 
-  /**
-   * 
-   **/
-  ApiResponse[] responses() default @ApiResponse();
+    /**
+     *
+     **/
+    ApiResponse[] responses() default @ApiResponse();
 
-  /**
-   * 
-   **/
-  Link[] links() default @Link();
 
-  /**
-   * allows an operation to be marked as deprecated.  Alternatively use the @Deprecated annotation
-   **/
-  boolean deprecated() default false;
+    /**
+     * allows an operation to be marked as deprecated.  Alternatively use the @Deprecated annotation
+     **/
+    boolean deprecated() default false;
 
-  /**
-   * 
-   **/
-  Server[] servers() default @Server();
+    /**
+     *
+     **/
+    Server[] servers() default @Server();
 
 }

--- a/modules/swagger-annotations/src/main/java/io/swagger/oas/annotations/responses/ApiResponse.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/oas/annotations/responses/ApiResponse.java
@@ -16,6 +16,7 @@
 
 package io.swagger.oas.annotations.responses;
 
+import io.swagger.oas.annotations.links.Link;
 import io.swagger.oas.annotations.media.Content;
 
 import java.lang.annotation.ElementType;
@@ -25,29 +26,34 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * 
  *
- * 
+ *
+ *
  **/
 
 
-@Target({ ElementType.METHOD })
+@Target({ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface ApiResponse {
-  /**
-   * 
-   **/
-  String description() default "";
+    /**
+     *
+     **/
+    String description() default "";
 
-  /**
-   * the HTTP response code, or default, for the supplied response
-   **/
-  String responseCode() default "";
+    /**
+     * the HTTP response code, or default, for the supplied response
+     **/
+    String responseCode() default "";
 
-  /**
-   * 
-   **/
-  Content content() default @Content();
+    /**
+     *
+     **/
+    Content content() default @Content();
+
+    /**
+     *
+     **/
+    Link[] links() default @Link();
 
 }

--- a/modules/swagger-annotations/src/test/java/io/swagger/oas/annotations/test/pathItems/OperationsWithLinks.java
+++ b/modules/swagger-annotations/src/test/java/io/swagger/oas/annotations/test/pathItems/OperationsWithLinks.java
@@ -3,6 +3,7 @@ package io.swagger.oas.annotations.test.pathItems;
 import io.swagger.oas.annotations.Operation;
 import io.swagger.oas.annotations.links.Link;
 import io.swagger.oas.annotations.links.LinkParameters;
+import io.swagger.oas.annotations.responses.ApiResponse;
 import io.swagger.oas.annotations.test.AbstractAnnotationTest;
 import org.testng.annotations.Test;
 
@@ -52,14 +53,17 @@ public class OperationsWithLinks extends AbstractAnnotationTest {
 
     static class ClassWithOperationAndLinks {
         @Path("/users")
-        @Operation(links = {
-            @Link(
-                name = "address",
-                operationId = "getAddress",
-                parameters = @LinkParameters(
-                        name = "userId",
-                        expression = "$request.query.userId"))
-        })
+        @Operation(responses = {
+                @ApiResponse(
+                        description = "no description",
+                        links = {
+                    @Link(
+                        name = "address",
+                        operationId = "getAddress",
+                        parameters = @LinkParameters(
+                                name = "userId",
+                                expression = "$request.query.userId"))
+        })})
         public User getUser(@QueryParam("userId") String userId) {
             return null;
         }
@@ -103,10 +107,13 @@ public class OperationsWithLinks extends AbstractAnnotationTest {
 
     static class ClassWithOperationAndLinkReferences {
         @Path("/users")
-        @Operation(links = {
+        @Operation(responses = {
+                @ApiResponse(
+                        description = "no description",
+                        links = {
             @Link(
                 operationRef = "#/components/links/MyLink")
-        })
+        })})
         public User getUser(@QueryParam("userId") String userId) {
             return null;
         }


### PR DESCRIPTION
The links are now int the ApiResponse annotation. They were in the operation annotation before. 