### PR TITLE
[osgi] Update to a more recent maven-bundle-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -493,7 +493,7 @@
         <joda-version>1.8.1</joda-version>
         <joda-time-version>2.9.1</joda-time-version>
 
-        <felix-version>2.3.7</felix-version>
+        <felix-version>3.3.0</felix-version>
         <servlet-api-version>2.5</servlet-api-version>
         <jersey-version>1.13</jersey-version>
         <jersey2-version>2.25.1</jersey2-version>


### PR DESCRIPTION
Swagger was using an ancient (mid 2012) version of the maven-bundle-plugin. This uses an even older version of bnd to work out what Swagger's OSGi metadata should be. This old version of bnd uses a naive algorithm for calculating uses constraints which often overspecifies, in this case putting constraints on Jackson and Guava which are not needed. This in turn makes Swagger much harder to deploy in OSGi as Guava's versioning policy is not semantic.

Switching to a more modern maven-bundle plugin fixes this. 

I originally wanted to look at ways to change 2.x to avoid these uses constraints (by changing the API if possible) when I found that the types aren't actually used in the API. It would therefore be great to see this fix back ported to 1.5.x if possible.

Signed-off-by: Tim Ward <timothyjward@apache.org>