### PR TITLE
#2191 - Added typing to BodyParameter 

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ParameterProcessor.java
@@ -252,12 +252,20 @@ public class ParameterProcessor {
             bp.setRequired(param.isRequired());
             bp.setName(StringUtils.isNotEmpty(param.getName()) ? param.getName() : "body");
 
+            if (StringUtils.isNotEmpty(param.getDataType())) {
+                bp.setType(param.getDataType());
+            }
+
             if (StringUtils.isNotEmpty(param.getDescription())) {
                 bp.setDescription(param.getDescription());
             }
 
             if (StringUtils.isNotEmpty(param.getAccess())) {
                 bp.setAccess(param.getAccess());
+            }
+
+            if(helper.getType() != null) {
+                bp.setType(helper.getType());
             }
 
             final Property property = ModelConverters.getInstance().readAsProperty(type);

--- a/modules/swagger-core/src/test/java/io/swagger/ParameterProcessorTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ParameterProcessorTest.java
@@ -498,4 +498,24 @@ public class ParameterProcessorTest {
         assertEquals(param0.getFormat(), "int64");
 
     }
+
+    @ApiImplicitParams(value = {
+            @ApiImplicitParam(name = "id", dataType = "com.example.api.model.UpsertPet", paramType = "body", required = true)
+    })
+    private void implicitParameterizedMethodParameterizedType() {
+    }
+
+    @Test(description = "test for issue #2191 fixing.")
+    public void implicitParameterParameterizedTypeProcessorTest() throws NoSuchMethodException {
+        final ApiImplicitParams params = getClass().getDeclaredMethod("implicitParameterizedMethodParameterizedType")
+                .getAnnotation(ApiImplicitParams.class);
+        final BodyParameter param0 = (BodyParameter) ParameterProcessor.applyAnnotations(null, new BodyParameter(),
+                String.class, Collections.<Annotation>singletonList(params.value()[0]));
+
+        assertEquals(param0.getName(), "id");
+        assertEquals(param0.getIn(), "body");
+        assertEquals(param0.getRequired(), true);
+        assertEquals(param0.getType(), "com.example.api.model.UpsertPet");
+
+    }
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractParameter.java
@@ -2,6 +2,8 @@ package io.swagger.models.parameters;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.models.properties.ArrayProperty;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -16,6 +18,8 @@ public abstract class AbstractParameter {
     protected String pattern;
     protected Boolean allowEmptyValue;
     protected Boolean readOnly;
+    protected String type;
+    protected String collectionFormat;
 
     @Override
     public boolean equals(Object o) {
@@ -52,6 +56,12 @@ public abstract class AbstractParameter {
         if (allowEmptyValue != null ? !allowEmptyValue.equals(that.allowEmptyValue) : that.allowEmptyValue != null) {
             return false;
         }
+        if (type != null ? !type.equals(that.type) : that.type != null) {
+            return false;
+        }
+        if (collectionFormat != null ? !collectionFormat.equals(that.collectionFormat) : that.collectionFormat != null) {
+             return false;
+        }
         return readOnly != null ? readOnly.equals(that.readOnly) : that.readOnly == null;
 
     }
@@ -67,6 +77,8 @@ public abstract class AbstractParameter {
         result = 31 * result + (pattern != null ? pattern.hashCode() : 0);
         result = 31 * result + (allowEmptyValue != null ? allowEmptyValue.hashCode() : 0);
         result = 31 * result + (readOnly != null ? readOnly.hashCode() : 0);
+        result = 31 * result + (collectionFormat != null ? collectionFormat.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
         return result;
     }
 
@@ -132,6 +144,28 @@ public abstract class AbstractParameter {
 
     public void setPattern(String pattern) {
         this.pattern = pattern;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+        setCollectionFormat(ArrayProperty.isType(type) ? getDefaultCollectionFormat() : null);
+    }
+
+    public String getCollectionFormat() {
+        return collectionFormat;
+    }
+
+    public void setCollectionFormat(String collectionFormat) {
+        this.collectionFormat = collectionFormat;
+    }
+
+    @JsonIgnore
+    protected String getDefaultCollectionFormat() {
+        return "csv";
     }
 
     @JsonAnyGetter

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
@@ -26,9 +26,7 @@ import java.util.List;
         "uniqueItems", "multipleOf" })
 public abstract class AbstractSerializableParameter<T extends AbstractSerializableParameter<T>> extends AbstractParameter implements SerializableParameter {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSerializableParameter.class);
-    protected String type;
     protected String format;
-    protected String collectionFormat;
     protected Property items;
     protected Boolean exclusiveMaximum;
     protected BigDecimal maximum;
@@ -113,11 +111,6 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
     public T readOnly(Boolean readOnly) {
         this.setReadOnly(readOnly);
         return castThis();
-    }
-
-    @JsonIgnore
-    protected String getDefaultCollectionFormat() {
-        return "csv";
     }
 
     public T items(Property items) {
@@ -238,27 +231,6 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
     @Override
     public void setFormat(String format) {
         this.format = format;
-    }
-
-    @Override
-    public String getType() {
-        return type;
-    }
-
-    @Override
-    public void setType(String type) {
-        this.type = type;
-        setCollectionFormat(ArrayProperty.isType(type) ? getDefaultCollectionFormat() : null);
-    }
-
-    @Override
-    public String getCollectionFormat() {
-        return collectionFormat;
-    }
-
-    @Override
-    public void setCollectionFormat(String collectionFormat) {
-        this.collectionFormat = collectionFormat;
     }
 
     public void setProperty(Property property) {
@@ -481,9 +453,6 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
         if (_enum == null) {
             if (other._enum != null) return false;
         } else if (!_enum.equals(other._enum)) return false;
-        if (collectionFormat == null) {
-            if (other.collectionFormat != null) return false;
-        } else if (!collectionFormat.equals(other.collectionFormat)) return false;
         if (defaultValue == null) {
             if (other.defaultValue != null) return false;
         } else if (!defaultValue.equals(other.defaultValue)) return false;
@@ -526,9 +495,6 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
         if (pattern == null) {
             if (other.pattern != null) return false;
         } else if (!pattern.equals(other.pattern)) return false;
-        if (type == null) {
-            if (other.type != null) return false;
-        } else if (!type.equals(other.type)) return false;
         if (uniqueItems == null) {
             if (other.uniqueItems != null) return false;
         } else if (!uniqueItems.equals(other.uniqueItems)) return false;
@@ -540,7 +506,6 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + ((_enum == null) ? 0 : _enum.hashCode());
-        result = prime * result + ((collectionFormat == null) ? 0 : collectionFormat.hashCode());
         result = prime * result + ((defaultValue == null) ? 0 : defaultValue.hashCode());
         result = prime * result + ((example == null) ? 0 : example.hashCode());
         result = prime * result + ((exclusiveMaximum == null) ? 0 : exclusiveMaximum.hashCode());
@@ -555,7 +520,6 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
         result = prime * result + ((minimum == null) ? 0 : minimum.hashCode());
         result = prime * result + ((multipleOf == null) ? 0 : multipleOf.hashCode());
         result = prime * result + ((pattern == null) ? 0 : pattern.hashCode());
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
         result = prime * result + ((uniqueItems == null) ? 0 : uniqueItems.hashCode());
         return result;
     }

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/Parameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/Parameter.java
@@ -40,4 +40,12 @@ public interface Parameter {
     Boolean getAllowEmptyValue();
 
     void setAllowEmptyValue(Boolean allowEmptyValue);
+
+    String getType();
+
+    void setType(String type);
+
+    String getCollectionFormat();
+
+    void setCollectionFormat(String collectionFormat);
 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/SerializableParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/SerializableParameter.java
@@ -6,9 +6,6 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public interface SerializableParameter extends Parameter {
-    String getType();
-
-    void setType(String type);
 
     Property getItems();
 
@@ -17,10 +14,6 @@ public interface SerializableParameter extends Parameter {
     String getFormat();
 
     void setFormat(String format);
-
-    String getCollectionFormat();
-
-    void setCollectionFormat(String collectionFormat);
 
     List<String> getEnum();
 


### PR DESCRIPTION
To support specifying the correct class name when class in Parameterized. Swagger Spec should now use just the class name (e.g. A class UpsertPet<T extends Pet> will now appear as UpsertPet when specified using the full package reference where previously this was UpsertPetPet which did not match any other generated classes in the Swagger Spec.