### PR TITLE
#2466 retain generic types for attributes of BeanParam

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/jaxrs2/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/jaxrs2/DefaultParameterExtension.java
@@ -114,7 +114,7 @@ public class DefaultParameterExtension extends AbstractOpenAPIExtension {
 
                 // Gather the field's details
                 if (field != null) {
-                    paramType = field.getRawType();
+                	paramType = field.getType();
 
                     for (final Annotation fieldAnnotation : field.annotations()) {
                         if (!paramAnnotations.contains(fieldAnnotation)) {
@@ -127,7 +127,8 @@ public class DefaultParameterExtension extends AbstractOpenAPIExtension {
                 if (setter != null) {
                     // Do not set the param class/type from the setter if the values are already identified
                     if (paramType == null) {
-                        paramType = setter.getRawParameterTypes() != null ? setter.getRawParameterTypes()[0] : null;
+                    	// paramType will stay null if there is no parameter
+                    	paramType = setter.getParameterType(0); 
                     }
 
                     for (final Annotation fieldAnnotation : setter.annotations()) {
@@ -141,7 +142,7 @@ public class DefaultParameterExtension extends AbstractOpenAPIExtension {
                 if (getter != null) {
                     // Do not set the param class/type from the getter if the values are already identified
                     if (paramType == null) {
-                        paramType = getter.getRawReturnType();
+                        paramType = getter.getType();
                     }
 
                     for (final Annotation fieldAnnotation : getter.annotations()) {


### PR DESCRIPTION
As described in #2466, this pull request will fix the wrong schema generation if BeanParams with generic attributes are used. The bug was originally introduced by commit 26f9572.

This is the pull request for the 2.0 branch.