### PR TITLE
Avoid possible NPE when innerModel is empty

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -626,9 +626,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
     private void handleUnwrapped(List<Property> props, Model innerModel, String prefix, String suffix) {
         if (StringUtils.isBlank(suffix) && StringUtils.isBlank(prefix)) {
-            Map<String, Property> innerProps = innerModel.getProperties();
-            if (innerProps != null) {
-                props.addAll(innerProps.values());
+            if (innerModel != null) {
+                Map<String, Property> innerProps = innerModel.getProperties();
+                if (innerProps != null) {
+                    props.addAll(innerProps.values());
+                }
             }
         } else {
             if (prefix == null) {


### PR DESCRIPTION
I'm getting the following NPE when trying to use the swagger-maven-plugin to generate my swagger.json file (see exception below).

Problem is related to 'swagger-core' which can thrown a NPE. The inner model seems to be missing - although I cannot explain why. By checking on 'null' value, I could resolve this issue.

Is it possible to investigate this pull request?

```bash
[ERROR] Failed to execute goal com.github.kongchen:swagger-maven-plugin:3.1.5:generate (default) on project api: null: MojoExecutionException: NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.github.kongchen:swagger-maven-plugin:3.1.5:generate (default) on project api: null
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:212)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
        at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
        at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
        at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
        at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
        at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
        at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
        at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
        at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
        at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
        at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
        at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException
        at com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo.execute(ApiDocumentMojo.java:133)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
        ... 20 more
Caused by: java.lang.NullPointerException
        at io.swagger.jackson.ModelResolver.handleUnwrapped(ModelResolver.java:608)
        at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:441)
        at com.github.kongchen.swagger.docgen.reader.ModelModifier.resolve(ModelModifier.java:96)
        at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:183)
        at com.github.kongchen.swagger.docgen.reader.ModelModifier.resolve(ModelModifier.java:90)
        at io.swagger.jackson.AbstractModelConverter.resolve(AbstractModelConverter.java:184)
        at io.swagger.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:100)
        at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:234)
        at com.github.kongchen.swagger.docgen.reader.ModelModifier.resolve(ModelModifier.java:96)
        at io.swagger.jackson.ModelResolver.resolve(ModelResolver.java:183)
        at com.github.kongchen.swagger.docgen.reader.ModelModifier.resolve(ModelModifier.java:90)
        at io.swagger.jackson.AbstractModelConverter.resolve(AbstractModelConverter.java:184)
        at io.swagger.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:100)
        at io.swagger.jackson.ModelResolver.resolveProperty(ModelResolver.java:159)
        at io.swagger.jackson.ModelResolver.resolveProperty(ModelResolver.java:110)
        at com.github.kongchen.swagger.docgen.reader.ModelModifier.resolveProperty(ModelModifier.java:76)
        at io.swagger.jackson.AbstractModelConverter.resolveProperty(AbstractModelConverter.java:74)
        at io.swagger.converter.ModelConverterContextImpl.resolveProperty(ModelConverterContextImpl.java:80)
        at io.swagger.converter.ModelConverters.readAsProperty(ModelConverters.java:58)
        at com.github.kongchen.swagger.docgen.reader.AbstractReader.isPrimitive(AbstractReader.java:295)
        at com.github.kongchen.swagger.docgen.reader.SpringMvcApiReader.parseMethod(SpringMvcApiReader.java:218)
        at com.github.kongchen.swagger.docgen.reader.SpringMvcApiReader.read(SpringMvcApiReader.java:115)
        at com.github.kongchen.swagger.docgen.reader.SpringMvcApiReader.read(SpringMvcApiReader.java:58)
        at com.github.kongchen.swagger.docgen.mavenplugin.SpringMavenDocumentSource.loadDocuments(SpringMavenDocumentSource.java:50)
        at com.github.kongchen.swagger.docgen.mavenplugin.ApiDocumentMojo.execute(ApiDocumentMojo.java:96)
        ... 22 more
[ERROR] 
```