### PR TITLE
Feature/model in response refactored

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
@@ -113,9 +113,9 @@ public class SpecFilter {
 
         if (swagger.getResponses() != null) {
             for (Response response: swagger.getResponses().values()) {
-                String propertyRef = getPropertyRef(response.getSchema());
-                if (propertyRef != null) {
-                    referencedDefinitions.add(propertyRef);
+                Set<String> modelRef = getModelRef(response.getResponseSchema());
+                if (modelRef != null) {
+                    referencedDefinitions.addAll(modelRef);
                 }
             }
         }
@@ -147,9 +147,9 @@ public class SpecFilter {
                     for (Operation op: path.getOperations()) {
                         if (op.getResponses() != null) {
                             for (Response response: op.getResponses().values()) {
-                                String propertyRef = getPropertyRef(response.getSchema());
-                                if (propertyRef != null) {
-                                    referencedDefinitions.add(propertyRef);
+                                Set<String> modelRef = getModelRef(response.getResponseSchema());
+                                if (modelRef != null) {
+                                    referencedDefinitions.addAll(modelRef);
                                 }
                             }
                         }

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/mixin/ResponseSchemaMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/mixin/ResponseSchemaMixin.java
@@ -1,0 +1,25 @@
+package io.swagger.jackson.mixin;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import io.swagger.models.Model;
+import io.swagger.models.properties.Property;
+
+public abstract class ResponseSchemaMixin {
+
+    @JsonIgnore
+    public abstract Property getSchema();
+
+    @JsonIgnore
+    public abstract void setSchema(Property schema);
+
+    @JsonGetter("schema")
+    public abstract Model getResponseSchema();
+
+    @JsonSetter("schema")
+    public abstract void setResponseSchema(Model schema);
+
+
+
+}

--- a/modules/swagger-core/src/main/java/io/swagger/util/ObjectMapperFactory.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ObjectMapperFactory.java
@@ -7,6 +7,10 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.swagger.jackson.mixin.ResponseSchemaMixin;
+import io.swagger.models.Response;
+
+
 
 
 public class ObjectMapperFactory {
@@ -36,6 +40,8 @@ public class ObjectMapperFactory {
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+        mapper.addMixIn(Response.class, ResponseSchemaMixin.class);
 
         return mapper;
     }

--- a/modules/swagger-core/src/test/java/io/swagger/properties/ArrayPropertyDeserializerTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/properties/ArrayPropertyDeserializerTest.java
@@ -1,5 +1,7 @@
 package io.swagger.properties;
 
+import io.swagger.models.ArrayModel;
+import io.swagger.models.Model;
 import io.swagger.models.Operation;
 import io.swagger.models.Response;
 import io.swagger.models.properties.ArrayProperty;
@@ -34,13 +36,13 @@ public class ArrayPropertyDeserializerTest {
       Response response = operation.getResponses().get("200");
       assertNotNull(response);
       
-      Property responseSchema = response.getSchema();
+      Model responseSchema = response.getResponseSchema();
       assertNotNull(responseSchema);
-      assertTrue(responseSchema instanceof ArrayProperty);
-      
-      ArrayProperty mp = (ArrayProperty) responseSchema;
-      assertNotNull( mp.getExample() );
-      assertEquals(mp.getMinItems(), new Integer(3));
-      assertEquals(mp.getMaxItems(), new Integer(100));
+      assertTrue(responseSchema instanceof ArrayModel);
+
+      ArrayModel arrayModel = (ArrayModel) responseSchema;
+      assertNotNull( arrayModel.getExample() );
+      assertEquals(arrayModel.getMinItems(), new Integer(3));
+      assertEquals(arrayModel.getMaxItems(), new Integer(100));
   }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/util/PropertyModelConverterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/PropertyModelConverterTest.java
@@ -1,0 +1,670 @@
+package io.swagger.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.swagger.models.ArrayModel;
+import io.swagger.models.ComposedModel;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.RefModel;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.BinaryProperty;
+import io.swagger.models.properties.BooleanProperty;
+import io.swagger.models.properties.ByteArrayProperty;
+import io.swagger.models.properties.DateProperty;
+import io.swagger.models.properties.DateTimeProperty;
+import io.swagger.models.properties.DoubleProperty;
+import io.swagger.models.properties.EmailProperty;
+import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.LongProperty;
+import io.swagger.models.properties.MapProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.StringProperty;
+import io.swagger.models.properties.UUIDProperty;
+import io.swagger.models.utils.PropertyModelConverter;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PropertyModelConverterTest {
+
+    @Test
+    public void convertToUUIDProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: string\n"+
+                "            format: uuid\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof UUIDProperty);
+        Assert.assertEquals(property.getType(),"string");
+        Assert.assertEquals(property.getFormat(),"uuid");
+
+    }
+
+    @Test
+    public void convertToEmailProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: string\n"+
+                "            format: email\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof EmailProperty);
+        Assert.assertEquals(property.getType(),"string");
+        Assert.assertEquals(property.getFormat(),"email");
+
+    }
+
+    @Test
+    public void convertToBooleanProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: boolean\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof BooleanProperty);
+        Assert.assertEquals(property.getType(),"boolean");
+
+    }
+
+    @Test
+    public void convertToDateProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: string\n"+
+                "            format: date\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof DateProperty);
+        Assert.assertEquals(property.getType(),"string");
+        Assert.assertEquals(property.getFormat(),"date");
+    }
+
+    @Test
+    public void convertToDateTimeProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: string\n"+
+                "            format: date-time\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof DateTimeProperty);
+        Assert.assertEquals(property.getType(),"string");
+        Assert.assertEquals(property.getFormat(),"date-time");
+    }
+
+    @Test
+    public void convertToStringProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: string\n"+
+                "            format: password\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof StringProperty);
+        Assert.assertEquals(property.getType(),"string");
+        Assert.assertEquals(property.getFormat(),"password");
+    }
+
+    @Test
+    public void convertToBinaryProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: string\n"+
+                "            format: binary\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof BinaryProperty);
+        Assert.assertEquals(property.getType(),"string");
+        Assert.assertEquals(property.getFormat(),"binary");
+    }
+
+    @Test
+    public void convertToDoubleProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: number\n"+
+                "            format: double\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof DoubleProperty);
+        Assert.assertEquals(property.getType(),"number");
+        Assert.assertEquals(property.getFormat(),"double");
+
+    }
+
+    @Test
+    public void convertToByteArrayProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: string\n"+
+                "            format: byte\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof ByteArrayProperty);
+        Assert.assertEquals(property.getType(),"string");
+        Assert.assertEquals(property.getFormat(),"byte");
+    }
+
+    @Test
+    public void convertToLongProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: integer\n"+
+                "            format: int64\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof LongProperty);
+        Assert.assertEquals(property.getType(),"integer");
+        Assert.assertEquals(property.getFormat(),"int64");
+
+    }
+
+    @Test
+    public void convertToIntegerProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: integer\n"+
+                "            format: int32\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof IntegerProperty);
+        Assert.assertEquals(property.getType(),"integer");
+        Assert.assertEquals(property.getFormat(),"int32");
+
+    }
+
+    @Test
+    public void convertToArrayProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: array\n" +
+                "            items:\n" +
+                "              type: string\n" +
+                "              format: date-time\n" +
+                "              example: 1985-04-12T23:20:50.52Z";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof ArrayProperty);
+        ArrayProperty arrayProperty = (ArrayProperty) property;
+        Assert.assertEquals(property.getType(),"array");
+        Assert.assertEquals(arrayProperty.getItems().getType(),"string");
+        Assert.assertEquals(arrayProperty.getItems().getFormat(),"date-time");
+        Assert.assertEquals(arrayProperty.getItems().getExample(),"1985-04-12T23:20:50.52Z");
+
+    }
+
+
+    @Test
+    public void convertArrayModel()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/models.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Model arrayModel  = swagger.getDefinitions().get("InstructionSequence");
+
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Property convertedProperty = converter.modelToProperty(arrayModel);
+
+        Assert.assertTrue(convertedProperty instanceof ArrayProperty);
+        ArrayProperty property = (ArrayProperty) convertedProperty;
+
+        Assert.assertEquals(property.getTitle(),"InstructionSequence");
+        Assert.assertEquals(property.getDescription(),"The sequence of steps that make up the Instructions");
+        Assert.assertEquals(property.getType(),"array");
+        Assert.assertTrue(property.getItems() instanceof StringProperty);
+        Assert.assertEquals(property.getItems().getType(),"string");
+
+    }
+
+    @Test
+    public void convertAddressModel()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/models.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Model arrayModel  = swagger.getDefinitions().get("Address");
+
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Property convertedProperty = converter.modelToProperty(arrayModel);
+
+        Assert.assertTrue(convertedProperty instanceof ObjectProperty);
+        ObjectProperty property = (ObjectProperty) convertedProperty;
+
+        Assert.assertEquals(property.getType(),"object");
+        Assert.assertEquals(property.getRequiredProperties().get(0),"street");
+        Assert.assertEquals(property.getProperties().get("city").getType(),"string");
+
+    }
+
+    @Test
+    public void composedExtendedModelToPropertyTest()throws Exception{
+
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/models.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Model composedModel  = swagger.getDefinitions().get("ExtendedAddress");
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Property convertedProperty = converter.modelToProperty(composedModel);
+
+        Assert.assertTrue(convertedProperty instanceof ObjectProperty);
+        ObjectProperty objectProperty = (ObjectProperty) convertedProperty;
+        Assert.assertEquals(objectProperty.getType(),"object");
+
+        Assert.assertEquals(objectProperty.getProperties().get("Address").getType(),"ref");
+        Assert.assertEquals(objectProperty.getProperties().get("gps").getType(),"string");
+        Assert.assertEquals(objectProperty.getRequiredProperties().get(0),"gps");
+    }
+
+
+
+
+    @Test
+    public void composedModelToPropertyTest(){
+
+        List<Model> list = new ArrayList();
+        List<String> requiredList = new ArrayList();
+        requiredList.add("url");
+
+        ModelImpl model = new ModelImpl();
+        model.setType("object");
+        model.setRequired(requiredList);
+
+        Property property = new StringProperty();
+        property.setDescription("Url with information or picture of the product");
+        Map<String, Property> propertyMap = new HashMap();
+        propertyMap.put("url", property);
+        model.setProperties(propertyMap);
+        list.add(model);
+
+        RefModel refModel1 = new RefModel("#/definitions/ReferencedObject1");
+        list.add(refModel1);
+
+        RefModel refModel2 = new RefModel("#/definitions/ReferencedObject2");
+        list.add(refModel2);
+
+        ComposedModel composedModel = new ComposedModel();
+        composedModel.setDescription("AllOf test");
+        composedModel.setExample("Example");
+        composedModel.setAllOf(list);
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Property convertedProperty = converter.modelToProperty(composedModel);
+
+        Assert.assertTrue(convertedProperty instanceof ObjectProperty);
+        ObjectProperty objectProperty = (ObjectProperty) convertedProperty;
+        Assert.assertEquals(objectProperty.getType(),"object");
+        Assert.assertEquals(objectProperty.getExample(),"Example");
+        Assert.assertEquals(objectProperty.getDescription(),"AllOf test");
+        Assert.assertEquals(objectProperty.getProperties().get("url").getType(),"string");
+        Assert.assertEquals(objectProperty.getProperties().get("ReferencedObject1").getType(),"ref");
+        Assert.assertEquals(objectProperty.getRequiredProperties().get(0),"url");
+
+    }
+
+    @Test
+    public void convertPropertyToModel(){
+
+        IntegerProperty integerProperty = new IntegerProperty();
+        MapProperty mapProperty = new MapProperty();
+        mapProperty.setAdditionalProperties(integerProperty);
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Model convertedModel = converter.propertyToModel(mapProperty);
+
+        Assert.assertTrue(convertedModel instanceof ModelImpl);
+        ModelImpl model = (ModelImpl) convertedModel;
+        Assert.assertEquals(model.getType(),"object");
+        Assert.assertEquals(model.getAdditionalProperties().getType(),"integer");
+
+    }
+
+    @Test
+    public void convertStringProperty()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Path string  = swagger.getPaths().get("/string");
+        Operation operation = string.getOperations().get(0);
+        Response response = operation.getResponses().get("200");
+        Property property = response.getSchema();
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Model convertedModel = converter.propertyToModel(property);
+
+        Assert.assertTrue(convertedModel instanceof ModelImpl);
+        ModelImpl model = (ModelImpl) convertedModel;
+        Assert.assertEquals(model.getType(),"string");
+        Assert.assertEquals(model.getExample(),"Hello");
+    }
+
+    @Test
+    public void convertStringRefProperty()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Path string  = swagger.getPaths().get("/stringRef");
+        Operation operation = string.getOperations().get(0);
+        Response response = operation.getResponses().get("200");
+        Property property = response.getSchema();
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Model convertedModel = converter.propertyToModel(property);
+
+        Assert.assertTrue(convertedModel instanceof RefModel);
+        RefModel model = (RefModel) convertedModel;
+        Assert.assertEquals(model.get$ref(),"#/definitions/DayOfWeekAsString");
+    }
+
+    @Test
+    public void convertBooleanProperty()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Path string  = swagger.getPaths().get("/boolean");
+        Operation operation = string.getOperations().get(0);
+        Response response = operation.getResponses().get("200");
+        Property property = response.getSchema();
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Model convertedModel = converter.propertyToModel(property);
+
+        Assert.assertTrue(convertedModel instanceof ModelImpl);
+        ModelImpl model = (ModelImpl) convertedModel;
+        Assert.assertEquals(model.getType(),"boolean");
+        Assert.assertEquals(model.getExample(),true);
+    }
+
+    @Test
+    public void convertNumberProperty()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Path string  = swagger.getPaths().get("/number");
+        Operation operation = string.getOperations().get(0);
+        Response response = operation.getResponses().get("200");
+        Property property = response.getSchema();
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Model convertedModel = converter.propertyToModel(property);
+
+        Assert.assertTrue(convertedModel instanceof ModelImpl);
+        ModelImpl model = (ModelImpl) convertedModel;
+        Assert.assertEquals(model.getType(),"number");
+        Assert.assertEquals(model.getExample(),1.5);
+    }
+
+    @Test
+    public void convertArrayProperty()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Path string  = swagger.getPaths().get("/arrayOfInt");
+        Operation operation = string.getOperations().get(0);
+        Response response = operation.getResponses().get("200");
+        Property property = response.getSchema();
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Model convertedModel = converter.propertyToModel(property);
+
+        Assert.assertTrue(convertedModel instanceof ArrayModel);
+        ArrayModel model = (ArrayModel) convertedModel;
+        Assert.assertEquals(model.getType(),"array");
+        Assert.assertEquals(model.getItems().getType(),"integer");
+    }
+
+    @Test
+    public void convertArrayOfRefProperty()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Path string  = swagger.getPaths().get("/arrayOfRef");
+        Operation operation = string.getOperations().get(0);
+        Response response = operation.getResponses().get("200");
+        Property property = response.getSchema();
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Model convertedModel = converter.propertyToModel(property);
+
+        Assert.assertTrue(convertedModel instanceof ArrayModel);
+        ArrayModel model = (ArrayModel) convertedModel;
+        Assert.assertEquals(model.getType(),"array");
+        Assert.assertEquals(model.getItems().getType(),"ref");
+        RefProperty items = (RefProperty) model.getItems();
+        Assert.assertEquals(items.get$ref(),"#/definitions/User");
+    }
+
+    @Test
+    public void convertArrayRefProperty()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Path string  = swagger.getPaths().get("/arrayRef");
+        Operation operation = string.getOperations().get(0);
+        Response response = operation.getResponses().get("200");
+        Property property = response.getSchema();
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Model convertedModel = converter.propertyToModel(property);
+
+        Assert.assertTrue(convertedModel instanceof RefModel);
+        RefModel model = (RefModel) convertedModel;
+        Assert.assertEquals(model.get$ref(),"#/definitions/ArrayOfint");
+
+
+    }
+
+    @Test
+    public void convertObjectProperty()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
+
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Path string  = swagger.getPaths().get("/object");
+        Operation operation = string.getOperations().get(0);
+        Response response = operation.getResponses().get("200");
+        Property property = response.getSchema();
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Model convertedModel = converter.propertyToModel(property);
+
+        Assert.assertTrue(convertedModel instanceof ModelImpl);
+        ModelImpl model = (ModelImpl) convertedModel;
+        Assert.assertEquals(model.getType(),"object");
+        Assert.assertEquals(model.getProperties().get("id").getType(), "integer");
+        Assert.assertEquals(model.getProperties().get("id").getFormat(), "int64");
+        Assert.assertEquals(model.getProperties().get("name").getType(), "string");
+        Assert.assertEquals(model.getRequired().get(0), "id");
+        Assert.assertEquals(model.getRequired().get(1), "name");
+
+
+    }
+}

