### PR TITLE
#2466 retain generic types for attributes of BeanParam

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
@@ -125,7 +125,7 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
      */
     private void handleAdditionalAnnotation(List<Parameter> parameters, Annotation annotation, 
         final Type type, Set<Type> typesToSkip) {
-        if (CLASS_BEAN_PARAM != null && CLASS_BEAN_PARAM.isAssignableFrom(annotation.getClass())) {
+        if (shouldHandleAdditionalAnnotation(annotation)) {
             // Use Jackson's logic for processing Beans
             final BeanDescription beanDesc = mapper.getSerializationConfig().introspect(constructType(type));
             final List<BeanPropertyDefinition> properties = beanDesc.findProperties();
@@ -194,6 +194,10 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
                 }
             }
         }
+    }
+    
+    protected boolean shouldHandleAdditionalAnnotation(Annotation annotation) {
+        return CLASS_BEAN_PARAM != null && CLASS_BEAN_PARAM.isAssignableFrom(annotation.getClass());
     }
 
     @Override

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
@@ -140,7 +140,7 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
 
                 // Gather the field's details
                 if (field != null) {
-                    paramType = field.getRawType();
+                    paramType = field.getType();
 
                     for (final Annotation fieldAnnotation : field.annotations()) {
                         if (!paramAnnotations.contains(fieldAnnotation)) {
@@ -153,7 +153,8 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
                 if (setter != null) {
                     // Do not set the param class/type from the setter if the values are already identified
                     if (paramType == null) {
-                        paramType = setter.getRawParameterTypes() != null ? setter.getRawParameterTypes()[0] : null;
+                    	// paramType will stay null if there is no parameter
+                        paramType = setter.getParameterType(0); 
                     }
 
                     for (final Annotation fieldAnnotation : setter.annotations()) {
@@ -167,7 +168,7 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
                 if (getter != null) {
                     // Do not set the param class/type from the getter if the values are already identified
                     if (paramType == null) {
-                        paramType = getter.getRawReturnType();
+                        paramType = getter.getType();
                     }
 
                     for (final Annotation fieldAnnotation : getter.annotations()) {

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/BeanParamTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/BeanParamTest.java
@@ -16,8 +16,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 import io.swagger.annotations.Api;
 import io.swagger.jaxrs.DefaultParameterExtension;
 import io.swagger.jaxrs.Reader;
@@ -29,58 +27,56 @@ import io.swagger.models.parameters.Parameter;
 import io.swagger.models.parameters.QueryParameter;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
-import io.swagger.util.Yaml;
 
 public class BeanParamTest {
 
-    @Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
-    @Retention(RetentionPolicy.RUNTIME)
-    public @interface MyBeanParam {
-        // Remove this Annotation and use BeanParam directly with Swagger Core 2.0
-    }
+	@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
+	@Retention(RetentionPolicy.RUNTIME)
+	public @interface MyBeanParam {
+		// Remove this Annotation and use BeanParam directly with Swagger Core 2.0
+	}
 
-    @Api
-    @Path("/")
-    private static class MyBeanParamResource {
-        @GET
-        public String getWithBeanParam(@MyBeanParam ListOfStringsBeanParam listOfStringsBean) {
-            return "result";
-        }
-    }
+	@Api
+	@Path("/")
+	private static class MyBeanParamResource {
+		@GET
+		public String getWithBeanParam(@MyBeanParam ListOfStringsBeanParam listOfStringsBean) {
+			return "result";
+		}
+	}
 
-    private final SwaggerExtension myDefaultParameterExtension = new DefaultParameterExtension() {
-        @Override
-        protected boolean shouldHandleAdditionalAnnotation(Annotation annotation) {
-            return annotation instanceof MyBeanParam;
-        }
-    };
+	private final SwaggerExtension myDefaultParameterExtension = new DefaultParameterExtension() {
+		@Override
+		protected boolean shouldHandleAdditionalAnnotation(Annotation annotation) {
+			return annotation instanceof MyBeanParam;
+		}
+	};
 
-    private List<SwaggerExtension> originalExtensions;
+	private List<SwaggerExtension> originalExtensions;
 
-    @BeforeMethod
-    public void beforeMethod() {
-        originalExtensions = SwaggerExtensions.getExtensions();
-        SwaggerExtensions.setExtensions(Collections.singletonList(myDefaultParameterExtension));
-    }
+	@BeforeMethod
+	public void beforeMethod() {
+		originalExtensions = SwaggerExtensions.getExtensions();
+		SwaggerExtensions.setExtensions(Collections.singletonList(myDefaultParameterExtension));
+	}
 
-    @AfterMethod
-    public void afterMethod() {
-        SwaggerExtensions.setExtensions(originalExtensions);
-    }
+	@AfterMethod
+	public void afterMethod() {
+		SwaggerExtensions.setExtensions(originalExtensions);
+	}
 
-    @Test(description = "check array type of serialized BeanParam containing QueryParams") // tests issue #2466
-    public void shouldSerializeTypeParameter() throws JsonProcessingException {
-        Swagger swagger = new Reader(new Swagger()).read(MyBeanParamResource.class);
-        System.out.println(Yaml.mapper().writeValueAsString(swagger));
-        List<Parameter> getOperationParams = swagger.getPath("/").getGet().getParameters();
-        Assert.assertEquals(1, getOperationParams.size());
-        QueryParameter param = (QueryParameter) getOperationParams.get(0);
-        Assert.assertEquals("listOfStrings", param.getName());
-        Assert.assertEquals("array", param.getType());
-        // These are the important checks:
-        Property itemsProperty = param.getItems();
-        Assert.assertTrue(itemsProperty instanceof StringProperty);
-        Assert.assertEquals("string", itemsProperty.getType());
-    }
+	@Test(description = "check array type of serialized BeanParam containing QueryParams") // tests issue #2466
+	public void shouldSerializeTypeParameter() {
+		Swagger swagger = new Reader(new Swagger()).read(MyBeanParamResource.class);
+		List<Parameter> getOperationParams = swagger.getPath("/").getGet().getParameters();
+		Assert.assertEquals(getOperationParams.size(), 1);
+		QueryParameter param = (QueryParameter) getOperationParams.get(0);
+		Assert.assertEquals(param.getName(), "listOfStrings");
+		Assert.assertEquals(param.getType(), "array");
+		// These are the important checks:
+		Property itemsProperty = param.getItems();
+		Assert.assertEquals(itemsProperty.getClass(), StringProperty.class);
+		Assert.assertEquals(itemsProperty.getType(), "string");
+	}
 
 }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/BeanParamTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/BeanParamTest.java
@@ -1,0 +1,86 @@
+package io.swagger;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Collections;
+import java.util.List;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.swagger.annotations.Api;
+import io.swagger.jaxrs.DefaultParameterExtension;
+import io.swagger.jaxrs.Reader;
+import io.swagger.jaxrs.ext.SwaggerExtension;
+import io.swagger.jaxrs.ext.SwaggerExtensions;
+import io.swagger.models.ListOfStringsBeanParam;
+import io.swagger.models.Swagger;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.parameters.QueryParameter;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.util.Yaml;
+
+public class BeanParamTest {
+
+    @Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface MyBeanParam {
+        // Remove this Annotation and use BeanParam directly with Swagger Core 2.0
+    }
+
+    @Api
+    @Path("/")
+    private static class MyBeanParamResource {
+        @GET
+        public String getWithBeanParam(@MyBeanParam ListOfStringsBeanParam listOfStringsBean) {
+            return "result";
+        }
+    }
+
+    private final SwaggerExtension myDefaultParameterExtension = new DefaultParameterExtension() {
+        @Override
+        protected boolean shouldHandleAdditionalAnnotation(Annotation annotation) {
+            return annotation instanceof MyBeanParam;
+        }
+    };
+
+    private List<SwaggerExtension> originalExtensions;
+
+    @BeforeMethod
+    public void beforeMethod() {
+        originalExtensions = SwaggerExtensions.getExtensions();
+        SwaggerExtensions.setExtensions(Collections.singletonList(myDefaultParameterExtension));
+    }
+
+    @AfterMethod
+    public void afterMethod() {
+        SwaggerExtensions.setExtensions(originalExtensions);
+    }
+
+    @Test(description = "check array type of serialized BeanParam containing QueryParams") // tests issue #2466
+    public void shouldSerializeTypeParameter() throws JsonProcessingException {
+        Swagger swagger = new Reader(new Swagger()).read(MyBeanParamResource.class);
+        System.out.println(Yaml.mapper().writeValueAsString(swagger));
+        List<Parameter> getOperationParams = swagger.getPath("/").getGet().getParameters();
+        Assert.assertEquals(1, getOperationParams.size());
+        QueryParameter param = (QueryParameter) getOperationParams.get(0);
+        Assert.assertEquals("listOfStrings", param.getName());
+        Assert.assertEquals("array", param.getType());
+        // These are the important checks:
+        Property itemsProperty = param.getItems();
+        Assert.assertTrue(itemsProperty instanceof StringProperty);
+        Assert.assertEquals("string", itemsProperty.getType());
+    }
+
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/BeanParamTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/BeanParamTest.java
@@ -30,53 +30,53 @@ import io.swagger.models.properties.StringProperty;
 
 public class BeanParamTest {
 
-	@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
-	@Retention(RetentionPolicy.RUNTIME)
-	public @interface MyBeanParam {
-		// Remove this Annotation and use BeanParam directly with Swagger Core 2.0
-	}
+    @Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface MyBeanParam {
+        // Remove this Annotation and use BeanParam directly with Swagger Core 2.0
+    }
 
-	@Api
-	@Path("/")
-	private static class MyBeanParamResource {
-		@GET
-		public String getWithBeanParam(@MyBeanParam ListOfStringsBeanParam listOfStringsBean) {
-			return "result";
-		}
-	}
+    @Api
+    @Path("/")
+    private static class MyBeanParamResource {
+        @GET
+        public String getWithBeanParam(@MyBeanParam ListOfStringsBeanParam listOfStringsBean) {
+            return "result";
+        }
+    }
 
-	private final SwaggerExtension myDefaultParameterExtension = new DefaultParameterExtension() {
-		@Override
-		protected boolean shouldHandleAdditionalAnnotation(Annotation annotation) {
-			return annotation instanceof MyBeanParam;
-		}
-	};
+    private final SwaggerExtension myDefaultParameterExtension = new DefaultParameterExtension() {
+        @Override
+        protected boolean shouldHandleAdditionalAnnotation(Annotation annotation) {
+            return annotation instanceof MyBeanParam;
+        }
+    };
 
-	private List<SwaggerExtension> originalExtensions;
+    private List<SwaggerExtension> originalExtensions;
 
-	@BeforeMethod
-	public void beforeMethod() {
-		originalExtensions = SwaggerExtensions.getExtensions();
-		SwaggerExtensions.setExtensions(Collections.singletonList(myDefaultParameterExtension));
-	}
+    @BeforeMethod
+    public void beforeMethod() {
+        originalExtensions = SwaggerExtensions.getExtensions();
+        SwaggerExtensions.setExtensions(Collections.singletonList(myDefaultParameterExtension));
+    }
 
-	@AfterMethod
-	public void afterMethod() {
-		SwaggerExtensions.setExtensions(originalExtensions);
-	}
+    @AfterMethod
+    public void afterMethod() {
+        SwaggerExtensions.setExtensions(originalExtensions);
+    }
 
-	@Test(description = "check array type of serialized BeanParam containing QueryParams") // tests issue #2466
-	public void shouldSerializeTypeParameter() {
-		Swagger swagger = new Reader(new Swagger()).read(MyBeanParamResource.class);
-		List<Parameter> getOperationParams = swagger.getPath("/").getGet().getParameters();
-		Assert.assertEquals(getOperationParams.size(), 1);
-		QueryParameter param = (QueryParameter) getOperationParams.get(0);
-		Assert.assertEquals(param.getName(), "listOfStrings");
-		Assert.assertEquals(param.getType(), "array");
-		// These are the important checks:
-		Property itemsProperty = param.getItems();
-		Assert.assertEquals(itemsProperty.getClass(), StringProperty.class);
-		Assert.assertEquals(itemsProperty.getType(), "string");
-	}
+    @Test(description = "check array type of serialized BeanParam containing QueryParams") // tests issue #2466
+    public void shouldSerializeTypeParameter() {
+        Swagger swagger = new Reader(new Swagger()).read(MyBeanParamResource.class);
+        List<Parameter> getOperationParams = swagger.getPath("/").getGet().getParameters();
+        Assert.assertEquals(getOperationParams.size(), 1);
+        QueryParameter param = (QueryParameter) getOperationParams.get(0);
+        Assert.assertEquals(param.getName(), "listOfStrings");
+        Assert.assertEquals(param.getType(), "array");
+        // These are the important checks:
+        Property itemsProperty = param.getItems();
+        Assert.assertEquals(itemsProperty.getClass(), StringProperty.class);
+        Assert.assertEquals(itemsProperty.getType(), "string");
+    }
 
 }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/models/ListOfStringsBeanParam.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/models/ListOfStringsBeanParam.java
@@ -1,0 +1,21 @@
+package io.swagger.models;
+
+import java.util.List;
+
+import javax.ws.rs.QueryParam;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+public class ListOfStringsBeanParam {
+    @QueryParam(value = "listOfStrings")
+    private List<String> list;
+
+    public List<String> getList() {
+        return list;
+    }
+
+    public void setList(List<String> list) {
+        this.list = list;
+    }
+}


### PR DESCRIPTION
As described in #2466, this pull request will fix the wrong schema generation if BeanParams with generic attributes are used. The bug was originally introduced by commit 26f9572a6a92cd2375ef876baabe8667dbbf9dcd.