### PR TITLE
Hibernate validator version has been updated

### DIFF
--- a/modules/swagger-hibernate-validations/pom.xml
+++ b/modules/swagger-hibernate-validations/pom.xml
@@ -63,7 +63,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
+            <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate-validator-version}</version>
             <scope>provided</scope>
@@ -87,7 +87,7 @@
         </dependency>
     </dependencies>
     <properties>
-        <hibernate-validator-version>5.1.3.Final</hibernate-validator-version>
+        <hibernate-validator-version>6.0.2.Final</hibernate-validator-version>
         <!-- TODO increase coverage and remove these overrides-->
         <coverage.complexity.minimum>0.50</coverage.complexity.minimum>
         <coverage.line.minimum>0.90</coverage.line.minimum>


### PR DESCRIPTION
...as internally it uses latest version of validation-api - 2.0.0.Final