### PR TITLE
#2705 Oerwritting Default Responses at Class Level

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/Reader.java
@@ -942,18 +942,16 @@ public class Reader {
             }
         }
 
+        //class level @ApiResponse
+        for (ApiResponse apiResponse : classApiResponses) {
+            addResponse(operation, apiResponse, jsonViewAnnotation);
+        }
+        
+        //method level @ApiResponse
         for (ApiResponse apiResponse : apiResponses) {
             addResponse(operation, apiResponse, jsonViewAnnotation);
         }
-        // merge class level @ApiResponse
-        for (ApiResponse apiResponse : classApiResponses) {
-            String key = (apiResponse.code() == 0) ? "default" : String.valueOf(apiResponse.code());
-            if (operation.getResponses() != null && operation.getResponses().containsKey(key)) {
-                continue;
-            }
-            addResponse(operation, apiResponse, jsonViewAnnotation);
-        }
-
+        
         if (ReflectionUtils.getAnnotation(method, Deprecated.class) != null) {
             operation.setDeprecated(true);
         }


### PR DESCRIPTION
Issue is [here](https://github.com/swagger-api/swagger-core/issues/2705)

Class level `@ApiResponse` annotations are not able to overwrite default responses (eg. 200). This PR allows for default responses to be overwritten at the class level while simplifying the order responses are added to the Operation object.