### PR TITLE
Addin MatrixParam support

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/DefaultParameterExtension.java
@@ -21,6 +21,7 @@ import javax.ws.rs.FormParam;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.MatrixParam;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -65,6 +66,13 @@ public class DefaultParameterExtension extends AbstractOpenAPIExtension {
                 PathParam param = (PathParam) annotation;
                 Parameter pp = new Parameter();
                 pp.setIn(PATH_PARAM);
+                pp.setName(param.value());
+                parameter = pp;
+            } else if (annotation instanceof MatrixParam) {
+                MatrixParam param = (MatrixParam) annotation;
+                Parameter pp = new Parameter();
+                pp.setIn(PATH_PARAM);
+                pp.setStyle(Parameter.StyleEnum.MATRIX);
                 pp.setName(param.value());
                 parameter = pp;
             } else if (annotation instanceof HeaderParam) {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/AnnotatedOperationMethodTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/AnnotatedOperationMethodTest.java
@@ -412,6 +412,36 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                 "                $ref: '#/components/schemas/Pet'\n" +
                 "        400:\n" +
                 "          description: Invalid tag value\n" +
+                "  /pet/findByCategory/{category}:\n" +
+                "    get:\n" +
+                "      summary: Finds Pets by category\n" +
+                "      operationId: findPetsByCategory\n" +
+                "      parameters:\n" +
+                "      - name: category\n" +
+                "        in: path\n" +
+                "        description: Category value that need to be considered for filter\n" +
+                "        required: true\n" +
+                "        style: matrix\n" +
+                "        schema:\n" +
+                "          $ref: '#/components/schemas/Category'\n" +
+                "      - name: skip\n" +
+                "        in: query\n" +
+                "        schema:\n" +
+                "          type: integer\n" +
+                "          format: int32\n" +
+                "      - name: limit\n" +
+                "        in: query\n" +
+                "        schema:\n" +
+                "          type: integer\n" +
+                "          format: int32\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          content:\n" +
+                "            application/json:\n" +
+                "              schema:\n" +
+                "                $ref: '#/components/schemas/Pet'\n" +
+                "        400:\n" +
+                "          description: Invalid category value\n" +
                 "  /pet/{petId}:\n" +
                 "    get:\n" +
                 "      summary: Find pet by ID\n" +

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/PetResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/PetResource.java
@@ -18,6 +18,7 @@ package io.swagger.v3.jaxrs2.resources;
 
 import io.swagger.v3.jaxrs2.resources.data.PetData;
 import io.swagger.v3.jaxrs2.resources.exception.NotFoundException;
+import io.swagger.v3.jaxrs2.resources.model.Category;
 import io.swagger.v3.jaxrs2.resources.model.Pet;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -28,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
+import javax.ws.rs.MatrixParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -143,6 +145,25 @@ public class PetResource {
             @BeanParam QueryResultBean qr
     ) {
         return Response.ok(petData.findPetByStatus(status)).build();
+    }
+
+    @GET
+    @Path("/findByCategory/{category}")
+    @Produces("application/xml")
+    @Operation(summary = "Finds Pets by category",
+            responses = {
+                    @ApiResponse(
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = Pet.class))),
+                    @ApiResponse(
+                            responseCode = "400", description = "Invalid category value"
+                    )}
+    )
+    public Response findPetsByCategory(
+            @Parameter(description = "Category value that need to be considered for filter", required = true) @MatrixParam("category") Category category,
+            @BeanParam QueryResultBean qr
+    ) {
+        return Response.ok(petData.findPetByCategory(category)).build();
     }
 
     @GET

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/data/PetData.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/data/PetData.java
@@ -22,6 +22,7 @@ import io.swagger.v3.jaxrs2.resources.model.Tag;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PetData {
     static List<Pet> pets = new ArrayList<Pet>();
@@ -78,6 +79,10 @@ public class PetData {
             }
         }
         return result;
+    }
+
+    public List<Pet> findPetByCategory(Category category) {
+        return pets.stream().filter(pet -> category.equals(pet.getCategory())).collect(Collectors.toList());
     }
 
     public List<Pet> findPetByTags(String tags) {


### PR DESCRIPTION
swagger-jaxrs2 is at the moment barely ignoring the `@MatrixParam` annotation.