### PR TITLE
BUG FIX - Use Reflection extension to capture annotations hidden by an aspect. 

### DIFF
--- a/modules/swagger-servlet/src/main/java/io/swagger/servlet/extensions/ServletReaderExtension.java
+++ b/modules/swagger-servlet/src/main/java/io/swagger/servlet/extensions/ServletReaderExtension.java
@@ -392,7 +392,7 @@ public class ServletReaderExtension implements ReaderExtension {
 
     @Override
     public void applyImplicitParameters(ReaderContext context, Operation operation, Method method) {
-        final ApiImplicitParams implicitParams = method.getAnnotation(ApiImplicitParams.class);
+        final ApiImplicitParams implicitParams = ReflectionUtils.getAnnotation(method, ApiImplicitParams.class);
         if (implicitParams != null && implicitParams.value().length > 0) {
             for (ApiImplicitParam param : implicitParams.value()) {
                 final Parameter p = readImplicitParam(context.getSwagger(), param);
@@ -405,7 +405,7 @@ public class ServletReaderExtension implements ReaderExtension {
 
     @Override
     public void applyExtensions(ReaderContext context, Operation operation, Method method) {
-        final ApiOperation apiOperation = method.getAnnotation( ApiOperation.class );
+        final ApiOperation apiOperation = ReflectionUtils.getAnnotation(method, ApiOperation.class );
         if( apiOperation != null ) {
             operation.getVendorExtensions().putAll(BaseReaderUtils.parseExtensions(apiOperation.extensions()));
         }


### PR DESCRIPTION
Aspect frameworks, like AspectJ, may extend or wrap the method making the annotation not to be retrieved using "method.getAnnotations()" . 

Therefore it is necessary to use the provided reflection util to capture these situations all across the reader.

This PR make uniform accross the reader the usage of the reflection util for all "apply*" methods which retrieve Swagger annotations.