### PR TITLE
#1857 Use @ApiModelProperty required value if present instead of @NotNull

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -472,6 +472,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 }
 
                 if (property != null) {
+                    // apply properties from bean validation annotations first,
+                    // so they could be overriden by Swagger annotation values
+                    // (see https://github.com/swagger-api/swagger-core/issues/1857)
+                    applyBeanValidatorAnnotations(property, annotations);
+
                     property.setName(propName);
 
                     if (mp != null && !mp.access().isEmpty()) {
@@ -518,7 +523,6 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                     }
 
                     JAXBAnnotationsHelper.apply(member, property);
-                    applyBeanValidatorAnnotations(property, annotations);
                     props.add(property);
                 }
             }

--- a/modules/swagger-core/src/test/java/io/swagger/BeanValidatorTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/BeanValidatorTest.java
@@ -6,6 +6,7 @@ import io.swagger.models.Model;
 import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.DoubleProperty;
 import io.swagger.models.properties.IntegerProperty;
+import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
 
@@ -22,6 +23,9 @@ public class BeanValidatorTest {
         final Map<String, Model> schemas = ModelConverters.getInstance().readAll(BeanValidationsModel.class);
         final Model model = schemas.get("BeanValidationsModel");
         final Map<String, Property> properties = model.getProperties();
+
+        final LongProperty id = (LongProperty) properties.get("id");
+        Assert.assertTrue(id.getRequired());
 
         final IntegerProperty age = (IntegerProperty) properties.get("age");
         Assert.assertEquals(age.getMinimum(), new BigDecimal(13.0));

--- a/modules/swagger-core/src/test/java/io/swagger/BeanValidatorTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/BeanValidatorTest.java
@@ -48,4 +48,14 @@ public class BeanValidatorTest {
         Assert.assertEquals((int) items.getMinItems(), 2);
         Assert.assertEquals((int) items.getMaxItems(), 10);
     }
+
+    @Test(description = "it should use require settings from @ApiModelProperty")
+    public void overrideRequiredSettings() {
+        final Map<String, Model> schemas = ModelConverters.getInstance().readAll(BeanValidationsModel.class);
+        final Model model = schemas.get("BeanValidationsModel");
+        final Map<String, Property> properties = model.getProperties();
+
+        final IntegerProperty birthYear = (IntegerProperty) properties.get("birthYear");
+        Assert.assertFalse(birthYear.getRequired());
+    }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/models/BeanValidationsModel.java
+++ b/modules/swagger-core/src/test/java/io/swagger/models/BeanValidationsModel.java
@@ -1,5 +1,7 @@
 package io.swagger.models;
 
+import io.swagger.annotations.ApiModelProperty;
+
 import java.util.List;
 
 import javax.validation.constraints.DecimalMax;
@@ -34,6 +36,8 @@ public class BeanValidationsModel {
     @DecimalMax(value = "1000000", inclusive = false)
     protected Double maxBalance;
 
+    @NotNull(groups = Adult.class)
+    @ApiModelProperty(required = false) // required value is optional here, as false is default
     protected Integer birthYear;
 
     @Size(min = 2, max = 10)
@@ -117,5 +121,9 @@ public class BeanValidationsModel {
 
     public void setItems(List<String> items) {
         this.items = items;
+    }
+
+    /** Validation group. */
+    interface Adult {
     }
 }


### PR DESCRIPTION
As stated in #1857, in this situation:
```java
@ApiModelProperty(required = false, value = "Required only for Ipsum group")
@NotNull(groups = Ipsum.class)
private int lorem;
```
field `lorem` is marked as required, as it has `@javax.validation.constraints.NotNull` annotation. This change modifies behavior so if `@ApiModelProperty` is present, it will always be used it's `required` value. Swagger annotations should have precedence over other annotations.

Only drawback is that in existing code this:
```java
@ApiModelProperty(value = "Smth")
@NotNull
private int lorem;
```
currently is marked as required (because of `@NotNull`), and after change it will be marked as not-required (as `required=false` is default value in `@ApiModelProperty`).

Every other code will act as before, so this:
```java
@NotNull
private int lorem;
```
will be marked as required, since there is no Swagger annotation that would override it.

This change can be done for 2.0 version as well, so if it will be accepted I can make another PR for 2.0. Or maybe this change should go only to 2.0, as it somehow changes previous behavior. Please let me know what do you think.