### PR TITLE
Immutable collections issue (2.0 branch)

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
@@ -113,7 +113,11 @@ public class OpenAPI {
     }
 
     public void setServers(List<Server> servers) {
-        this.servers = new ArrayList<>(servers);
+        if (servers == null) {
+            this.servers = null;
+        } else {
+            this.servers = new ArrayList<>(servers);
+        }
     }
 
     public OpenAPI servers(List<Server> servers) {
@@ -140,7 +144,11 @@ public class OpenAPI {
     }
 
     public void setSecurity(List<SecurityRequirement> security) {
-        this.security = new ArrayList<>(security);
+        if (security == null) {
+            this.security = null;
+        } else {
+            this.security = new ArrayList<>(security);
+        }
     }
 
     public OpenAPI security(List<SecurityRequirement> security) {
@@ -167,7 +175,11 @@ public class OpenAPI {
     }
 
     public void setTags(List<Tag> tags) {
-        this.tags = new ArrayList<>(tags);
+        if (tags == null) {
+            this.tags = null;
+        } else {
+            this.tags = new ArrayList<>(tags);
+        }
     }
 
     public OpenAPI tags(List<Tag> tags) {
@@ -287,7 +299,11 @@ public class OpenAPI {
     }
 
     public void setExtensions(java.util.Map<String, Object> extensions) {
-        this.extensions = new HashMap<>(extensions);
+        if (extensions == null) {
+            this.extensions = null;
+        } else {
+            this.extensions = new HashMap<>(extensions);
+        }
     }
 
     public OpenAPI extensions(java.util.Map<String, Object> extensions) {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -112,11 +113,11 @@ public class OpenAPI {
     }
 
     public void setServers(List<Server> servers) {
-        this.servers = servers;
+        this.servers = new ArrayList<>(servers);
     }
 
     public OpenAPI servers(List<Server> servers) {
-        this.servers = servers;
+        setServers(servers);
         return this;
     }
 
@@ -139,11 +140,11 @@ public class OpenAPI {
     }
 
     public void setSecurity(List<SecurityRequirement> security) {
-        this.security = security;
+        this.security = new ArrayList<>(security);
     }
 
     public OpenAPI security(List<SecurityRequirement> security) {
-        this.security = security;
+        setSecurity(security);
         return this;
     }
 
@@ -166,11 +167,11 @@ public class OpenAPI {
     }
 
     public void setTags(List<Tag> tags) {
-        this.tags = tags;
+        this.tags = new ArrayList<>(tags);
     }
 
     public OpenAPI tags(List<Tag> tags) {
-        this.tags = tags;
+        setTags(tags);
         return this;
     }
 
@@ -192,9 +193,7 @@ public class OpenAPI {
         return paths;
     }
 
-    public void setPaths(Paths paths) {
-        this.paths = paths;
-    }
+    public void setPaths(Paths paths) { this.paths = paths; }
 
     public OpenAPI paths(Paths paths) {
         this.paths = paths;
@@ -216,19 +215,18 @@ public class OpenAPI {
     }
 
     public OpenAPI components(Components components) {
-        this.components = components;
+        setComponents(components);
         return this;
     }
 
-  /*
-   * helpers
-   */
+   /*
+    * helpers
+    */
 
     public OpenAPI path(String name, PathItem path) {
         if (this.paths == null) {
             this.paths = new Paths();
         }
-
         this.paths.addPathItem(name, path);
         return this;
     }
@@ -237,7 +235,7 @@ public class OpenAPI {
         if (components == null) {
             this.components = new Components();
         }
-        components.addSchemas(name, schema);
+        this.components.addSchemas(name, schema);
         return this;
     }
 
@@ -245,7 +243,7 @@ public class OpenAPI {
         if (components == null) {
             this.components = new Components();
         }
-        components.addSecuritySchemes(name, securityScheme);
+        this.components.addSecuritySchemes(name, securityScheme);
         return this;
     }
 
@@ -283,17 +281,17 @@ public class OpenAPI {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new HashMap<>();
         }
         this.extensions.put(name, value);
     }
 
     public void setExtensions(java.util.Map<String, Object> extensions) {
-        this.extensions = extensions;
+        this.extensions = new HashMap<>(extensions);
     }
 
     public OpenAPI extensions(java.util.Map<String, Object> extensions) {
-        this.extensions = extensions;
+        setExtensions(extensions);
         return this;
     }
 


### PR DESCRIPTION
I ran into an issue with Swagger 1.5.17 but thought it best to suggest the equivalent change on the 2.0 branch instead.
[swagger-akka-http](https://github.com/swagger-akka-http/swagger-akka-http) uses Scala immutable collections and when they are converted to Java, these collections are immutable too. This means that if you subsequently use an API on OpenAPI class that adds an entry to the collection, it will fail (UnsupportedOperationException).
If these changes look ok, I can extend the Pull Request to add extra test coverage.
I suspect that there are other model classes that allow the setting of collections too and I can also update those classes too.