### PR TITLE
Update commons-lang3, commons-io and joda (2.0 branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -483,8 +483,8 @@
         </dependencies>
     </dependencyManagement>
     <properties>
-        <joda-version>1.2</joda-version>
-        <joda-time-version>2.7</joda-time-version>
+        <joda-version>1.9.2</joda-version>
+        <joda-time-version>2.9.9</joda-time-version>
         <snakeyaml-version>1.18</snakeyaml-version>
         <javax.ws-version>2.1</javax.ws-version>
         <felix-version>2.4.0</felix-version>
@@ -494,8 +494,8 @@
         <logback-version>1.2.3</logback-version>
         <reflections-version>0.9.11</reflections-version>
         <guava-version>23.0</guava-version>
-        <commons-lang-version>3.6</commons-lang-version>
-        <commons-io-version>2.5</commons-io-version>
+        <commons-lang-version>3.7</commons-lang-version>
+        <commons-io-version>2.6</commons-io-version>
         <slf4j-version>1.7.25</slf4j-version>
         <jetty-version>9.4.6.v20170531</jetty-version>
         <testng-version>6.11</testng-version>


### PR DESCRIPTION
there are some bug fixes and better java 9 support