### PR TITLE
CDI 2.0 beans.xml for swagger-jaxrs2 integration auto-discovery

### DIFF
--- a/modules/swagger-jaxrs2/pom.xml
+++ b/modules/swagger-jaxrs2/pom.xml
@@ -184,6 +184,24 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+            <version>3.0.2.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
+            <version>1.1.15.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-weld-embedded</artifactId>
+            <version>2.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <properties>
         <models.version>2.0.0-SNAPSHOT</models.version>

--- a/modules/swagger-jaxrs2/src/main/resources/META-INF/beans.xml
+++ b/modules/swagger-jaxrs2/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,1 @@
+<beans version="2.0" bean-discovery-mode="all"></beans>

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/cdi2/CDIAutodiscoveryTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/cdi2/CDIAutodiscoveryTest.java
@@ -1,0 +1,54 @@
+package io.swagger.v3.jaxrs2.cdi2;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.testng.AssertJUnit;
+import org.testng.annotations.Test;
+
+import io.swagger.v3.jaxrs2.SwaggerSerializers;
+import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
+
+import javax.enterprise.inject.spi.Extension;
+import javax.inject.Inject;
+
+public class CDIAutodiscoveryTest extends Arquillian {
+
+    @Inject
+    DiscoveryTestExtension ext;
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClasses(SwaggerSerializers.class)
+                .addPackage(OpenApiResource.class.getPackage())
+                .addAsServiceProviderAndClasses(Extension.class, DiscoveryTestExtension.class)
+                .addAsManifestResource("META-INF/beans.xml");
+    }
+
+    @Test
+    void confirmPathClassesWereDiscovered() {
+        String[] expected = {
+                "io.swagger.v3.jaxrs2.integration.resources.AcceptHeaderOpenApiResource",
+                "io.swagger.v3.jaxrs2.integration.resources.OpenApiResource"
+                };
+        Object[] found = ext.getResources().stream()
+                .map(resource -> resource.getName())
+                .sorted()
+                .toArray();
+        AssertJUnit.assertArrayEquals(expected, found);
+    }
+
+    @Test
+    void confirmProviderClassesWereDiscovered() {
+        String[] expected = {
+                "io.swagger.v3.jaxrs2.SwaggerSerializers"
+                };
+        Object[] found = ext.getProviders().stream()
+                .map(resource -> resource.getName())
+                .toArray();
+        AssertJUnit.assertArrayEquals(expected, found);
+    }
+
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/cdi2/DiscoveryTestExtension.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/cdi2/DiscoveryTestExtension.java
@@ -1,0 +1,43 @@
+package io.swagger.v3.jaxrs2.cdi2;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.WithAnnotations;
+import javax.ws.rs.Path;
+import javax.ws.rs.ext.Provider;
+
+public class DiscoveryTestExtension implements Extension {
+
+    private final Set<Class<?>> providers = new HashSet<>();
+    private final Set<Class<?>> resources = new HashSet<>();
+
+    public Set<Class<?>> getProviders() {
+        return providers;
+    }
+
+    public Set<Class<?>> getResources() {
+        return resources;
+    }
+
+    public <T> void observeResources(@WithAnnotations({ Path.class }) @Observes ProcessAnnotatedType<T> event) {
+        AnnotatedType<T> annotatedType = event.getAnnotatedType();
+
+        if (!annotatedType.getJavaClass().isInterface()) {
+            this.resources.add(annotatedType.getJavaClass());
+        }
+    }
+
+    public <T> void observeProviders(@WithAnnotations({ Provider.class }) @Observes ProcessAnnotatedType<T> event) {
+        AnnotatedType<T> annotatedType = event.getAnnotatedType();
+
+        if (!annotatedType.getJavaClass().isInterface()) {
+            this.providers.add(annotatedType.getJavaClass());
+        }
+    }
+
+}


### PR DESCRIPTION
This tiny beans.xml file allows me to directly use Swagger 2.0's `swagger-jaxrs2` jar in CDI-enabled environments that auto-detect all `@Path` & `@Provider` annotated classes by merely declaring the following dependencies:
```
    <dependency>
      <groupId>io.swagger.core.v3</groupId>
      <artifactId>swagger-jaxrs2</artifactId>
      <version>2.0.0-SNAPSHOT</version>
    </dependency>
    <dependency>
      <groupId>com.fasterxml.jackson.core</groupId>
      <artifactId>jackson-annotations</artifactId>
      <version>2.9.1</version>
    </dependency>
    <dependency>
      <groupId>com.google.guava</groupId>
      <artifactId>guava</artifactId>
      <version>23.0</version>
    </dependency>
```

BOOM! Live Swagger-2.0-provided `/openapi*` endpoints that are reflecting my other JAX-RS endpoints! I don't even need Swagger 2.0's convenient config file!

Fixes #2617