### PR TITLE
Support the JsonValue annotation

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/oas/models/JsonValueModel.java
+++ b/modules/swagger-core/src/test/java/io/swagger/oas/models/JsonValueModel.java
@@ -1,0 +1,61 @@
+/**
+ * (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.swagger.oas.models;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@XmlRootElement
+public class JsonValueModel {
+    public ValueBean value;
+    public InnerBean inner;
+    public ListBean list;
+    
+    public static class ValueBean {
+        @JsonValue
+        public String getString(){
+            return "string";
+        }
+        
+        public int getInt() {
+            // Should be ignored due to JsonValue annotation on other method.
+            return 0;
+        }
+    }
+
+    public static class InnerBean {
+        @JsonValue
+        public ComplexBean getComplexBean() {
+            return new ComplexBean();
+        }
+    }
+    
+    public static class ComplexBean {
+        public int count;
+        public String name;
+    }
+    
+    public static class ListBean {
+        @JsonValue
+        List<String> getList() {
+            return new ArrayList<String>();
+        }
+    }
+}


### PR DESCRIPTION
Currently the very useful `@JsonValue` annotation isn't supported by swagger-core. Schemas generated by swagger core will **not** be correct for the output of serializing models making use of this annotation.

https://fasterxml.github.io/jackson-annotations/javadoc/2.0.0/com/fasterxml/jackson/annotation/JsonValue.html

"Marker annotation similar to XmlValue that indicates that results of the annotated "getter" method (which means signature must be that of getters; non-void return type, no args) is to be used as the single value to serialize for the instance. Usually value will be of a simple scalar type (String or Number), but it can be any serializable type (Collection, Map or Bean). "

e.g. if you have these classes
```
public class A {
    public B b = B();
}
public class B {
    @JsonValue
    public string getValue() {
        return "value";
    }
}
```
`A` would **not** marshal to `{"b": {"value":"value"}}` but just to `{"b":"value"}`.

This PR attempts to add support for `@JsonValue` to swagger-core 2.x. It would be difficult to add to 1.x without a certain amount of refactoring due to the difference between `Property` and `Model`.