### PR TITLE
Bugfix/issue 673 missing properties body parameter convertion

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/ModelSerializerTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/ModelSerializerTest.java
@@ -6,6 +6,7 @@ import io.swagger.converter.ModelConverters;
 import io.swagger.matchers.SerializationMatchers;
 import io.swagger.models.ArrayModel;
 import io.swagger.models.Car;
+import io.swagger.models.ComposedModel;
 import io.swagger.models.ExternalDocs;
 import io.swagger.models.Manufacturers;
 import io.swagger.models.Model;
@@ -384,5 +385,147 @@ public class ModelSerializerTest {
         IntegerProperty ip = (IntegerProperty) model.getProperties().get("id");
         assertEquals(ip.getMultipleOf(), new BigDecimal("3.0"));
 
+    }
+
+    @Test(description = "It should serialize a ModelImpl with new values added in 673")
+    public void issue673SerializeModelImpl() throws IOException {
+        final ModelImpl modelImpl = new ModelImpl();
+        modelImpl.setMultipleOf(new BigDecimal(10));
+        modelImpl.setMinimum(new BigDecimal(1));
+        modelImpl.setMaximum(new BigDecimal(100));
+        modelImpl.setExclusiveMinimum(true);
+        modelImpl.setExclusiveMaximum(true);
+        modelImpl.setUniqueItems(true);
+        modelImpl.setMinLength(1);
+        modelImpl.setMaxLength(10);
+        modelImpl.setPattern("Pattern");
+        assertEquals(m.writeValueAsString(modelImpl), "{\"minimum\":1,\"maximum\":100,\"multipleOf\":10,\"exclusiveMinimum\":true,\"exclusiveMaximum\":true,\"minLength\":1,\"maxLength\":10,\"pattern\":\"Pattern\",\"uniqueItems\":true}");
+    }
+
+    @Test(description = "It should serialize an ArrayModel with new values added in 673")
+    public void issue673SerializeArrayModel() throws IOException {
+        final ArrayModel arrayModel = new ArrayModel();
+        arrayModel.setMultipleOf(new BigDecimal(10));
+        arrayModel.setMinimum(new BigDecimal(1));
+        arrayModel.setMaximum(new BigDecimal(100));
+        arrayModel.setExclusiveMinimum(true);
+        arrayModel.setExclusiveMaximum(true);
+        arrayModel.setUniqueItems(true);
+        arrayModel.setMinLength(1);
+        arrayModel.setMaxLength(10);
+        arrayModel.setPattern("Pattern");
+        assertEquals(m.writeValueAsString(arrayModel), "{\"minimum\":1,\"maximum\":100,\"multipleOf\":10,\"exclusiveMinimum\":true,\"exclusiveMaximum\":true,\"minLength\":1,\"maxLength\":10,\"pattern\":\"Pattern\",\"type\":\"array\",\"uniqueItems\":true}");
+    }
+
+    @Test(description = "It should serialize a ComposedModel with new values added in 673")
+    public void issue673SerializeComposedModel() throws IOException {
+        final ComposedModel composedModel = new ComposedModel();
+        composedModel.setMultipleOf(new BigDecimal(10));
+        composedModel.setMinimum(new BigDecimal(1));
+        composedModel.setMaximum(new BigDecimal(100));
+        composedModel.setExclusiveMinimum(true);
+        composedModel.setExclusiveMaximum(true);
+        composedModel.setMinLength(1);
+        composedModel.setMaxLength(10);
+        composedModel.setPattern("Pattern");
+        assertEquals(m.writeValueAsString(composedModel), "{\"minimum\":1,\"maximum\":100,\"multipleOf\":10,\"exclusiveMinimum\":true,\"exclusiveMaximum\":true,\"minLength\":1,\"maxLength\":10,\"pattern\":\"Pattern\",\"allOf\":[]}");
+    }
+
+    @Test(description = "Deserialize New Boolean Values: SwaggerConverter drops some validation properties of body parameters")
+    public void testIssue673DeserializeBooleanValues() throws Exception {
+        String json = "{\n" +
+                "  \"type\": \"boolean\",\n" +
+                "  \"exclusiveMaximum\": true,\n" +
+                "  \"exclusiveMinimum\": true" +
+                "}";
+
+        final ModelImpl modelImpl = Json.mapper().readValue(json, ModelImpl.class);
+        final ArrayModel arrayModel = Json.mapper().readValue(json, ArrayModel.class);
+        final ComposedModel composedModel = Json.mapper().readValue(json, ComposedModel.class);
+
+        assertEquals(modelImpl.getExclusiveMaximum().booleanValue(), true);
+        assertEquals(modelImpl.getExclusiveMinimum().booleanValue(), true);
+
+        assertEquals(arrayModel.getExclusiveMaximum().booleanValue(), true);
+        assertEquals(arrayModel.getExclusiveMinimum().booleanValue(), true);
+
+        assertEquals(composedModel.getExclusiveMaximum().booleanValue(), true);
+        assertEquals(composedModel.getExclusiveMinimum().booleanValue(), true);
+    }
+
+    @Test(description = "Deserialize New Integer Values: SwaggerConverter drops some validation properties of body parameters")
+    public void testIssue673DeserializeIntegerValues() throws Exception {
+        String json = "{\n" +
+                "  \"type\": \"integer\",\n" +
+                "  \"minLength\": 1,\n" +
+                "  \"maxLength\": 10" +
+                "}";
+
+        final ModelImpl modelImpl = Json.mapper().readValue(json, ModelImpl.class);
+        final ArrayModel arrayModel = Json.mapper().readValue(json, ArrayModel.class);
+        final ComposedModel composedModel = Json.mapper().readValue(json, ComposedModel.class);
+
+        assertEquals(modelImpl.getMinLength().intValue(), 1);
+        assertEquals(modelImpl.getMaxLength().intValue(), 10);
+
+        assertEquals(arrayModel.getMinLength().intValue(), 1);
+        assertEquals(arrayModel.getMaxLength().intValue(), 10);
+
+        assertEquals(composedModel.getMinLength().intValue(), 1);
+        assertEquals(composedModel.getMaxLength().intValue(), 10);
+    }
+
+    @Test(description = "Deserialize New Number Values: SwaggerConverter drops some validation properties of body parameters")
+    public void testIssue673DeserializeNumberValues() throws Exception {
+        String json = "{\n" +
+                "  \"type\": \"number\",\n" +
+                "  \"multipleOf\": 5" +
+                "}";
+
+        final ModelImpl modelImpl = Json.mapper().readValue(json, ModelImpl.class);
+        final ArrayModel arrayModel = Json.mapper().readValue(json, ArrayModel.class);
+        final ComposedModel composedModel = Json.mapper().readValue(json, ComposedModel.class);
+
+        assertEquals(modelImpl.getMultipleOf().intValue(), 5);
+        assertEquals(arrayModel.getMultipleOf().intValue(), 5);
+        assertEquals(composedModel.getMultipleOf().intValue(), 5);
+    }
+
+    @Test(description = "Deserialize New BigDecimal Values: SwaggerConverter drops some validation properties of body parameters")
+    public void testIssue673DeserializeBigDecimalValues() throws Exception {
+        String json = "{\n" +
+                "  \"type\": \"bigDecimal\",\n" +
+                "  \"minimum\": 1,\n" +
+                "  \"maximum\": 100" +
+                "}";
+
+        final ModelImpl modelImpl = Json.mapper().readValue(json, ModelImpl.class);
+        final ArrayModel arrayModel = Json.mapper().readValue(json, ArrayModel.class);
+        final ComposedModel composedModel = Json.mapper().readValue(json, ComposedModel.class);
+
+        assertEquals(modelImpl.getMinimum().intValue(), 1);
+        assertEquals(modelImpl.getMaximum().intValue(), 100);
+
+        assertEquals(arrayModel.getMinimum().intValue(), 1);
+        assertEquals(arrayModel.getMaximum().intValue(), 100);
+
+        assertEquals(composedModel.getMinimum().intValue(), 1);
+        assertEquals(composedModel.getMaximum().intValue(), 100);
+    }
+
+    @Test(description = "Deserialize New String Values: SwaggerConverter drops some validation properties of body parameters")
+    public void testIssue673DeserializeStringValues() throws Exception {
+        String json = "{\n" +
+                "  \"type\": \"string\",\n" +
+                "  \"pattern\": \"Pattern\"" +
+                "}";
+
+        final ModelImpl modelImpl = Json.mapper().readValue(json, ModelImpl.class);
+        final ArrayModel arrayModel = Json.mapper().readValue(json, ArrayModel.class);
+        final ComposedModel composedModel = Json.mapper().readValue(json, ComposedModel.class);
+
+        assertEquals(modelImpl.getPattern(), "Pattern");
+        assertEquals(arrayModel.getPattern(), "Pattern");
+        assertEquals(composedModel.getPattern(), "Pattern");
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/util/PropertyModelConverterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/util/PropertyModelConverterTest.java
@@ -12,26 +12,12 @@ import io.swagger.models.Path;
 import io.swagger.models.RefModel;
 import io.swagger.models.Response;
 import io.swagger.models.Swagger;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.BinaryProperty;
-import io.swagger.models.properties.BooleanProperty;
-import io.swagger.models.properties.ByteArrayProperty;
-import io.swagger.models.properties.DateProperty;
-import io.swagger.models.properties.DateTimeProperty;
-import io.swagger.models.properties.DoubleProperty;
-import io.swagger.models.properties.EmailProperty;
-import io.swagger.models.properties.IntegerProperty;
-import io.swagger.models.properties.LongProperty;
-import io.swagger.models.properties.MapProperty;
-import io.swagger.models.properties.ObjectProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.RefProperty;
-import io.swagger.models.properties.StringProperty;
-import io.swagger.models.properties.UUIDProperty;
+import io.swagger.models.properties.*;
 import io.swagger.models.utils.PropertyModelConverter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,7 +47,6 @@ public class PropertyModelConverterTest {
         Assert.assertTrue(property instanceof UUIDProperty);
         Assert.assertEquals(property.getType(),"string");
         Assert.assertEquals(property.getFormat(),"uuid");
-
     }
 
     @Test
@@ -85,7 +70,6 @@ public class PropertyModelConverterTest {
         Assert.assertTrue(property instanceof EmailProperty);
         Assert.assertEquals(property.getType(),"string");
         Assert.assertEquals(property.getFormat(),"email");
-
     }
 
     @Test
@@ -107,7 +91,6 @@ public class PropertyModelConverterTest {
 
         Assert.assertTrue(property instanceof BooleanProperty);
         Assert.assertEquals(property.getType(),"boolean");
-
     }
 
     @Test
@@ -180,6 +163,31 @@ public class PropertyModelConverterTest {
     }
 
     @Test
+    public void convertToStringNewProperty()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: string\n"+
+                "            format: password\n"+
+                "            pattern: Pattern\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof StringProperty);
+        Assert.assertEquals(property.getType(),"string");
+        Assert.assertEquals(property.getFormat(),"password");
+        Assert.assertEquals(((StringProperty)property).getPattern(),"Pattern");
+    }
+
+    @Test
     public void convertToBinaryProperty()throws Exception{
         String yaml = "      produces:\n" +
                 "        - application/json\n" +
@@ -223,7 +231,33 @@ public class PropertyModelConverterTest {
         Assert.assertTrue(property instanceof DoubleProperty);
         Assert.assertEquals(property.getType(),"number");
         Assert.assertEquals(property.getFormat(),"double");
+    }
 
+    @Test
+    public void convertToNumericNewProperties()throws Exception{
+        String yaml = "      produces:\n" +
+                "        - application/json\n" +
+                "      parameters:\n" +
+                "        []\n" +
+                "      responses:\n" +
+                "        200:\n" +
+                "          description: OK\n" +
+                "          schema:\n" +
+                "            type: number\n"+
+                "            minimum: 1\n"+
+                "            maximum: 100\n"+
+                "            format: double\n";
+
+        Operation operation = Yaml.mapper().readValue(yaml, Operation.class);
+        Response response = operation.getResponses().get("200");
+        Assert.assertNotNull(response);
+        Property property = response.getSchema();
+
+        Assert.assertTrue(property instanceof DoubleProperty);
+        Assert.assertEquals(property.getType(),"number");
+        Assert.assertEquals(property.getFormat(),"double");
+        Assert.assertEquals(((DoubleProperty)property).getMinimum(), new BigDecimal(1));
+        Assert.assertEquals(((DoubleProperty)property).getMaximum(), new BigDecimal(100));
     }
 
     @Test
@@ -270,7 +304,6 @@ public class PropertyModelConverterTest {
         Assert.assertTrue(property instanceof LongProperty);
         Assert.assertEquals(property.getType(),"integer");
         Assert.assertEquals(property.getFormat(),"int64");
-
     }
 
     @Test
@@ -294,7 +327,6 @@ public class PropertyModelConverterTest {
         Assert.assertTrue(property instanceof IntegerProperty);
         Assert.assertEquals(property.getType(),"integer");
         Assert.assertEquals(property.getFormat(),"int32");
-
     }
 
     @Test
@@ -324,22 +356,18 @@ public class PropertyModelConverterTest {
         Assert.assertEquals(arrayProperty.getItems().getType(),"string");
         Assert.assertEquals(arrayProperty.getItems().getFormat(),"date-time");
         Assert.assertEquals(arrayProperty.getItems().getExample(),"1985-04-12T23:20:50.52Z");
-
     }
-
 
     @Test
     public void convertArrayModel()throws Exception{
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/models.yaml").toURI())));
 
-
         String specAsYaml = rootNode.toString();
 
         Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
 
         Model arrayModel  = swagger.getDefinitions().get("InstructionSequence");
-
 
         PropertyModelConverter converter = new PropertyModelConverter();
         Property convertedProperty = converter.modelToProperty(arrayModel);
@@ -352,6 +380,34 @@ public class PropertyModelConverterTest {
         Assert.assertEquals(property.getType(),"array");
         Assert.assertTrue(property.getItems() instanceof StringProperty);
         Assert.assertEquals(property.getItems().getType(),"string");
+    }
+
+    @Test
+    public void convertArrayWithNewPropertiesModel()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/models.yaml").toURI())));
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Model arrayModel  = swagger.getDefinitions().get("NewSequence");
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Property convertedProperty = converter.modelToProperty(arrayModel);
+
+        Assert.assertTrue(convertedProperty instanceof ArrayProperty);
+        ArrayProperty property = (ArrayProperty) convertedProperty;
+
+        Assert.assertEquals(property.getTitle(),"NewSequence");
+        Assert.assertEquals(property.getDescription(),"A new sequence of steps that make up the Instructions");
+        Assert.assertEquals(property.getType(),"array");
+        Assert.assertTrue(property.getItems() instanceof StringProperty);
+        final StringProperty stringProperty = (StringProperty) property.getItems();
+        Assert.assertEquals(property.getItems().getType(),"string");
+        /*Assert.assertEquals(stringProperty.getPattern(),"Pattern");
+        Assert.assertEquals(property.getExclusiveMaximum(), Boolean.TRUE);
+        Assert.assertEquals(property.getExclusiveMinimum(), Boolean.TRUE);*/
 
     }
 
@@ -360,13 +416,11 @@ public class PropertyModelConverterTest {
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/models.yaml").toURI())));
 
-
         String specAsYaml = rootNode.toString();
 
         Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
 
         Model arrayModel  = swagger.getDefinitions().get("Address");
-
 
         PropertyModelConverter converter = new PropertyModelConverter();
         Property convertedProperty = converter.modelToProperty(arrayModel);
@@ -377,15 +431,12 @@ public class PropertyModelConverterTest {
         Assert.assertEquals(property.getType(),"object");
         Assert.assertEquals(property.getRequiredProperties().get(0),"street");
         Assert.assertEquals(property.getProperties().get("city").getType(),"string");
-
     }
 
     @Test
     public void composedExtendedModelToPropertyTest()throws Exception{
-
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/models.yaml").toURI())));
-
 
         String specAsYaml = rootNode.toString();
 
@@ -405,12 +456,56 @@ public class PropertyModelConverterTest {
         Assert.assertEquals(objectProperty.getRequiredProperties().get(0),"gps");
     }
 
+    @Test
+    public void stringNewPropertiesModelToPropertyTest()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/models.yaml").toURI())));
 
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Model composedModel  = swagger.getDefinitions().get("NewExtendedStringAddress");
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Property convertedProperty = converter.modelToProperty(composedModel);
+
+        Assert.assertTrue(convertedProperty instanceof StringProperty);
+        StringProperty objectProperty = (StringProperty) convertedProperty;
+        Assert.assertEquals(objectProperty.getType(),"string");
+
+        Assert.assertEquals(objectProperty.getPattern(),"Pattern");
+        Assert.assertEquals(objectProperty.getMinLength(), new Integer(10));
+        Assert.assertEquals(objectProperty.getMaxLength(), new Integer(50));
+    }
+
+    @Test
+    public void numericNewPropertiesModelToPropertyTest()throws Exception{
+        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/models.yaml").toURI())));
+
+        String specAsYaml = rootNode.toString();
+
+        Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
+
+        Model composedModel  = swagger.getDefinitions().get("NewExtendedNumericAddress");
+
+        PropertyModelConverter converter = new PropertyModelConverter();
+        Property convertedProperty = converter.modelToProperty(composedModel);
+
+        Assert.assertTrue(convertedProperty instanceof AbstractNumericProperty);
+        AbstractNumericProperty objectProperty = (AbstractNumericProperty) convertedProperty;
+        Assert.assertEquals(objectProperty.getType(),"number");
+        Assert.assertEquals(objectProperty.getExclusiveMaximum(), Boolean.TRUE);
+        Assert.assertEquals(objectProperty.getExclusiveMinimum(), Boolean.TRUE);
+        Assert.assertEquals(objectProperty.getMultipleOf(),new BigDecimal(5));
+        Assert.assertEquals(objectProperty.getMinimum(),new BigDecimal(1));
+        Assert.assertEquals(objectProperty.getMaximum(),new BigDecimal(100));
+    }
 
 
     @Test
     public void composedModelToPropertyTest(){
-
         List<Model> list = new ArrayList();
         List<String> requiredList = new ArrayList();
         requiredList.add("url");
@@ -448,12 +543,10 @@ public class PropertyModelConverterTest {
         Assert.assertEquals(objectProperty.getProperties().get("url").getType(),"string");
         Assert.assertEquals(objectProperty.getProperties().get("ReferencedObject1").getType(),"ref");
         Assert.assertEquals(objectProperty.getRequiredProperties().get(0),"url");
-
     }
 
     @Test
     public void convertPropertyToModel(){
-
         IntegerProperty integerProperty = new IntegerProperty();
         MapProperty mapProperty = new MapProperty();
         mapProperty.setAdditionalProperties(integerProperty);
@@ -465,14 +558,12 @@ public class PropertyModelConverterTest {
         ModelImpl model = (ModelImpl) convertedModel;
         Assert.assertEquals(model.getType(),"object");
         Assert.assertEquals(model.getAdditionalProperties().getType(),"integer");
-
     }
 
     @Test
     public void convertStringProperty()throws Exception{
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
-
 
         String specAsYaml = rootNode.toString();
 
@@ -497,7 +588,6 @@ public class PropertyModelConverterTest {
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
 
-
         String specAsYaml = rootNode.toString();
 
         Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
@@ -519,7 +609,6 @@ public class PropertyModelConverterTest {
     public void convertBooleanProperty()throws Exception{
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
-
 
         String specAsYaml = rootNode.toString();
 
@@ -544,7 +633,6 @@ public class PropertyModelConverterTest {
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
 
-
         String specAsYaml = rootNode.toString();
 
         Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
@@ -568,7 +656,6 @@ public class PropertyModelConverterTest {
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
 
-
         String specAsYaml = rootNode.toString();
 
         Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
@@ -591,7 +678,6 @@ public class PropertyModelConverterTest {
     public void convertArrayOfRefProperty()throws Exception{
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
-
 
         String specAsYaml = rootNode.toString();
 
@@ -618,7 +704,6 @@ public class PropertyModelConverterTest {
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
 
-
         String specAsYaml = rootNode.toString();
 
         Swagger swagger = Yaml.mapper().readValue(specAsYaml, Swagger.class);
@@ -634,15 +719,12 @@ public class PropertyModelConverterTest {
         Assert.assertTrue(convertedModel instanceof RefModel);
         RefModel model = (RefModel) convertedModel;
         Assert.assertEquals(model.get$ref(),"#/definitions/ArrayOfint");
-
-
     }
 
     @Test
     public void convertObjectProperty()throws Exception{
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         final JsonNode rootNode = mapper.readTree(Files.readAllBytes(java.nio.file.Paths.get(getClass().getResource("/specFiles/responses.yaml").toURI())));
-
 
         String specAsYaml = rootNode.toString();
 
@@ -664,7 +746,5 @@ public class PropertyModelConverterTest {
         Assert.assertEquals(model.getProperties().get("name").getType(), "string");
         Assert.assertEquals(model.getRequired().get(0), "id");
         Assert.assertEquals(model.getRequired().get(1), "name");
-
-
     }
 }

--- a/modules/swagger-core/src/test/resources/specFiles/models.yaml
+++ b/modules/swagger-core/src/test/resources/specFiles/models.yaml
@@ -95,9 +95,55 @@ definitions:
         properties:
           gps:
             type: string
+  NewExtendedAddress:
+    type: object
+    pattern: Pattern
+    exclusiveMinimum: true
+    exclusiveMaximum: true
+    minimum: 1
+    maximum: 100
+    minLength: 10
+    maxLength: 50
+    multipleOf: 5
+    allOf:
+      - $ref: '#/definitions/Address'
+      - type: object
+        required:
+        - gps
+        properties:
+          gps:
+            type: string
+            pattern: Pattern
+  NewExtendedStringAddress:
+      type: string
+      pattern: Pattern
+      minLength: 10
+      maxLength: 50
+  NewExtendedNumericAddress:
+      type: number
+      exclusiveMinimum: true
+      exclusiveMaximum: true
+      minimum: 1
+      maximum: 100
+      multipleOf: 5
   InstructionSequence:
       title: InstructionSequence
       description: The sequence of steps that make up the Instructions
       type: array
       items:
           type: string
+  NewSequence:
+      title: NewSequence
+      description: A new sequence of steps that make up the Instructions
+      type: array
+      pattern: Pattern
+      exclusiveMinimum: true
+      exclusiveMaximum: true
+      minimum: 1
+      maximum: 100
+      minLength: 10
+      maxLength: 50
+      multipleOf: 5
+      items:
+          type: string
+          pattern: Pattern

--- a/modules/swagger-models/src/main/java/io/swagger/models/AbstractModel.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/AbstractModel.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -13,6 +14,14 @@ public abstract class AbstractModel implements Model {
     private String title;
     private Map<String, Object> vendorExtensions = new LinkedHashMap<String, Object>();
     private Xml xml;
+    private BigDecimal minimum;
+    private BigDecimal maximum;
+    private BigDecimal multipleOf;
+    private Boolean exclusiveMinimum;
+    private Boolean exclusiveMaximum;
+    private Integer minLength;
+    private Integer maxLength;
+    private String pattern;
 
     @Override
     public ExternalDocs getExternalDocs() {
@@ -45,6 +54,70 @@ public abstract class AbstractModel implements Model {
         }
     }
 
+    public BigDecimal getMinimum() {
+        return minimum;
+    }
+
+    public void setMinimum(BigDecimal minimum) {
+        this.minimum = minimum;
+    }
+
+    public BigDecimal getMaximum() {
+        return maximum;
+    }
+
+    public void setMaximum(BigDecimal maximum) {
+        this.maximum = maximum;
+    }
+
+    public BigDecimal getMultipleOf() {
+        return multipleOf;
+    }
+
+    public void setMultipleOf(BigDecimal multipleOf) {
+        this.multipleOf = multipleOf;
+    }
+
+    public Boolean getExclusiveMinimum() {
+        return exclusiveMinimum;
+    }
+
+    public void setExclusiveMinimum(Boolean exclusiveMinimum) {
+        this.exclusiveMinimum = exclusiveMinimum;
+    }
+
+    public Boolean getExclusiveMaximum() {
+        return exclusiveMaximum;
+    }
+
+    public void setExclusiveMaximum(Boolean exclusiveMaximum) {
+        this.exclusiveMaximum = exclusiveMaximum;
+    }
+
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    public void setMinLength(Integer minLength) {
+        this.minLength = minLength;
+    }
+
+    public Integer getMaxLength() {
+        return maxLength;
+    }
+
+    public void setMaxLength(Integer maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
     public void setVendorExtensions(Map<String, Object> vendorExtensions) {
         this.vendorExtensions = vendorExtensions;
     }
@@ -54,6 +127,15 @@ public abstract class AbstractModel implements Model {
         cloned.externalDocs = this.externalDocs;
         cloned.reference = reference;
         cloned.title = title;
+        cloned.minimum = this.minimum;
+        cloned.maximum = this.maximum;
+        cloned.minLength = this.minLength;
+        cloned.maxLength = this.maxLength;
+        cloned.exclusiveMinimum = this.exclusiveMinimum;
+        cloned.exclusiveMaximum = this.exclusiveMaximum;
+        cloned.pattern = this.pattern;
+        cloned.multipleOf = this.multipleOf;
+        cloned.pattern = this.pattern;
         if (vendorExtensions == null) {
             cloned.vendorExtensions = vendorExtensions;
         } else {
@@ -76,16 +158,20 @@ public abstract class AbstractModel implements Model {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result
-                + ((externalDocs == null) ? 0 : externalDocs.hashCode());
-        result = prime * result
-                + ((vendorExtensions == null) ? 0 : vendorExtensions.hashCode());
-        result = prime * result
-                + ((reference == null) ? 0 : reference.hashCode());
-        result = prime * result
-                + ((title == null) ? 0 : title.hashCode());
-        result = prime * result
-                + ((xml == null) ? 0 : xml.hashCode());
+        result = prime * result + ((externalDocs == null) ? 0 : externalDocs.hashCode());
+        result = prime * result + ((vendorExtensions == null) ? 0 : vendorExtensions.hashCode());
+        result = prime * result + ((reference == null) ? 0 : reference.hashCode());
+        result = prime * result + ((title == null) ? 0 : title.hashCode());
+        result = prime * result + ((xml == null) ? 0 : xml.hashCode());
+        result = prime * result + (minimum != null ? minimum.hashCode() : 0);
+        result = prime * result + (maximum != null ? maximum.hashCode() : 0);
+        result = prime * result + (minLength != null ? minLength.hashCode() : 0);
+        result = prime * result + (maxLength != null ? maxLength.hashCode() : 0);
+        result = prime * result + (exclusiveMinimum != null ? exclusiveMinimum.hashCode() : 0);
+        result = prime * result + (exclusiveMaximum != null ? exclusiveMaximum.hashCode() : 0);
+        result = prime * result + (pattern != null ? pattern.hashCode() : 0);
+        result = prime * result + (multipleOf != null ? multipleOf.hashCode() : 0);
+        result = prime * result + (pattern != null ? pattern.hashCode() : 0);
         return result;
     }
 
@@ -136,8 +222,32 @@ public abstract class AbstractModel implements Model {
         } else if (!xml.equals(other.xml)) {
             return false;
         }
+        if (exclusiveMaximum != null ? !exclusiveMaximum.equals(other.exclusiveMaximum) : other.exclusiveMaximum != null) {
+            return false;
+        }
+        if (exclusiveMinimum != null ? !exclusiveMinimum.equals(other.exclusiveMinimum) : other.exclusiveMinimum != null) {
+            return false;
+        }
+        if (minimum != null ? !minimum.equals(other.minimum) : other.minimum != null) {
+            return false;
+        }
+        if (minLength != null ? !minLength.equals(other.minLength) : other.minLength != null) {
+            return false;
+        }
+        if (maxLength != null ? !maxLength.equals(other.maxLength) : other.maxLength != null) {
+            return false;
+        }
+        if (pattern != null ? !pattern.equals(other.pattern) : other.pattern != null) {
+            return false;
+        }
+        if (multipleOf != null ? !multipleOf.equals(other.multipleOf) : other.multipleOf != null) {
+            return false;
+        }
+        if (pattern != null ? !pattern.equals(other.pattern) : other.pattern != null) {
+            return false;
+        }
 
-        return true;
+        return maximum != null ? maximum.equals(other.maximum) : other.maximum == null;
     }
 
     @JsonIgnore

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractNumericProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractNumericProperty.java
@@ -3,8 +3,12 @@ package io.swagger.models.properties;
 import java.math.BigDecimal;
 
 public abstract class AbstractNumericProperty extends AbstractProperty implements Property {
-    protected BigDecimal minimum, maximum, multipleOf;
-    protected Boolean exclusiveMinimum, exclusiveMaximum;
+
+    protected BigDecimal minimum;
+    protected BigDecimal maximum;
+    protected BigDecimal multipleOf;
+    protected Boolean exclusiveMinimum;
+    protected Boolean exclusiveMaximum;
 
     public AbstractNumericProperty minimum(BigDecimal minimum) {
         this.setMinimum(minimum);

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/AbstractProperty.java
@@ -95,6 +95,7 @@ public abstract class AbstractProperty implements Property, Cloneable {
         if (access != null ? !access.equals(that.access) : that.access != null) {
             return false;
         }
+
         return vendorExtensions != null ? vendorExtensions.equals(that.vendorExtensions) : that.vendorExtensions == null;
 
     }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/StringProperty.java
@@ -13,7 +13,7 @@ public class StringProperty extends AbstractProperty implements Property {
     public static final String TYPE = "string";
     protected List<String> _enum;
     protected Integer minLength = null, maxLength = null;
-    protected String pattern = null;
+    protected String pattern;
     protected String _default;
 
     public enum Format {
@@ -57,6 +57,11 @@ public class StringProperty extends AbstractProperty implements Property {
         return TYPE.equals(type);
     }
 
+    public StringProperty pattern(String pattern) {
+        this.setPattern(pattern);
+        return this;
+    }
+
     public StringProperty xml(Xml xml) {
         this.setXml(xml);
         return this;
@@ -74,11 +79,6 @@ public class StringProperty extends AbstractProperty implements Property {
 
     public StringProperty maxLength(Integer maxLength) {
         this.setMaxLength(maxLength);
-        return this;
-    }
-
-    public StringProperty pattern(String pattern) {
-        this.setPattern(pattern);
         return this;
     }
 
@@ -206,11 +206,7 @@ public class StringProperty extends AbstractProperty implements Property {
         } else if (!minLength.equals(other.minLength)) {
             return false;
         }
-        if (pattern == null) {
-            if (other.pattern != null) {
-                return false;
-            }
-        } else if (!pattern.equals(other.pattern)) {
+        if (pattern != null ? !pattern.equals(other.pattern) : other.pattern != null) {
             return false;
         }
         return true;

--- a/modules/swagger-models/src/main/java/io/swagger/models/utils/PropertyModelConverter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/utils/PropertyModelConverter.java
@@ -6,12 +6,7 @@ import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.RefModel;
 import io.swagger.models.Xml;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.MapProperty;
-import io.swagger.models.properties.ObjectProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.PropertyBuilder;
-import io.swagger.models.properties.RefProperty;
+import io.swagger.models.properties.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,6 +55,26 @@ public class PropertyModelConverter {
                 return objectProperty;
             }
 
+            if(property instanceof StringProperty) {
+                StringProperty stringProperty = (StringProperty) property;
+                ModelImpl modelImpl = (ModelImpl) model;
+                stringProperty.setPattern(modelImpl.getPattern());
+                stringProperty.setMaxLength(modelImpl.getMaxLength());
+                stringProperty.setMinLength(modelImpl.getMinLength());
+                return stringProperty;
+            }
+
+            if(property instanceof AbstractNumericProperty) {
+                AbstractNumericProperty numericProperty = (AbstractNumericProperty) property;
+                ModelImpl modelImpl = (ModelImpl) model;
+                numericProperty.setMaximum(modelImpl.getMaximum());
+                numericProperty.setMinimum(modelImpl.getMinimum());
+                numericProperty.setMultipleOf(modelImpl.getMultipleOf());
+                numericProperty.setExclusiveMinimum(modelImpl.getExclusiveMinimum());
+                numericProperty.setExclusiveMaximum(modelImpl.getExclusiveMaximum());
+                return numericProperty;
+            }
+
             return property;
 
         } else if(model instanceof ArrayModel) {
@@ -86,6 +101,7 @@ public class PropertyModelConverter {
             objectProperty.setTitle(model.getTitle());
             objectProperty.setExample(model.getExample());
             ComposedModel cm = (ComposedModel) model;
+
             Set<String> requiredProperties = new HashSet<>();
             for(Model item : cm.getAllOf()) {
                 Property itemProperty = modelToProperty(item);
@@ -134,10 +150,16 @@ public class PropertyModelConverter {
         args.put(PropertyBuilder.PropertyId.TITLE, model.getTitle());
         args.put(PropertyBuilder.PropertyId.DEFAULT, model.getDefaultValue());
         args.put(PropertyBuilder.PropertyId.DESCRIMINATOR, model.getDiscriminator());
-        args.put(PropertyBuilder.PropertyId.MINIMUM, model.getMinimum());
-        args.put(PropertyBuilder.PropertyId.MAXIMUM, model.getMaximum());
         args.put(PropertyBuilder.PropertyId.UNIQUE_ITEMS, model.getUniqueItems());
         args.put(PropertyBuilder.PropertyId.VENDOR_EXTENSIONS, model.getVendorExtensions());
+        args.put(PropertyBuilder.PropertyId.PATTERN, model.getPattern());
+        args.put(PropertyBuilder.PropertyId.MAXIMUM, model.getMaximum());
+        args.put(PropertyBuilder.PropertyId.MINIMUM, model.getMinimum());
+        args.put(PropertyBuilder.PropertyId.EXCLUSIVE_MAXIMUM, model.getExclusiveMaximum());
+        args.put(PropertyBuilder.PropertyId.EXCLUSIVE_MINIMUM, model.getExclusiveMinimum());
+        args.put(PropertyBuilder.PropertyId.MULTIPLE_OF, model.getMultipleOf());
+        args.put(PropertyBuilder.PropertyId.MIN_LENGTH, model.getMinLength());
+        args.put(PropertyBuilder.PropertyId.MAX_LENGTH, model.getMaxLength());
         return args;
     }
 
@@ -210,6 +232,22 @@ public class PropertyModelConverter {
         model.setType(type);
         model.setFormat(format);
         model.setAllowEmptyValue(allowEmptyValue);
+
+        if(property instanceof StringProperty) {
+            StringProperty stringProperty = (StringProperty) property;
+            model.setPattern(stringProperty.getPattern());
+            model.setMinLength(stringProperty.getMinLength());
+            model.setMaxLength(stringProperty.getMaxLength());
+        }
+
+        if(property instanceof AbstractNumericProperty) {
+            AbstractNumericProperty numericProperty = (AbstractNumericProperty) property;
+            model.setMaximum(numericProperty.getMaximum());
+            model.setMinimum(numericProperty.getMinimum());
+            model.setExclusiveMaximum(numericProperty.getExclusiveMaximum());
+            model.setExclusiveMinimum(numericProperty.getExclusiveMinimum());
+            model.setMultipleOf(numericProperty.getMultipleOf());
+        }
 
         if(extensions != null) {
             model.setVendorExtensions(extensions);


### PR DESCRIPTION
Adding this properties to the ModelImpl, this is required by the SwaggerDeserializar to be used in the Converter:

- multipleOf
- minimum
- maximum
- exclusiveMinimum
- exclusiveMaximum
- uniqueItems
- minLength
- maxLength
- pattern

The related issue is: https://github.com/swagger-api/swagger-parser/issues/673