### PR TITLE
ReaderTest Fix (getMethods Order), Reader Fix (Duplicated Operation Id)

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -719,7 +719,7 @@ public class Reader implements OpenApiReader {
 
         // operation id
         if (StringUtils.isBlank(operation.getOperationId())) {
-            operation.setOperationId(method.getName());
+            operation.setOperationId(getOperationId(method.getName()));
         }
 
         if (apiOperation != null) {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.jaxrs2.resources.BasicFieldsResource;
 import io.swagger.v3.jaxrs2.resources.CompleteFieldsResource;
 import io.swagger.v3.jaxrs2.resources.DeprecatedFieldsResource;
 import io.swagger.v3.jaxrs2.resources.DuplicatedOperationIdResource;
+import io.swagger.v3.jaxrs2.resources.DuplicatedOperationMethodNameResource;
 import io.swagger.v3.jaxrs2.resources.DuplicatedSecurityResource;
 import io.swagger.v3.jaxrs2.resources.ExternalDocsReference;
 import io.swagger.v3.jaxrs2.resources.ResponseContentWithArrayResource;
@@ -162,6 +163,27 @@ public class ReaderTest {
         assertNotNull(secondOperation);
         assertNotEquals(firstOperation.getOperationId(), secondOperation.getOperationId());
     }
+
+    @Test(description = "Get a Duplicated Operation Id with same id as method name")
+    public void testResolveDuplicatedOperationIdMethodName() {
+        Reader reader = new Reader(new OpenAPI());
+        OpenAPI openAPI = reader.read(DuplicatedOperationMethodNameResource.class);
+
+        Paths paths = openAPI.getPaths();
+        assertNotNull(paths);
+        Operation firstOperation = paths.get("/1").getGet();
+        Operation secondOperation = paths.get("/2").getGet();
+        assertNotNull(firstOperation);
+        assertNotNull(secondOperation);
+        assertNotEquals(firstOperation.getOperationId(), secondOperation.getOperationId());
+        Operation thirdOperation = paths.get("/3").getGet();
+        Operation fourthOperation = paths.get("/4").getGet();
+        assertNotNull(thirdOperation);
+        assertNotNull(fourthOperation);
+        assertNotEquals(thirdOperation.getOperationId(), fourthOperation.getOperationId());
+
+    }
+
 
     @Test(description = "Test a Set of classes")
     public void testSetOfClasses() {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -130,7 +130,6 @@ public class ReaderTest {
     @Test(description = "scan methods")
     public void testScanMethods() {
         Reader reader = new Reader(new OpenAPI());
-        OpenAPI openAPI = reader.read(SimpleMethods.class);
         Method[] methods = SimpleMethods.class.getMethods();
         for (final Method method : methods) {
             if (isValidRestPath(method)) {
@@ -259,8 +258,9 @@ public class ReaderTest {
     @Test(description = "Security Requirement")
     public void testSecurityRequirement() {
         Reader reader = new Reader(new OpenAPI());
-        Method[] methods = SecurityResource.class.getMethods();
-        Operation securityOperation = reader.parseMethod(methods[0], null);
+        Method[] methods = SecurityResource.class.getDeclaredMethods();
+        Operation securityOperation = reader.parseMethod(Arrays.stream(methods).filter(
+                (method -> method.getName().equals("getSecurity"))).findFirst().get(), null);
         assertNotNull(securityOperation);
         List<SecurityRequirement> securityRequirements = securityOperation.getSecurity();
         assertNotNull(securityRequirements);

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/DuplicatedOperationMethodNameResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/DuplicatedOperationMethodNameResource.java
@@ -1,0 +1,38 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.Operation;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+public class DuplicatedOperationMethodNameResource {
+
+    @GET
+    @Path("/1")
+    @Operation(operationId = "getSummaryAndDescription2",
+            summary = "Operation Summary",
+            description = "Operation Description")
+    public Response getSummaryAndDescription1() {
+        return Response.ok().entity("ok").build();
+    }
+
+    @GET
+    @Path("/2")
+    public Response getSummaryAndDescription2() {
+        return Response.ok().entity("ok").build();
+    }
+
+    @GET
+    @Path("/3")
+    public Response getSummaryAndDescription3() {
+        return Response.ok().entity("ok").build();
+    }
+
+    @GET
+    @Path("/4")
+    public Response getSummaryAndDescription3(String foo) {
+        return Response.ok().entity("ok").build();
+    }
+
+}


### PR DESCRIPTION
Duplicated Operation Id when it was generated automatically by the method name.