### PR TITLE
add extensions to api model property

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModelProperty.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/annotations/ApiModelProperty.java
@@ -111,4 +111,9 @@ public @interface ApiModelProperty {
      * @since 1.5.11
      */
     boolean allowEmptyValue() default false;
+
+    /**
+     * @return an optional array of extensions
+     */
+    Extension[] extensions() default @Extension(properties = @ExtensionProperty(name = "", value = ""));
 }

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -1,5 +1,35 @@
 package io.swagger.jackson;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlSchema;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -20,6 +50,7 @@ import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.google.common.collect.Iterables;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.converter.ModelConverter;
@@ -40,36 +71,9 @@ import io.swagger.models.properties.StringProperty;
 import io.swagger.models.properties.UUIDProperty;
 import io.swagger.util.AllowableValues;
 import io.swagger.util.AllowableValuesUtils;
+import io.swagger.util.BaseReaderUtils;
 import io.swagger.util.PrimitiveType;
 import io.swagger.util.ReflectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSchema;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public class ModelResolver extends AbstractModelConverter implements ModelConverter {
     Logger LOGGER = LoggerFactory.getLogger(ModelResolver.class);
@@ -506,6 +510,12 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                             PropertyBuilder.merge(property, args);
                         }
                     }
+
+                    if (mp != null && mp.extensions() != null) {
+                        property.getVendorExtensions().clear();
+                        property.getVendorExtensions().putAll(BaseReaderUtils.parseExtensions(mp.extensions()));
+                    }
+
                     JAXBAnnotationsHelper.apply(member, property);
                     applyBeanValidatorAnnotations(property, annotations);
                     props.add(property);

--- a/modules/swagger-core/src/test/java/io/swagger/ModelPropertyExtensionTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ModelPropertyExtensionTest.java
@@ -1,0 +1,54 @@
+package io.swagger;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.annotations.Extension;
+import io.swagger.annotations.ExtensionProperty;
+import io.swagger.converter.ModelConverters;
+import io.swagger.models.Model;
+import io.swagger.models.properties.LongProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
+
+public class ModelPropertyExtensionTest {
+    @Test(description = "it should parse extensions on a model property")
+    public void testHiddenField() {
+        final Map<String, Model> models = ModelConverters.getInstance().read(ModelWithHiddenFields.class);
+
+        final Model model = models.get("ModelWithHiddenFields");
+        assertNotNull(model);
+        assertEquals(model.getProperties().size(), 3);
+
+        final Property idValue = model.getProperties().get("id");
+        assertTrue(idValue instanceof LongProperty);
+        assertTrue(idValue.getRequired());
+
+        final Property nameValue = model.getProperties().get("name");
+        assertTrue(nameValue instanceof StringProperty);
+        assertEquals(nameValue.getVendorExtensions(), Collections.<String, Object>emptyMap());
+
+
+        final Property extendedValue = model.getProperties().get("extended");
+        assertTrue(extendedValue instanceof StringProperty);
+        assertEquals(extendedValue.getVendorExtensions().get("x-proprietary"), "corporate");
+    }
+
+    class ModelWithHiddenFields {
+        @ApiModelProperty(required = true)
+        public Long id = null;
+
+        @ApiModelProperty(required = true, hidden = false, extensions = @Extension(properties = {}))
+        public String name = null;
+
+        @ApiModelProperty(required = true, extensions = @Extension(properties = {@ExtensionProperty(name = "x-proprietary", value = "corporate")}))
+        public String extended = null;
+    }
+}


### PR DESCRIPTION
Hi,

OpenAPI Spec allows vendor extensions on API model property level. (see https://github.com/OAI/OpenAPI-Specification/issues/241)
I added these to the `@ApiModelProperty` annotation, extended the model resolver and added a test.

I am looking forward to your feedback!

Regards,

Tobi