### PR TITLE
Support fluent interface for extensions

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/Components.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/Components.java
@@ -335,6 +335,11 @@ public class Components {
     this.extensions = extensions;
   }
 
+  public Components extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/ExternalDocumentation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/ExternalDocumentation.java
@@ -104,6 +104,11 @@ public class ExternalDocumentation {
     this.extensions = extensions;
   }
 
+  public ExternalDocumentation extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/OpenAPI.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/OpenAPI.java
@@ -291,6 +291,11 @@ public class OpenAPI {
     this.extensions = extensions;
   }
 
+  public OpenAPI extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/Operation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/Operation.java
@@ -356,6 +356,11 @@ public class Operation {
     this.extensions = extensions;
   }
 
+  public Operation extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/PathItem.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/PathItem.java
@@ -381,6 +381,11 @@ public class PathItem {
         this.extensions = extensions;
     }
 
+    public PathItem extensions(java.util.Map<String, Object> extensions) {
+      this.extensions = extensions;
+      return this;
+    }
+
     /**
      * returns the ref property from a PathItem instance.
      *

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/Paths.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/Paths.java
@@ -16,8 +16,8 @@
 
 package io.swagger.oas.models;
 
-import java.util.Objects;
 import java.util.LinkedHashMap;
+import java.util.Objects;
 
 /**
  * Paths
@@ -67,6 +67,11 @@ public class Paths extends LinkedHashMap<String, PathItem> {
 
   public void setExtensions(java.util.Map<String, Object> extensions) {
     this.extensions = extensions;
+  }
+
+  public Paths extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
   }
 
   @Override

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/callbacks/Callback.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/callbacks/Callback.java
@@ -16,9 +16,10 @@
 
 package io.swagger.oas.models.callbacks;
 
-import java.util.Objects;
 import io.swagger.oas.models.PathItem;
+
 import java.util.LinkedHashMap;
+import java.util.Objects;
 
 /**
  * Callback
@@ -68,6 +69,11 @@ public class Callback extends LinkedHashMap<String, PathItem> {
 
   public void setExtensions(java.util.Map<String, Object> extensions) {
     this.extensions = extensions;
+  }
+
+  public Callback extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
   }
 
   @Override

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/examples/Example.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/examples/Example.java
@@ -136,6 +136,11 @@ public class Example {
         this.extensions = extensions;
     }
 
+    public Example extensions(java.util.Map<String, Object> extensions) {
+        this.extensions = extensions;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/headers/Header.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/headers/Header.java
@@ -20,9 +20,7 @@ import io.swagger.oas.models.examples.Example;
 import io.swagger.oas.models.media.Content;
 import io.swagger.oas.models.media.Schema;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -306,6 +304,11 @@ public class Header {
 
   public void setExtensions(java.util.Map<String, Object> extensions) {
     this.extensions = extensions;
+  }
+
+  public Header extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
   }
 
   public String get$ref() {

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/info/Contact.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/info/Contact.java
@@ -125,6 +125,11 @@ public class Contact {
     this.extensions = extensions;
   }
 
+  public Contact extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/info/Info.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/info/Info.java
@@ -187,6 +187,11 @@ public class Info {
     this.extensions = extensions;
   }
 
+  public Info extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/info/License.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/info/License.java
@@ -104,6 +104,11 @@ public class License {
     this.extensions = extensions;
   }
 
+  public License extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/links/Link.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/links/Link.java
@@ -256,6 +256,11 @@ public class Link {
         this.extensions = extensions;
     }
 
+    public Link extensions(java.util.Map<String, Object> extensions) {
+        this.extensions = extensions;
+        return this;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/links/LinkParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/links/LinkParameter.java
@@ -78,6 +78,11 @@ public class LinkParameter {
     this.extensions = extensions;
   }
 
+  public LinkParameter extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/media/Encoding.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/media/Encoding.java
@@ -136,6 +136,11 @@ public class Encoding {
         this.extensions = extensions;
     }
 
+    public Encoding extensions(java.util.Map<String, Object> extensions) {
+        this.extensions = extensions;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "Encoding{" +

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/media/EncodingProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/media/EncodingProperty.java
@@ -203,6 +203,11 @@ public class EncodingProperty {
     this.extensions = extensions;
   }
 
+  public EncodingProperty extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/media/MediaType.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/media/MediaType.java
@@ -166,6 +166,11 @@ public class MediaType {
     this.extensions = extensions;
   }
 
+  public MediaType extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/media/Schema.java
@@ -809,6 +809,11 @@ public class Schema<T> {
         this.extensions = extensions;
     }
 
+    public Schema<T> extensions(java.util.Map<String, Object> extensions) {
+        this.extensions = extensions;
+        return this;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/media/XML.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/media/XML.java
@@ -167,6 +167,11 @@ public class XML {
     this.extensions = extensions;
   }
 
+  public XML extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/parameters/Parameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/parameters/Parameter.java
@@ -393,6 +393,11 @@ public class Parameter {
         this.extensions = extensions;
     }
 
+    public Parameter extensions(java.util.Map<String, Object> extensions) {
+        this.extensions = extensions;
+        return this;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/parameters/RequestBody.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/parameters/RequestBody.java
@@ -104,6 +104,11 @@ public class RequestBody {
     this.extensions = extensions;
   }
 
+  public RequestBody extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   public String get$ref() {
     return $ref;
   }

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/responses/ApiResponse.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/responses/ApiResponse.java
@@ -187,6 +187,11 @@ public class ApiResponse {
         this.extensions = extensions;
     }
 
+    public ApiResponse extensions(java.util.Map<String, Object> extensions) {
+        this.extensions = extensions;
+        return this;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/security/OAuthFlow.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/security/OAuthFlow.java
@@ -146,6 +146,11 @@ public class OAuthFlow {
     this.extensions = extensions;
   }
 
+  public OAuthFlow extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/security/OAuthFlows.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/security/OAuthFlows.java
@@ -146,6 +146,11 @@ public class OAuthFlows {
     this.extensions = extensions;
   }
 
+  public OAuthFlows extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/security/Scopes.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/security/Scopes.java
@@ -16,8 +16,8 @@
 
 package io.swagger.oas.models.security;
 
-import java.util.Objects;
 import java.util.LinkedHashMap;
+import java.util.Objects;
 
 /**
  * Scopes
@@ -67,6 +67,11 @@ public class Scopes extends LinkedHashMap<String, String> {
 
   public void setExtensions(java.util.Map<String, Object> extensions) {
     this.extensions = extensions;
+  }
+
+  public Scopes extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
   }
 
   @Override

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/security/SecurityScheme.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/security/SecurityScheme.java
@@ -246,6 +246,11 @@ public class SecurityScheme {
         this.extensions = extensions;
     }
 
+    public SecurityScheme extensions(java.util.Map<String, Object> extensions) {
+        this.extensions = extensions;
+        return this;
+    }
+
     /**
      * returns the $ref property from an SecurityScheme instance.
      *

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/servers/Server.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/servers/Server.java
@@ -125,6 +125,11 @@ public class Server {
     this.extensions = extensions;
   }
 
+  public Server extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/servers/ServerVariable.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/servers/ServerVariable.java
@@ -16,9 +16,9 @@
 
 package io.swagger.oas.models.servers;
 
-import java.util.Objects;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * ServerVariable
@@ -133,6 +133,11 @@ public class ServerVariable {
 
   public void setExtensions(java.util.Map<String, Object> extensions) {
     this.extensions = extensions;
+  }
+
+  public ServerVariable extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
   }
 
   @Override

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/servers/ServerVariables.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/servers/ServerVariables.java
@@ -16,8 +16,8 @@
 
 package io.swagger.oas.models.servers;
 
-import java.util.Objects;
 import java.util.LinkedHashMap;
+import java.util.Objects;
 
 /**
  * ServerVariables
@@ -67,6 +67,11 @@ public class ServerVariables extends LinkedHashMap<String, ServerVariable> {
 
   public void setExtensions(java.util.Map<String, Object> extensions) {
     this.extensions = extensions;
+  }
+
+  public ServerVariables extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
   }
 
   @Override

--- a/modules/swagger-models/src/main/java/io/swagger/oas/models/tags/Tag.java
+++ b/modules/swagger-models/src/main/java/io/swagger/oas/models/tags/Tag.java
@@ -127,6 +127,11 @@ public class Tag {
     this.extensions = extensions;
   }
 
+  public Tag extensions(java.util.Map<String, Object> extensions) {
+    this.extensions = extensions;
+    return this;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();

--- a/modules/swagger-models/src/test/java/io/swagger/test/SimpleBuilderTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/test/SimpleBuilderTest.java
@@ -46,7 +46,8 @@ public class SimpleBuilderTest {
                                 .url("http://swagger.io"))
                         .addTagsItem(new Tag()
                                 .name("funky dunky")
-                                .description("all about neat things"));
+                                .description("all about neat things"))
+                        .extensions(new HashMap<String, Object>() {{ put("x-fancy-extension", "something"); }});
 
         Map<String, Schema> schemas = new HashMap<>();
 


### PR DESCRIPTION
Made extension configuration consistent with other properties. Extensions can now be set with the fluent builder interface, e.g.:

```java
new Operation().extensions(...).responses(...);
```