### PR TITLE
 Inner properties may have XML declared

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -135,9 +135,6 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
             throws IOException, JsonProcessingException {
         JsonNode node = jp.getCodec().readTree(jp);
         Property property = propertyFromNode(node);
-        if(property != null) {
-            property.setXml(getXml(node));
-        }
         return property;
     }
 
@@ -208,6 +205,8 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
         final String format = getString(node, PropertyBuilder.PropertyId.FORMAT);
 
         String description = getString(node, PropertyBuilder.PropertyId.DESCRIPTION);
+        
+        Xml xml = getXml(node);
 
         JsonNode detailNode = node.get("$ref");
         if (detailNode != null) {
@@ -224,7 +223,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                 if (items != null) {
                     MapProperty mapProperty = new MapProperty(items)
                             .description(description)
-                            .title(title);
+                            .title(title).xml(xml);
                     mapProperty.setExample(example);
                     mapProperty.setMinProperties(getInteger(node, PropertyBuilder.PropertyId.MIN_PROPERTIES));
                     mapProperty.setMaxProperties(getInteger(node, PropertyBuilder.PropertyId.MAX_PROPERTIES));
@@ -256,7 +255,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                 if("array".equals(detailNodeType)) {
                     ArrayProperty ap = new ArrayProperty()
                             .description(description)
-                            .title(title);
+                            .title(title).xml(xml);
                     ap.setExample(example);
                     PropertyBuilder.merge(ap, argsFromNode(detailNode));
                     ap.setDescription(description);
@@ -270,7 +269,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                 }
                 ObjectProperty objectProperty = new ObjectProperty(properties)
                         .description(description)
-                        .title(title);
+                        .title(title).xml(xml);
                 objectProperty.setExample(example);
                 objectProperty.setVendorExtensionMap(getVendorExtensions(node));
 
@@ -287,7 +286,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                 ArrayProperty arrayProperty = new ArrayProperty()
                         .items(subProperty)
                         .description(description)
-                        .title(title);
+                        .title(title).xml(xml);
                 arrayProperty.setMinItems(getInteger(node, PropertyBuilder.PropertyId.MIN_ITEMS));
                 arrayProperty.setMaxItems(getInteger(node, PropertyBuilder.PropertyId.MAX_ITEMS));
                 arrayProperty.setUniqueItems(getBoolean(node, PropertyBuilder.PropertyId.UNIQUE_ITEMS));
@@ -307,6 +306,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
             LOGGER.warn("no property from " + type + ", " + format + ", " + args);
             return null;
         }
+        output.setXml(xml);
         output.setDescription(description);
 
         return output;

--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -210,7 +210,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
 
         JsonNode detailNode = node.get("$ref");
         if (detailNode != null) {
-            return new RefProperty(detailNode.asText())
+            return new RefProperty(detailNode.asText()).xml(xml)
                     .description(description)
                     .title(title);
         }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
@@ -1,6 +1,8 @@
 package io.swagger.models.properties;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import io.swagger.models.Xml;
 import io.swagger.models.refs.GenericRef;
 import io.swagger.models.refs.RefFormat;
 import io.swagger.models.refs.RefType;
@@ -99,5 +101,10 @@ public class RefProperty extends AbstractProperty implements Property {
             return false;
         }
         return true;
+    }
+    
+    public RefProperty xml(Xml xml) {
+        this.setXml(xml);
+        return this;
     }
 }


### PR DESCRIPTION
Swagger specification allows for "xml" element defined on the "items" of an array:

> When defined within the Items Object (items), it will affect the name of the individual XML elements within the list. When defined alongside type being array (outside the items), it will affect the wrapping element and only if wrapped is true. If wrapped is false, it will be ignored.

For `ArrayProperty`, the `detailNode = node.get("items")` is read, but the "xml" declaration on that element is not set. This PR moves to `property.setXml(getXml(node));` to the `propertyFromNode(JsonNode node)` method.