### PR TITLE
Revert pointless commit to fix #2320

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/AcceptHeaderApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/AcceptHeaderApiListingResource.java
@@ -1,6 +1,5 @@
 package io.swagger.jaxrs.listing;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.annotations.ApiOperation;
 
 import javax.servlet.ServletConfig;
@@ -26,7 +25,7 @@ public class AcceptHeaderApiListingResource extends BaseApiListingResource {
             @Context Application app,
             @Context ServletConfig sc,
             @Context HttpHeaders headers,
-            @Context UriInfo uriInfo) throws JsonProcessingException {
+            @Context UriInfo uriInfo) {
         return getListingJsonResponse(app, context, sc, headers, uriInfo);
     }
 

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/ApiListingResource.java
@@ -1,6 +1,5 @@
 package io.swagger.jaxrs.listing;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.annotations.ApiOperation;
 import org.apache.commons.lang3.StringUtils;
 
@@ -26,7 +25,7 @@ public class ApiListingResource extends BaseApiListingResource {
             @Context ServletConfig sc,
             @Context HttpHeaders headers,
             @Context UriInfo uriInfo,
-            @PathParam("type") String type) throws JsonProcessingException {
+            @PathParam("type") String type) {
         if (StringUtils.isNotBlank(type) && type.trim().equalsIgnoreCase("yaml")) {
             return getListingYamlResponse(app, context, sc, headers, uriInfo);
         } else {

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/BaseApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/BaseApiListingResource.java
@@ -1,6 +1,5 @@
 package io.swagger.jaxrs.listing;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.config.FilterFactory;
 import io.swagger.config.Scanner;
 import io.swagger.config.SwaggerConfig;
@@ -11,7 +10,6 @@ import io.swagger.jaxrs.config.JaxrsScanner;
 import io.swagger.jaxrs.config.ReaderConfigUtils;
 import io.swagger.jaxrs.config.SwaggerContextService;
 import io.swagger.models.Swagger;
-import io.swagger.util.Json;
 import io.swagger.util.Yaml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -163,11 +161,11 @@ public abstract class BaseApiListingResource {
             ServletContext servletContext,
             ServletConfig servletConfig,
             HttpHeaders headers,
-            UriInfo uriInfo) throws JsonProcessingException {
+            UriInfo uriInfo) {
         Swagger swagger = process(app, servletContext, servletConfig, headers, uriInfo);
 
         if (swagger != null) {
-            return Response.ok().entity(Json.mapper().writeValueAsString(swagger)).type(MediaType.APPLICATION_JSON_TYPE).build();
+            return Response.ok().entity(swagger).build();
         } else {
             return Response.status(404).build();
         }

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/BaseApiListingResource.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/listing/BaseApiListingResource.java
@@ -139,19 +139,9 @@ public abstract class BaseApiListingResource {
             HttpHeaders headers,
             UriInfo uriInfo) {
         Swagger swagger = process(app, servletContext, servletConfig, headers, uriInfo);
-        try {
-            if (swagger != null) {
-                String yaml = Yaml.mapper().writeValueAsString(swagger);
-                StringBuilder b = new StringBuilder();
-                String[] parts = yaml.split("\n");
-                for (String part : parts) {
-                    b.append(part);
-                    b.append("\n");
-                }
-                return Response.ok().entity(b.toString()).type("application/yaml").build();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
+        
+        if (swagger != null) {
+            return Response.ok().entity(swagger).type("application/yaml").build();
         }
         return Response.status(404).build();
     }
@@ -165,10 +155,9 @@ public abstract class BaseApiListingResource {
         Swagger swagger = process(app, servletContext, servletConfig, headers, uriInfo);
 
         if (swagger != null) {
-            return Response.ok().entity(swagger).build();
-        } else {
-            return Response.status(404).build();
+            return Response.ok().entity(swagger).type(MediaType.APPLICATION_JSON).build();
         }
+        return Response.status(404).build();
     }
 
     private static Map<String, List<String>> getQueryParams(MultivaluedMap<String, String> params) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ApiListingResourceTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ApiListingResourceTest.java
@@ -1,6 +1,5 @@
 package io.swagger;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.swagger.jaxrs.Reader;
 import io.swagger.jaxrs.listing.ApiListingResource;
 import io.swagger.models.Swagger;
@@ -25,7 +24,7 @@ public class ApiListingResourceTest {
     }
 
     @Test
-    public void shouldHandleNullServletConfig_issue1689() throws JsonProcessingException {
+    public void shouldHandleNullServletConfig_issue1689() {
         ApiListingResource a = new ApiListingResource();
         try {
             a.getListing(null, null, null, null, "json");
@@ -39,7 +38,7 @@ public class ApiListingResourceTest {
 
     }
     @Test
-    public void shouldHandleErrorServletConfig_issue1691() throws JsonProcessingException {
+    public void shouldHandleErrorServletConfig_issue1691() {
 
         ServletConfig sc = new ServletConfig() {
             @Override


### PR DESCRIPTION
Revert "use custom object mapper to serialize json in order to avoid
null values"

This reverts commit 3ad759596f321ffb195256e045ec5803c00ee53c.

This fixes issue #2320. The original commit is pointless and dangerous,
as it surprisingly overrides the behavior of SwaggerSerializers.java,
but does essentially the same (but without supporting pretty printing).