### PR TITLE
Use dynamic port number for integration test

### DIFF
--- a/modules/swagger-jaxrs/pom.xml
+++ b/modules/swagger-jaxrs/pom.xml
@@ -49,6 +49,26 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <portNames>
+                        <portName>jetty.port</portName>
+                        <portName>jetty.port.stop</portName>
+                    </portNames>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>reserve-port</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>reserve-network-port</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${failsafe-plugin-version}</version>
@@ -58,17 +78,24 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <jetty.port>${jetty.port}</jetty.port>
+                            </systemPropertyVariables>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty-version}</version>
                 <configuration>
                     <scanIntervalSeconds>10</scanIntervalSeconds>
+                    <httpConnector><port>${jetty.port}</port></httpConnector>
                     <stopKey>a</stopKey>
-                    <stopPort>9999</stopPort>
+                    <stopPort>${jetty.port.stop}</stopPort>
                     <useTestScope>true</useTestScope>
                     <webAppSourceDirectory>${project.basedir}/src/test/webapp</webAppSourceDirectory>
                 </configuration>

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/functional/test/ApiListingResourceIT.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/functional/test/ApiListingResourceIT.java
@@ -1,6 +1,9 @@
 package io.swagger.functional.test;
 
 import com.jayway.restassured.http.ContentType;
+
+import org.testng.SkipException;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static com.jayway.restassured.RestAssured.given;
@@ -51,9 +54,20 @@ public class ApiListingResourceIT {
             "      id:\n" +
             "        type: \"string\"\n";
 
+    private static final int jettyPort = System.getProperties().containsKey("jetty.port") ? Integer.parseInt(System.getProperty("jetty.port")): -1;
+
+    @BeforeMethod
+    public void checkJetty() {
+        if (jettyPort == -1) {
+            throw new SkipException("Jetty not configured");
+        }
+    }
+
     @Test
     public void testSwaggerJson() throws Exception {
+
         String actualBody = given()
+                .port(jettyPort)
                 .log().all()
                 .when()
                 .get("/swagger.json")
@@ -71,6 +85,7 @@ public class ApiListingResourceIT {
     @Test
     public void testSwaggerJsonUsingAcceptHeader() throws Exception {
         String actualBody = given()
+                .port(jettyPort)
                 .log().all()
                 .accept(ContentType.JSON)
                 .when()
@@ -88,6 +103,7 @@ public class ApiListingResourceIT {
     @Test
     public void testSwaggerYaml() throws Exception {
         String actualBody = given()
+                .port(jettyPort)
                 .log().all()
                 .when()
                 .get("/swagger.yaml")
@@ -104,6 +120,7 @@ public class ApiListingResourceIT {
     @Test
     public void testSwaggerYamlUsingAcceptHeader() throws Exception {
         String actualBody = given()
+                .port(jettyPort)
                 .log().all()
                 .accept("application/yaml")
                 .when()


### PR DESCRIPTION
Also makes the tests get skipped insted of failing when run from outside of maven.