### PR TITLE
Fixing Guava version OSGi imports as reflections-0.9.11 is using 20.0

### DIFF
--- a/modules/swagger-jaxrs2/pom.xml
+++ b/modules/swagger-jaxrs2/pom.xml
@@ -38,6 +38,7 @@
                         </Export-Package>
                         <Import-Package>
                             javax.ws.rs*;version="2.0",
+                            com.google.common.base;version="[20.0,24)",
                             *
                         </Import-Package>
                     </instructions>


### PR DESCRIPTION
Hey guys,

Run into this unexpected issue recently while integrating `Swagger 2.0` into Karaf OSGi container (`4.1.x` releases) for JAX-RS services. So Swagger `2.0` has a dependency on Guava `23.0` while the underlying `reflections-0.9.11` library is declaring dependency on Guava `20.0`. Obviously, the `23.0` is being picked up at the end, which messes up the  OSGi import constraints. One of the possible solutions (this PR) is to relax the requirement for Guava versions, `[20.0, 24)` instead of `[23.0, 24)`. With that, and the fix for `reflections-0.9.11` (https://github.com/apache/servicemix-bundles/pull/111), things are working properly. 

Best Regards,
    Andriy Redko