### PR TITLE
refs #672 - NullPointerException when converting an spec

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/utils/PropertyModelConverter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/utils/PropertyModelConverter.java
@@ -40,7 +40,7 @@ public class PropertyModelConverter {
                 List<String> required = m.getRequired();
                 if (required != null) {
                     for (String name : required) {
-                        if (m.getName().equals(name)) {
+                        if (name.equals(m.getName())) {
                             mapProperty.setRequired(true);
                         }
                     }


### PR DESCRIPTION
Solution to https://github.com/swagger-api/swagger-parser/issues/672, it was happening when we were trying to convert a spec.

Avoiding NPE changing the if logic.

The Test Case was added in the parser project.