--- a/modules/swagger-core/src/test/resources/specFiles/models.yaml
+++ b/modules/swagger-core/src/test/resources/specFiles/models.yaml
@@ -1,0 +1,103 @@
+swagger: '2.0'
+info:
+  version: 0.0.0
+  title: Response schema test
+produces:
+  - application/json
+paths:
+  /string:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: string
+            example: Hello
+definitions:
+  User:
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+    description: 'the name!'
+    example: |
+      {
+        "foo":"bar"
+      }
+  Address:
+    type: object
+    x-swagger-router-model: io.swagger.test.models.Address
+    required:
+      - street
+    properties:
+      street:
+        type: string
+        example: 12345 El Monte Road
+      city:
+        type: string
+        example: Los Altos Hills
+      state:
+        type: string
+        example: CA
+      zip:
+        type: string
+        example: '94022'
+  Water:
+    properties:
+      clear:
+        type: boolean
+      name:
+        type: string
+      prices:
+        type: array
+        items:
+          type: number
+          format: float
+      id:
+        type: string
+        format: uuid
+  Animal:
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      address:
+        $ref: '#/definitions/Address'
+    description: 'the name!'
+  Dog:
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      dogType:
+        type: string
+  UnmappedModel:
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+  ExtendedAddress:
+    type: object
+    x-swagger-router-model: io.swagger.test.models.ExtendedAddress
+    allOf:
+      - $ref: '#/definitions/Address'
+      - type: object
+        required:
+        - gps
+        properties:
+          gps:
+            type: string
+  InstructionSequence:
+      title: InstructionSequence
+      description: The sequence of steps that make up the Instructions
+      type: array
+      items:
+          type: string

