### PR TITLE
Take into account parentResponses and components.getResponses()

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -720,6 +720,19 @@ public class Reader implements OpenApiReader {
                 parentResponses);
     }
 
+    private void addApiResponses(Operation operation, Map<String, ApiResponse> responses) {
+        if (responses != null && !responses.isEmpty()) {
+            responses.forEach((code, response) -> {
+                if (!ApiResponses.DEFAULT.equals(code)) {
+                    if (operation.getResponses() == null) {
+                        operation.setResponses(new ApiResponses());
+                    }
+                    operation.getResponses().addApiResponse(code, response);
+                }
+            });
+        }
+    }
+
     private Operation parseMethod(
             Class<?> cls,
             Method method,
@@ -825,7 +838,9 @@ public class Reader implements OpenApiReader {
         }
 
         // apiResponses
-        if (apiResponses != null && apiResponses.size() > 0) {
+        addApiResponses(operation, components.getResponses());
+        addApiResponses(operation, parentResponses);
+        if (apiResponses != null && !apiResponses.isEmpty()) {
             OperationParser.getApiResponses(
                     apiResponses.toArray(new io.swagger.v3.oas.annotations.responses.ApiResponse[apiResponses.size()]),
                     classProduces,


### PR DESCRIPTION
At the moment it seems that `parentResponses` and `components.getResponses()` are barely ignored.