### PR TITLE
Bugfix/issue 2287 multiple consumes for request body

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/jaxrs2/Reader.java
@@ -19,6 +19,7 @@ import io.swagger.oas.models.Paths;
 import io.swagger.oas.models.callbacks.Callback;
 import io.swagger.oas.models.media.Content;
 import io.swagger.oas.models.media.MediaType;
+import io.swagger.oas.models.media.Schema;
 import io.swagger.oas.models.parameters.Parameter;
 import io.swagger.oas.models.parameters.RequestBody;
 import io.swagger.oas.models.security.SecurityScheme;
@@ -217,14 +218,10 @@ public class Reader {
                                         Content content = new Content();
                                         if (consumes != null) {
                                             for (String value : consumes.value()) {
-                                                MediaType mediaTypeObject = new MediaType();
-                                                mediaTypeObject.setSchema(parameter.getSchema());
-                                                content.addMediaType(value, mediaTypeObject);
+                                                setMediaTypeToContent(parameter.getSchema(), content, value);
                                             }
                                         } else {
-                                            MediaType mediaTypeObject = new MediaType();
-                                            mediaTypeObject.setSchema(parameter.getSchema());
-                                            content.addMediaType(DEFAULT_MEDIA_TYPE_VALUE, mediaTypeObject);
+                                            setMediaTypeToContent(parameter.getSchema(), content, DEFAULT_MEDIA_TYPE_VALUE);
                                         }
 
                                         requestBody.setContent(content);
@@ -270,6 +267,12 @@ public class Reader {
         OperationParser.getInfo(apiInfo).ifPresent(info -> openAPI.setInfo(info));
 
         return openAPI;
+    }
+
+    private void setMediaTypeToContent(Schema schema, Content content, String value) {
+        MediaType mediaTypeObject = new MediaType();
+        mediaTypeObject.setSchema(schema);
+        content.addMediaType(value, mediaTypeObject);
     }
 
     public Operation parseMethod(Method method) {

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/jaxrs2/Reader.java
@@ -50,6 +50,7 @@ import java.util.TreeSet;
 
 public class Reader {
     private static final Logger LOGGER = LoggerFactory.getLogger(Reader.class);
+    public static final String DEFAULT_MEDIA_TYPE_VALUE = "*/*";
 
     private final ReaderConfig config;
 
@@ -213,16 +214,19 @@ public class Reader {
                                     }
 
                                     if (parameter.getSchema() != null) {
-                                        String mediaType = "*/*";
-                                        if (consumes != null) {
-                                            if (consumes.value().length == 1) {
-                                                mediaType = consumes.value()[0];
-                                            }
-                                        }
                                         Content content = new Content();
-                                        MediaType mediaTypeObject = new MediaType();
-                                        mediaTypeObject.setSchema(parameter.getSchema());
-                                        content.addMediaType(mediaType, mediaTypeObject);
+                                        if (consumes != null) {
+                                            for (String value : consumes.value()) {
+                                                MediaType mediaTypeObject = new MediaType();
+                                                mediaTypeObject.setSchema(parameter.getSchema());
+                                                content.addMediaType(value, mediaTypeObject);
+                                            }
+                                        } else {
+                                            MediaType mediaTypeObject = new MediaType();
+                                            mediaTypeObject.setSchema(parameter.getSchema());
+                                            content.addMediaType(DEFAULT_MEDIA_TYPE_VALUE, mediaTypeObject);
+                                        }
+
                                         requestBody.setContent(content);
                                         isRequestBodyEmpty = false;
                                     }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/jaxrs2/annotations/operations/AnnotatedOperationMethodTests.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/jaxrs2/annotations/operations/AnnotatedOperationMethodTests.java
@@ -270,6 +270,9 @@ public class AnnotatedOperationMethodTests extends AbstractAnnotationTest {
                 "          application/json:\n" +
                 "            schema:\n" +
                 "              $ref: \"#/components/schemas/Pet\"\n" +
+                "          application/xml:\n" +
+                "            schema:\n" +
+                "              $ref: \"#/components/schemas/Pet\"\n" +
                 "        required: true\n" +
                 "      responses:\n" +
                 "        405:\n" +

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/jaxrs2/resources/PetResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/jaxrs2/resources/PetResource.java
@@ -63,7 +63,7 @@ public class PetResource {
     }
 
     @POST
-    @Consumes("application/json")
+    @Consumes({"application/json", "application/xml"})
     @Operation(summary = "Add a new pet to the store",
             responses = {
                     @ApiResponse(responseCode = "405", description = "Invalid input")


### PR DESCRIPTION
Fix implemented. The requestBody now includes a content for each value of the consume.

@fehguy 