### PR TITLE
refs #2644 2.0 issue/interface annotation inheritance

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
@@ -302,7 +302,7 @@ public class ReflectionUtils {
                 annotations = getRepeatableAnnotationsArray(superClass, annotationClass);
             }
         }
-        if (annotations == null) {
+        if (annotations == null || annotations.length == 0) {
             for (Class<?> anInterface : cls.getInterfaces()) {
                 for (Annotation metaAnnotation : anInterface.getAnnotations()) {
                     annotations = metaAnnotation.annotationType().getAnnotationsByType(annotationClass);
@@ -315,9 +315,6 @@ public class ReflectionUtils {
                     return annotations;
                 }
             }
-        }
-        if (annotations == null) {
-            return null;
         }
         return annotations;
     }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/util/reflection/ReflectionUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/util/reflection/ReflectionUtilsTest.java
@@ -6,6 +6,7 @@ import io.swagger.v3.core.util.reflection.resources.IParent;
 import io.swagger.v3.core.util.reflection.resources.Parent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -138,4 +139,18 @@ public class ReflectionUtilsTest {
         Method method = ReflectionUtilsTest.class.getMethod("testFindMethodForNullClass", (Class<?>[]) null);
         assertNull(ReflectionUtils.findMethod(method, null));
     }
+
+    @Test
+    public void getRepeatableAnnotationsArrayTest() {
+        Tag[] annotations = ReflectionUtils.getRepeatableAnnotationsArray(InheritingClass.class, Tag.class);
+        Assert.assertNotNull(annotations);
+        Assert.assertTrue(annotations.length == 1);
+        Assert.assertNotNull(annotations[0]);
+        Assert.assertEquals("inherited tag", annotations[0].name());
+    }
+
+    @Tag(name = "inherited tag")
+    private interface AnnotatedInterface {}
+
+    private class InheritingClass implements AnnotatedInterface {}
 }


### PR DESCRIPTION
This fixes the bug described in https://github.com/swagger-api/swagger-core/issues/2644 (_Annotation inheritance from interfaces broken_). I feel like the problem is pretty well documented in the issue, so I'll spare duplicating it here.

I'll note that at the time I branched off of the [2.0 branch](https://github.com/swagger-api/swagger-core/tree/2.0), there were 4 tests failing:
```
io.swagger.v3.core.converting.NumericFormatTest
    testFormatOfBigDecimal
    testFormatOfDecimal
    testFormatOfInteger
io.swagger.v3.core.deserialization.properties.MapPropertyDeserializerTest
    testBooleanAdditionalPropertiesSerialization
```
No new tests fail after my additions, and the same 4 tests still fail.


I was not able to use to the HEAD of 2.0 to generate the openApi doc in my application where I first noticed the issue (it seems as if the latest commit, https://github.com/swagger-api/swagger-core/commit/b1fd067e65ea1a2bd8e0d8317b8fdfee6447948a, is not stable) . Hence, I am unable to validate in a live application that my change fixes the issue against that commit.

However, I did checkout https://github.com/swagger-api/swagger-core/commit/3d5cdee7d3eccdb276ac9ad70549fb1510dbc46f (_prepare rc 2.0.0-rc4_ ) and re-applied my changes. From there I was able to bring the modified artifact into my application (which was using 2.0.0-rc4 already), and verify that the swagger doc generation was working as expected.

I am confident that my fix will work similarly applied against https://github.com/swagger-api/swagger-core/commit/b1fd067e65ea1a2bd8e0d8317b8fdfee6447948a, once any issues are resolved.

My team (I work at Cerner) is eager to see this code change integrated. Please let me know if I can help resolve any road blocks to accepting this PR.