--- a/modules/swagger-core/src/test/resources/specFiles/responses.yaml
+++ b/modules/swagger-core/src/test/resources/specFiles/responses.yaml
@@ -1,0 +1,192 @@
+swagger: '2.0'
+info:
+  version: 0.0.0
+  title: Response schema test
+produces:
+  - application/json
+paths:
+  /string:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: string
+            example: Hello
+  /stringRef:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/DayOfWeekAsString'
+  /integer:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: integer
+            example: 42
+  /integerRef:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/DayOfWeekAsInt'
+  /boolean:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: boolean
+            example: true
+  /booleanRef:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/ABoolean'
+  /number:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: number
+            example: 1.5
+  /numberRef:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/ANumber'
+  /arrayOfInt:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: array
+            items:
+              type: integer
+  /arrayOfRef:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/User'
+  /arrayRef:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/ArrayOfint'
+  /object:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              id:
+                type: integer
+                format: int64
+              name:
+                type: string
+            required:
+              - id
+              - name
+  /objectRef:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/User'
+  /anything:
+    get:
+      responses:
+        200:
+          description: OK
+          schema: {}
+  /anythingRef:
+    get:
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/AnyValue'
+  /user:
+    get:
+      produces:
+        - application/json
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              id:
+                type: integer
+                format: int32
+              name:
+                type: string
+            required: [id, name]
+            example:
+              obj: {b: ho, a: hey}
+              arr: [hey, ho]
+              double: 1.2
+              int: 42
+              biginteger: 118059162071741130342442
+              long: 1099511627776
+              boolean: yes
+              string: Arthur Dent
+definitions:
+  DayOfWeekAsString:
+    type: string
+    enum:
+      - Monday
+      - Tuesday
+      - Wednesday
+      - Thursday
+      - Friday
+      - Saturday
+      - Sunday
+  ABoolean:
+    type: boolean
+    example: true
+  DayOfWeekAsInt:
+    type: integer
+    minimum: 1
+    maximum: 7
+    example: 3
+  ANumber:
+    type: number
+    example: 42
+  ArrayOfint:
+    type: array
+    items:
+      type: integer
+  User:
+    type: object
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+    required:
+      - id
+      - name
+  AnyValue:
+    description: Can be anything (except `null`)

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ChildTypeTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ChildTypeTest.java
@@ -26,17 +26,17 @@ public class ChildTypeTest {
     @Test(description = "Tests child type response schema ref is correctly set up")
     public void testChildTypeResponse() {
         Operation op = swagger.getPath("/childType/testChildTypeResponse").getGet();
-        Property schema = op.getResponses().get("200").getSchema();
-        assertEquals(schema.getClass().getName(), RefProperty.class.getName());
-        assertEquals(((RefProperty) schema).getSimpleRef(), "Sub1Bean");
+        Model schema = op.getResponses().get("200").getResponseSchema();
+        assertEquals(schema.getClass().getName(), RefModel.class.getName());
+        assertEquals(((RefModel) schema).getSimpleRef(), "Sub1Bean");
     }
 
     @Test(description = "Tests child type response schema ref is correctly set up when specified on the operation")
     public void testChildTypeResponseOnOperation() {
         Operation op = swagger.getPath("/childType/testChildTypeResponseOnOperation").getGet();
-        Property schema = op.getResponses().get("200").getSchema();
-        assertEquals(schema.getClass().getName(), RefProperty.class.getName());
-        assertEquals(((RefProperty) schema).getSimpleRef(), "Sub1Bean");
+        Model schema = op.getResponses().get("200").getResponseSchema();
+        assertEquals(schema.getClass().getName(), RefModel.class.getName());
+        assertEquals(((RefModel) schema).getSimpleRef(), "Sub1Bean");
     }
 
     @Test(description = "Tests schema ref is correctly set up for child type parameter")

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/GenericsTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/GenericsTest.java
@@ -204,9 +204,9 @@ public class GenericsTest {
     @Test(description = "check generic result")
     public void checkGenericResult() {
         Operation op = swagger.getPath("/generics/testGenericResult").getGet();
-        Property schema = op.getResponses().get("200").getSchema();
-        assertEquals(schema.getClass().getName(), RefProperty.class.getName());
-        assertEquals(((RefProperty) schema).getSimpleRef(), "GenericListWrapperTag");
+        Model schema = op.getResponses().get("200").getResponseSchema();
+        assertEquals(schema.getClass().getName(), RefModel.class.getName());
+        assertEquals(((RefModel) schema).getSimpleRef(), "GenericListWrapperTag");
 
         Property entries = getProperty("GenericListWrapperTag", "entries");
         assertNotEquals(entries, null);

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -192,8 +192,10 @@ public class SimpleReaderTest {
         Response response = get.getResponses().get("200");
         assertNotNull(response);
 
-        Property schema = response.getSchema();
-        assertEquals(schema.getClass(), MapProperty.class);
+        Model schema = response.getResponseSchema();
+        assertEquals(schema.getClass(), ModelImpl.class);
+        ModelImpl model = (ModelImpl) schema;
+        assertTrue(model.getAdditionalProperties() != null);
     }
 
     @Test(description = "scan a resource with generics per 653")
@@ -207,7 +209,7 @@ public class SimpleReaderTest {
 
         Response response = responses.get("default");
         assertNotNull(response);
-        assertNull(response.getSchema());
+        assertNull(response.getResponseSchema());
     }
 
     @Test(description = "scan a resource with javax.ws.core.Response ")
@@ -410,41 +412,44 @@ public class SimpleReaderTest {
         Swagger swagger = getSwagger(ResourceWithApiResponseResponseContainer.class);
         Path paths = swagger.getPaths().get("/{id}");
         Map<String, Response> responses1 = paths.getGet().getResponses();
-        assertEquals(responses1.get("200").getSchema().getClass(), MapProperty.class);
-        assertEquals(responses1.get("400").getSchema().getClass(), ArrayProperty.class);
+
+        assertEquals(responses1.get("200").getResponseSchema().getClass(), ModelImpl.class);
+        assertTrue(((ModelImpl)responses1.get("200").getResponseSchema()).getAdditionalProperties() != null);
+
+        assertEquals(responses1.get("400").getResponseSchema().getClass(), ArrayModel.class);
 
         Map<String, Response> responses2 = paths.getPut().getResponses();
-        assertEquals(responses2.get("201").getSchema().getClass(), RefProperty.class);
-        assertEquals(responses2.get("401").getSchema().getClass(), ArrayProperty.class);
+        assertEquals(responses2.get("201").getResponseSchema().getClass(), RefModel.class);
+        assertEquals(responses2.get("401").getResponseSchema().getClass(), ArrayModel.class);
 
         Map<String, Response> responses3 = paths.getPost().getResponses();
-        assertEquals(responses3.get("202").getSchema().getClass(), RefProperty.class);
-        assertEquals(responses3.get("402").getSchema().getClass(), RefProperty.class);
+        assertEquals(responses3.get("202").getResponseSchema().getClass(), RefModel.class);
+        assertEquals(responses3.get("402").getResponseSchema().getClass(), RefModel.class);
 
         Map<String, Response> responses4 = paths.getDelete().getResponses();
-        assertEquals(responses4.get("203").getSchema().getClass(), RefProperty.class);
-        assertEquals(responses4.get("403").getSchema().getClass(), RefProperty.class);
+        assertEquals(responses4.get("203").getResponseSchema().getClass(), RefModel.class);
+        assertEquals(responses4.get("403").getResponseSchema().getClass(), RefModel.class);
 
         Path paths2 = swagger.getPaths().get("/{id}/name");
         Map<String, Response> responses5 = paths2.getGet().getResponses();
-        assertEquals(responses5.get("203").getSchema().getClass(), ArrayProperty.class);
-        assertNull(((ArrayProperty) responses5.get("203").getSchema()).getUniqueItems());
+        assertEquals(responses5.get("203").getResponseSchema().getClass(), ArrayModel.class);
+        assertNull(((ArrayModel) responses5.get("203").getResponseSchema()).getUniqueItems());
         assertNotEquals(responses5.get("203").getHeaders().get("foo").getClass(), MapProperty.class);
-        assertEquals(responses5.get("403").getSchema().getClass(), ArrayProperty.class);
-        assertEquals(((ArrayProperty) responses5.get("403").getSchema()).getUniqueItems(), Boolean.TRUE);
+        assertEquals(responses5.get("403").getResponseSchema().getClass(), ArrayModel.class);
+        assertEquals(((ArrayModel) responses5.get("403").getResponseSchema()).getUniqueItems(), Boolean.TRUE);
 
         Map<String, Response> responses6 = paths2.getPut().getResponses();
-        assertEquals(responses6.get("203").getSchema().getClass(), ArrayProperty.class);
-        assertEquals(((ArrayProperty) responses6.get("203").getSchema()).getUniqueItems(), Boolean.TRUE);
+        assertEquals(responses6.get("203").getResponseSchema().getClass(), ArrayModel.class);
+        assertEquals(((ArrayModel) responses6.get("203").getResponseSchema()).getUniqueItems(), Boolean.TRUE);
         assertEquals(responses6.get("203").getHeaders().get("foo").getClass(), ArrayProperty.class);
         assertEquals(((ArrayProperty) responses6.get("203").getHeaders().get("foo")).getUniqueItems(), Boolean.TRUE);
-        assertEquals(responses6.get("403").getSchema().getClass(), ArrayProperty.class);
+        assertEquals(responses6.get("403").getResponseSchema().getClass(), ArrayModel.class);
     }
 
     @Test(description = "scan a resource with inner class")
     public void scanResourceWithInnerClass() {
         Swagger swagger = getSwagger(ResourceWithInnerClass.class);
-        assertEquals(((RefProperty) ((ArrayProperty) getGetResponses(swagger, "/description").get("200").getSchema()).
+        assertEquals(((RefProperty) ((ArrayModel) getGetResponses(swagger, "/description").get("200").getResponseSchema()).
                 getItems()).get$ref(), "#/definitions/Description");
         assertTrue(swagger.getDefinitions().containsKey("Description"));
     }
@@ -546,30 +551,31 @@ public class SimpleReaderTest {
                 assertEquals(entry.getValue().getGet().getResponses().size(), expected.size());
                 for (Map.Entry<String, Response> responseEntry : entry.getValue().getGet().getResponses().entrySet()) {
                     String[] expectedProp = expected.get(responseEntry.getKey());
-                    Property property = responseEntry.getValue().getSchema();
-                    assertEquals(property.getType(), expectedProp[0]);
-                    assertEquals(property.getFormat(), expectedProp[1]);
+                    Model model = responseEntry.getValue().getResponseSchema();
+                    ModelImpl modelImpl = (ModelImpl) model;
+                    assertEquals(modelImpl.getType(), expectedProp[0]);
+                    assertEquals(modelImpl.getFormat(), expectedProp[1]);
                 }
             } else {
                 Operation op = entry.getValue().getGet();
-                Property response = op.getResponses().get("200").getSchema();
+                Model response = op.getResponses().get("200").getResponseSchema();
                 Model model = ((BodyParameter) op.getParameters().get(0)).getSchema();
                 assertEquals(op.getParameters().size(), 1);
 
                 if ("testObjectResponse".equals(name)) {
-                    assertEquals(((RefProperty) response).getSimpleRef(), "Tag");
+                    assertEquals(((RefModel) response).getSimpleRef(), "Tag");
                     assertEquals(((RefModel) model).getSimpleRef(), "Tag");
                 } else if ("testObjectsResponse".equals(name)) {
-                    assertEquals(((RefProperty) ((ArrayProperty) response).getItems()).getSimpleRef(), "Tag");
+                    assertEquals(((RefProperty) ((ArrayModel) response).getItems()).getSimpleRef(), "Tag");
                     assertEquals(((RefProperty) ((ArrayModel) model).getItems()).getSimpleRef(), "Tag");
                 } else if ("testStringResponse".equals(name)) {
-                    assertEquals(response.getClass(), StringProperty.class);
+                    assertEquals(response.getClass(), ModelImpl.class);
                     assertEquals(((ModelImpl) model).getType(), "string");
                 } else if ("testStringsResponse".equals(name)) {
-                    assertEquals(((ArrayProperty) response).getItems().getClass(), StringProperty.class);
+                    assertEquals(((ArrayModel) response).getItems().getClass(), StringProperty.class);
                     assertEquals(((ArrayModel) model).getItems().getClass(), StringProperty.class);
                 } else if ("testMapResponse".equals(name)) {
-                    assertEquals(((RefProperty) ((MapProperty) response).getAdditionalProperties()).getSimpleRef(), "Tag");
+                    assertEquals(((RefProperty) ((ModelImpl) response).getAdditionalProperties()).getSimpleRef(), "Tag");
                     assertNull(model.getProperties());
                     assertEquals(((RefProperty) ((ModelImpl) model).getAdditionalProperties()).getSimpleRef(), "Tag");
                 } else {

--- a/modules/swagger-models/pom.xml
+++ b/modules/swagger-models/pom.xml
@@ -115,7 +115,6 @@
             <version>3.3.1</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
     <properties>
         <!-- TODO increase coverage -->

--- a/modules/swagger-models/src/main/java/io/swagger/models/ArrayModel.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/ArrayModel.java
@@ -9,6 +9,7 @@ public class ArrayModel extends AbstractModel {
     private String type;
     private String description;
     private Property items;
+    private Boolean uniqueItems;
     private Object example;
     private Integer minItems;
     private Integer maxItems;
@@ -24,6 +25,11 @@ public class ArrayModel extends AbstractModel {
 
     public ArrayModel items(Property items) {
         this.setItems(items);
+        return this;
+    }
+
+    public ArrayModel uniqueItems(Boolean uniqueItems) {
+        this.setUniqueItems(uniqueItems);
         return this;
     }
 
@@ -57,8 +63,17 @@ public class ArrayModel extends AbstractModel {
         return items;
     }
 
+    public Boolean getUniqueItems() {
+        return uniqueItems;
+    }
+
     public void setItems(Property items) {
         this.items = items;
+    }
+
+    public void setUniqueItems(Boolean uniqueItems) {
+        this.uniqueItems = uniqueItems;
+
     }
 
     public Map<String, Property> getProperties() {
@@ -119,6 +134,9 @@ public class ArrayModel extends AbstractModel {
         if (items != null ? !items.equals(that.items) : that.items != null) {
             return false;
         }
+        if (uniqueItems != null ? !uniqueItems.equals(that.uniqueItems) : that.uniqueItems != null) {
+            return false;
+        }
         if (example != null ? !example.equals(that.example) : that.example != null) {
             return false;
         }
@@ -136,6 +154,7 @@ public class ArrayModel extends AbstractModel {
         result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (items != null ? items.hashCode() : 0);
+        result = 31 * result + (uniqueItems != null ? uniqueItems.hashCode() : 0);
         result = 31 * result + (example != null ? example.hashCode() : 0);
         result = 31 * result + (minItems != null ? minItems.hashCode() : 0);
         result = 31 * result + (maxItems != null ? maxItems.hashCode() : 0);

--- a/modules/swagger-models/src/main/java/io/swagger/models/Response.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Response.java
@@ -3,21 +3,18 @@ package io.swagger.models;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import io.swagger.models.properties.Property;
+import io.swagger.models.utils.PropertyModelConverter;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Response {
     private String description;
-    private Property schema;
+    private Model schemaAsModel;
+    private Property schemaAsProperty;
     private Map<String, Object> examples;
     private Map<String, Property> headers;
     private Map<String, Object> vendorExtensions = new LinkedHashMap<String, Object>();
-
-    public Response schema(Property property) {
-        this.setSchema(property);
-        return this;
-    }
 
     public Response description(String description) {
         this.setDescription(description);
@@ -55,12 +52,39 @@ public class Response {
         this.description = description;
     }
 
+    @Deprecated
     public Property getSchema() {
-        return schema;
+        if (schemaAsProperty == null && schemaAsModel != null) {
+            return new PropertyModelConverter().modelToProperty(schemaAsModel);
+        }
+        return schemaAsProperty;
     }
 
+    @Deprecated
     public void setSchema(Property schema) {
-        this.schema = schema;
+        this.schemaAsProperty = schema;
+    }
+
+    @Deprecated
+    public Response schema(Property property) {
+        this.setSchema(property);
+        return this;
+    }
+
+    public Model getResponseSchema() {
+        if(schemaAsModel == null && schemaAsProperty != null) {
+            return new PropertyModelConverter().propertyToModel(schemaAsProperty);
+        }
+        return schemaAsModel;
+    }
+
+    public void setResponseSchema(Model model) {
+        this.schemaAsModel = model;
+    }
+
+    public Response responseSchema(Model model) {
+        this.setResponseSchema(model);
+        return this;
     }
 
     public Map<String, Object> getExamples() {
@@ -116,7 +140,10 @@ public class Response {
         if (description != null ? !description.equals(response.description) : response.description != null) {
             return false;
         }
-        if (schema != null ? !schema.equals(response.schema) : response.schema != null) {
+        if (schemaAsModel != null ? !schemaAsModel.equals(response.schemaAsModel) : response.schemaAsModel != null) {
+            return false;
+        }
+        if (schemaAsProperty != null ? !schemaAsProperty.equals(response.schemaAsProperty) : response.schemaAsProperty != null) {
             return false;
         }
         if (examples != null ? !examples.equals(response.examples) : response.examples != null) {
@@ -132,7 +159,8 @@ public class Response {
     @Override
     public int hashCode() {
         int result = description != null ? description.hashCode() : 0;
-        result = 31 * result + (schema != null ? schema.hashCode() : 0);
+        result = 31 * result + (schemaAsModel != null ? schemaAsModel.hashCode() : 0);
+        result = 31 * result + (schemaAsProperty != null ? schemaAsProperty.hashCode() : 0);
         result = 31 * result + (examples != null ? examples.hashCode() : 0);
         result = 31 * result + (headers != null ? headers.hashCode() : 0);
         result = 31 * result + (vendorExtensions != null ? vendorExtensions.hashCode() : 0);

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -808,7 +808,7 @@ public class PropertyBuilder {
                     resolved.setDescription(value);
                 }
                 if (args.containsKey(PropertyId.EXAMPLE)) {
-                    final String value = PropertyId.EXAMPLE.findValue(args);
+                    final Object value = PropertyId.EXAMPLE.findValue(args);
                     resolved.setExample(value);
                 }
                 if(args.containsKey(PropertyId.VENDOR_EXTENSIONS)) {

--- a/modules/swagger-models/src/main/java/io/swagger/models/utils/PropertyModelConverter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/utils/PropertyModelConverter.java
@@ -1,0 +1,229 @@
+package io.swagger.models.utils;
+
+import io.swagger.models.ArrayModel;
+import io.swagger.models.ComposedModel;
+import io.swagger.models.Model;
+import io.swagger.models.ModelImpl;
+import io.swagger.models.RefModel;
+import io.swagger.models.Xml;
+import io.swagger.models.properties.ArrayProperty;
+import io.swagger.models.properties.MapProperty;
+import io.swagger.models.properties.ObjectProperty;
+import io.swagger.models.properties.Property;
+import io.swagger.models.properties.PropertyBuilder;
+import io.swagger.models.properties.RefProperty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PropertyModelConverter {
+
+    public Property modelToProperty(Model model){
+
+        if(model instanceof ModelImpl) {
+            ModelImpl m = (ModelImpl) model;
+            if (m.getAdditionalProperties() != null){
+                MapProperty mapProperty = new MapProperty();
+                mapProperty.setType(m.getType());
+                mapProperty.setAllowEmptyValue(m.getAllowEmptyValue());
+                mapProperty.setDefault((String) m.getDefaultValue());
+                mapProperty.setDescription(m.getDescription());
+                mapProperty.setExample(m.getExample());
+                mapProperty.setFormat(m.getFormat());
+                mapProperty.setName(m.getName());
+                mapProperty.setTitle(m.getTitle());
+                List<String> required = m.getRequired();
+                if (required != null) {
+                    for (String name : required) {
+                        if (m.getName().equals(name)) {
+                            mapProperty.setRequired(true);
+                        }
+                    }
+                }
+                mapProperty.setXml(m.getXml());
+                mapProperty.setVendorExtensions(m.getVendorExtensions());
+                mapProperty.setAdditionalProperties(m.getAdditionalProperties());
+                return mapProperty;
+            }
+
+            Property property = propertyByType(m);
+
+            if(property instanceof ObjectProperty){
+                ObjectProperty objectProperty = (ObjectProperty) property;
+                objectProperty.setProperties(model.getProperties());
+                objectProperty.setExample(model.getExample());
+                return objectProperty;
+            }
+
+            return property;
+
+        } else if(model instanceof ArrayModel) {
+            ArrayModel m = (ArrayModel) model;
+            ArrayProperty property = new ArrayProperty();
+            Property inner = m.getItems();
+            property.setItems(inner);
+            property.setExample(m.getExample());
+            property.setMaxItems(m.getMaxItems());
+            property.setMinItems(m.getMinItems());
+            property.setDescription(m.getDescription());
+            property.setTitle(m.getTitle());
+            property.setUniqueItems(m.getUniqueItems());
+            return property;
+
+        } else if(model instanceof RefModel) {
+            RefModel ref = (RefModel) model;
+            RefProperty refProperty = new RefProperty(ref.get$ref());
+            return refProperty;
+
+        } else if(model instanceof ComposedModel) {
+            ObjectProperty objectProperty = new ObjectProperty();
+            objectProperty.setDescription(model.getDescription());
+            objectProperty.setTitle(model.getTitle());
+            objectProperty.setExample(model.getExample());
+            ComposedModel cm = (ComposedModel) model;
+            Set<String> requiredProperties = new HashSet<>();
+            for(Model item : cm.getAllOf()) {
+                Property itemProperty = modelToProperty(item);
+                if(itemProperty instanceof RefProperty) {
+                    RefProperty refProperty = (RefProperty) itemProperty;
+                    objectProperty.property(refProperty.getSimpleRef(), itemProperty);
+
+                }else if(itemProperty instanceof ObjectProperty) {
+                    ObjectProperty itemPropertyObject = (ObjectProperty) itemProperty;
+                    if(itemPropertyObject.getProperties() != null) {
+                        for (String key : itemPropertyObject.getProperties().keySet()) {
+                            objectProperty.property(key, itemPropertyObject.getProperties().get(key));
+                        }
+                    }
+                    if(itemPropertyObject.getRequiredProperties() != null) {
+                        for(String req : itemPropertyObject.getRequiredProperties()) {
+                            requiredProperties.add(req);
+                        }
+                    }
+                }
+            }
+            if(requiredProperties.size() > 0) {
+                objectProperty.setRequiredProperties(new ArrayList(requiredProperties));
+            }
+            if(cm.getVendorExtensions() != null) {
+                for(String key : cm.getVendorExtensions().keySet()) {
+                    objectProperty.vendorExtension(key, cm.getVendorExtensions().get(key));
+                }
+            }
+            return objectProperty;
+
+        }
+        return null;
+    }
+
+    private Property propertyByType(ModelImpl model) {
+        return PropertyBuilder.build(model.getType(), model.getFormat(), argsFromModel(model));
+    }
+
+    private Map<PropertyBuilder.PropertyId, Object> argsFromModel(ModelImpl model) {
+        if (model == null) return Collections.emptyMap();
+        final Map<PropertyBuilder.PropertyId, Object> args = new EnumMap<>(PropertyBuilder.PropertyId.class);
+        args.put(PropertyBuilder.PropertyId.DESCRIPTION, model.getDescription());
+        args.put(PropertyBuilder.PropertyId.EXAMPLE, model.getExample());
+        args.put(PropertyBuilder.PropertyId.ENUM, model.getEnum());
+        args.put(PropertyBuilder.PropertyId.TITLE, model.getTitle());
+        args.put(PropertyBuilder.PropertyId.DEFAULT, model.getDefaultValue());
+        args.put(PropertyBuilder.PropertyId.DESCRIMINATOR, model.getDiscriminator());
+        args.put(PropertyBuilder.PropertyId.MINIMUM, model.getMinimum());
+        args.put(PropertyBuilder.PropertyId.MAXIMUM, model.getMaximum());
+        args.put(PropertyBuilder.PropertyId.UNIQUE_ITEMS, model.getUniqueItems());
+        args.put(PropertyBuilder.PropertyId.VENDOR_EXTENSIONS, model.getVendorExtensions());
+        return args;
+    }
+
+
+
+
+    public Model propertyToModel(Property property){
+
+        String description = property.getDescription();
+        String type = property.getType();
+        String format = property.getFormat();
+        String example = null;
+
+        /*Object obj = property.getExample();
+        if (obj != null) {
+            example = obj.toString();
+        }*/
+
+        Boolean allowEmptyValue = property.getAllowEmptyValue();
+
+        if(property instanceof RefProperty){
+            RefProperty ref = (RefProperty) property;
+            RefModel refModel = new RefModel(ref.get$ref());
+            return refModel;
+        }
+
+        Map<String, Object> extensions = property.getVendorExtensions();
+
+        Property additionalProperties = null;
+
+        if (property instanceof MapProperty) {
+             additionalProperties = ((MapProperty) property).getAdditionalProperties();
+        }
+
+        String name = property.getName();
+        Xml xml = property.getXml();
+
+        Map<String, Property> properties = null;
+
+        if (property instanceof ObjectProperty) {
+            ObjectProperty objectProperty = (ObjectProperty) property;
+            properties = objectProperty.getProperties();
+        }
+
+        if (property instanceof ArrayProperty){
+            ArrayProperty arrayProperty = (ArrayProperty) property;
+            ArrayModel arrayModel = new ArrayModel();
+            arrayModel.setItems(arrayProperty.getItems());
+            arrayModel.setDescription(description);
+            arrayModel.setExample(example);
+            arrayModel.setUniqueItems(arrayProperty.getUniqueItems());
+
+            if(extensions != null) {
+                arrayModel.setVendorExtensions(extensions);
+            }
+
+            if (properties != null) {
+                arrayModel.setProperties(properties);
+            }
+
+            return arrayModel;
+        }
+
+        ModelImpl model = new ModelImpl();
+
+        model.setDescription(description);
+        model.setExample(property.getExample());//example
+        model.setName(name);
+        model.setXml(xml);
+        model.setType(type);
+        model.setFormat(format);
+        model.setAllowEmptyValue(allowEmptyValue);
+
+        if(extensions != null) {
+            model.setVendorExtensions(extensions);
+        }
+
+        if(additionalProperties != null) {
+            model.setAdditionalProperties(additionalProperties);
+        }
+
+        if (properties != null) {
+            model.setProperties(properties);
+        }
+
+
+        return model;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,7 @@
                         <exclude>**/io/swagger/model/ApiInfo.*</exclude>
                         <exclude>**/io/swagger/util/Yaml.*</exclude>
                         <exclude>**/io/swagger/jackson/*</exclude>
+                        <exclude>**/io/swagger/jackson/mixin/*</exclude>
                         <exclude>**/io/swagger/converter/ModelConverters.*</exclude>
 
                         <!-- JAXRS -->


### PR DESCRIPTION
This PR includes:
Utils class in core module: converter property to model and model to property
Changes in Response model in models module: added an attribute schemaAsModel type Model,
deprecated getSchema, setSchema methods. added method for new attribute.
Use converter in response model.
Related- issues: swagger-api/swagger-parser#567 
swagger-api/swagger-parser#488