### PR TITLE
Remove guava dependency from core code (2.0 branch)

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -86,6 +86,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.joda</groupId>

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.google.common.collect.Iterables;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.core.util.AnnotationsUtils;
@@ -707,8 +706,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                         if (PrimitiveType.fromType(propType) != null) {
                             return PrimitiveType.createProperty(propType);
                         } else {
-                            return context.resolve(propType,
-                                    Iterables.toArray(propMember.annotations(), Annotation.class));
+                            List<Annotation> list = new ArrayList<>();
+                            for (Annotation a : propMember.annotations()) {
+                                list.add(a);
+                            }
+                            return context.resolve(propType, list.toArray(new Annotation[list.size()]));
                         }
                     }
                 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
@@ -1,7 +1,6 @@
 package io.swagger.v3.core.util;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.google.common.collect.ImmutableMap;
 import io.swagger.v3.oas.models.media.BinarySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.ByteArraySchema;
@@ -149,28 +148,30 @@ public enum PrimitiveType {
     private final Class<?> keyClass;
     private final String commonName;
 
-    public static final Map<String, String> datatypeMappings = ImmutableMap.<String, String>builder()
-            .put("integer_int32", "integer")
-            .put("integer_", "integer")
-            .put("integer_int64", "long")
-            .put("number_", "number")
-            .put("number_float", "float")
-            .put("number_double", "double")
-            .put("string_", "string")
-            .put("string_byte", "byte")
-            .put("string_email", "email")
-            .put("string_binary", "binary")
-            .put("string_uri", "uri")
-            .put("string_url", "url")
-            .put("string_uuid", "uuid")
-            .put("string_date", "date")
-            .put("string_date-time", "date-time")
-            .put("string_password", "password")
-            .put("boolean", "boolean")
-            .put("object_", "object")
-            .build();
+    public static final Map<String, String> datatypeMappings;
 
     static {
+        final Map<String, String> dms = new HashMap<>();
+        dms.put("integer_int32", "integer");
+        dms.put("integer_", "integer");
+        dms.put("integer_int64", "long");
+        dms.put("number_", "number");
+        dms.put("number_float", "float");
+        dms.put("number_double", "double");
+        dms.put("string_", "string");
+        dms.put("string_byte", "byte");
+        dms.put("string_email", "email");
+        dms.put("string_binary", "binary");
+        dms.put("string_uri", "uri");
+        dms.put("string_url", "url");
+        dms.put("string_uuid", "uuid");
+        dms.put("string_date", "date");
+        dms.put("string_date-time", "date-time");
+        dms.put("string_password", "password");
+        dms.put("boolean", "boolean");
+        dms.put("object_", "object");
+        datatypeMappings = Collections.unmodifiableMap(dms);
+
         final Map<Class<?>, PrimitiveType> keyClasses = new HashMap<Class<?>, PrimitiveType>();
         addKeys(keyClasses, BOOLEAN, Boolean.class, Boolean.TYPE);
         addKeys(keyClasses, STRING, String.class, Character.class, Character.TYPE);

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
@@ -1,7 +1,6 @@
 package io.swagger.v3.core.util;
 
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +57,10 @@ public class ReflectionUtils {
      * @return true if the method is overridden method
      */
     public static boolean isOverriddenMethod(Method methodToFind, Class<?> cls) {
-        Set<Class<?>> superClasses = Sets.newHashSet(cls.getInterfaces());
+        Set<Class<?>> superClasses = new HashSet<>();
+        for (Class c : cls.getInterfaces()) {
+            superClasses.add(c);
+        }
 
         if (cls.getSuperclass() != null) {
             superClasses.add(cls.getSuperclass());

--- a/modules/swagger-jaxrs2/pom.xml
+++ b/modules/swagger-jaxrs2/pom.xml
@@ -142,6 +142,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
         </dependency>

--- a/modules/swagger-jaxrs2/pom.xml
+++ b/modules/swagger-jaxrs2/pom.xml
@@ -142,10 +142,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
         </dependency>

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
@@ -8,7 +8,6 @@ import io.swagger.v3.jaxrs2.ext.OpenAPIExtension;
 import io.swagger.v3.jaxrs2.ext.OpenAPIExtensions;
 import io.swagger.v3.oas.integration.api.OpenAPIConfiguration;
 import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import org.apache.commons.lang3.StringUtils;
 

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
@@ -23,10 +23,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public class ReaderUtils {
     private static final String GET_METHOD = "get";
@@ -126,25 +124,6 @@ public class ReaderUtils {
             }
         }
         return false;
-    }
-
-    /**
-     * Splits the provided array of strings into an array, using comma as the separator.
-     * Also removes leading and trailing whitespace and omits empty strings from the results.
-     *
-     * @param strings is the provided array of strings
-     * @return the resulted array of strings
-     */
-    public static String[] splitContentValues(String[] strings) {
-        final Set<String> result = new LinkedHashSet<String>();
-
-        for (String string : strings) {
-            for (String split : string.split("\\s*,\\s*")) {
-                if (!split.isEmpty()) result.add(split);
-            }
-        }
-
-        return result.toArray(new String[result.size()]);
     }
 
     public static Optional<List<String>> getStringListFromStringArray(String[] array) {

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
@@ -1,7 +1,5 @@
 package io.swagger.v3.jaxrs2.util;
 
-import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
 import io.swagger.v3.core.util.ParameterProcessor;
 import io.swagger.v3.core.util.ReflectionUtils;
 import io.swagger.v3.jaxrs2.ext.OpenAPIExtension;
@@ -141,7 +139,9 @@ public class ReaderUtils {
         final Set<String> result = new LinkedHashSet<String>();
 
         for (String string : strings) {
-            Iterables.addAll(result, Splitter.on(",").trimResults().omitEmptyStrings().split(string));
+            for (String split : string.split("\\s*,\\s*")) {
+                if (!split.isEmpty()) result.add(split);
+            }
         }
 
         return result.toArray(new String[result.size()]);

--- a/modules/swagger-servlet/pom.xml
+++ b/modules/swagger-servlet/pom.xml
@@ -45,6 +45,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
There are some libs that have dependency on old Guava jars and some APIs have been removed over the years.
The swagger dependency on guava is pretty small, so I'm suggesting it would be nice to remove the dependency altogether.