### PR TITLE
fix #2556 - updated logging for ApiImplicitParam with no datatype defined

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.type.TypeFactory;
@@ -26,6 +27,9 @@ public class ReflectionUtils {
         final PrimitiveType primitive = PrimitiveType.fromName(type);
         if (primitive != null) {
             return primitive.getKeyClass();
+        }
+        if (StringUtils.isBlank(type)) {
+            return null;
         }
         try {
             return loadClassByName(type);

--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -474,6 +474,9 @@ public class Reader {
         }
         final Type type = param.dataTypeClass() == Void.class ? ReflectionUtils.typeFromString(param.dataType())
                 : param.dataTypeClass();
+        if (type == null) {
+            LOGGER.error("no dataType defined for implicit param `{}`! resolved parameter will not have a type defined, and will therefore be not compliant with spec. see https://github.com/swagger-api/swagger-core/issues/2556.", param.name());
+        }
         return ParameterProcessor.applyAnnotations(swagger, p, (type == null) ? String.class : type,
                 Arrays.<Annotation>asList(param));
     }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReaderTest.java
@@ -228,7 +228,7 @@ public class ReaderTest {
         Swagger swagger = getSwagger(ResourceWithImplicitParams.class);
         List<Parameter> params = swagger.getPath("/testString").getPost().getParameters();
         assertNotNull(params);
-        assertEquals(params.size(), 7);
+        assertEquals(params.size(), 8);
 
         assertEquals(params.get(0).getName(), "sort");
         assertEquals(params.get(0).getIn(), "query");
@@ -262,6 +262,13 @@ public class ReaderTest {
         assertEquals(bodyParam.getName(), "body");
         assertEquals(bodyParam.getIn(), "body");
         assertTrue(bodyParam.getRequired());
+
+        queryParam = (QueryParameter) params.get(7);
+        assertEquals(queryParam.getName(), "description");
+        assertEquals(queryParam.getIn(), "query");
+        // see https://github.com/swagger-api/swagger-core/issues/2556. should be not null
+        assertNull(queryParam.getType());
+
     }
 
     @Test(description = "scan implicit params with file objct")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithImplicitParams.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithImplicitParams.java
@@ -22,7 +22,8 @@ public class ResourceWithImplicitParams {
             @ApiImplicitParam(name = "width", paramType = "formData", dataType = "int", allowableValues = "range[infinity,1]"),
             @ApiImplicitParam(name = "height", paramType = "query", dataType = "int", allowableValues = "range[3,4]"),
             @ApiImplicitParam(name = "body", paramType = "body", dataType = "string", required = true),
-            @ApiImplicitParam(name = "width", paramType = "unknown")
+            @ApiImplicitParam(name = "width", paramType = "unknown"),
+            @ApiImplicitParam(name = "description", paramType = "query")
     })
     @ApiOperation("Test operation with implicit parameters")
     public void testString() {


### PR DESCRIPTION
fix #2556 - updated logging for ApiImplicitParam with no datatype defined