### PR TITLE
"Operation.isDeprecated()" should return false as default

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/Operation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Operation.java
@@ -259,10 +259,10 @@ public class Operation {
 
     public void setDeprecated(Boolean value) {
         if (value == null) {
-            this.deprecated = null;
-        } else {
-            this.deprecated = value;
+            return;
         }
+
+        this.deprecated = value;
     }
 
     @JsonAnyGetter

--- a/modules/swagger-models/src/main/java/io/swagger/models/Operation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Operation.java
@@ -258,7 +258,7 @@ public class Operation {
     }
 
     public void setDeprecated(Boolean value) {
-        if (value == null || value.equals(Boolean.FALSE)) {
+        if (value == null) {
             this.deprecated = null;
         } else {
             this.deprecated = value;

--- a/modules/swagger-models/src/main/java/io/swagger/models/Operation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Operation.java
@@ -22,7 +22,7 @@ public class Operation {
     private Map<String, Response> responses;
     private List<Map<String, List<String>>> security;
     private ExternalDocs externalDocs;
-    private Boolean deprecated;
+    private Boolean deprecated = false;
 
     public Operation summary(String summary) {
         this.setSummary(summary);

--- a/modules/swagger-models/src/test/java/io/swagger/models/OperationTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/OperationTest.java
@@ -141,7 +141,7 @@ public class OperationTest {
         operation.deprecated(false);
 
         // then
-        assertNull(operation.isDeprecated(), "Must not been deprecated after set to false");
+        assertFalse(operation.isDeprecated(), "Must not been deprecated after set to false");
     }
 
     @Test

--- a/modules/swagger-models/src/test/java/io/swagger/models/OperationTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/OperationTest.java
@@ -136,6 +136,15 @@ public class OperationTest {
     }
 
     @Test
+    public void testDeprecatedMustBeFalseIfNullIsPassed() {
+        // when
+        operation.deprecated(null);
+
+        // then
+        assertFalse(operation.isDeprecated());
+    }
+
+    @Test
     public void testDeprecated() {
         // when
         operation.deprecated(false);

--- a/modules/swagger-models/src/test/java/io/swagger/models/OperationTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/OperationTest.java
@@ -11,9 +11,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class OperationTest {
 
@@ -130,6 +128,11 @@ public class OperationTest {
         // then
         assertEquals(operation.getResponses().get("default"), response,
                 "The default response should be the one that have just been set");
+    }
+
+    @Test
+    public void testDefaultDeprecatedValue() {
+        assertFalse(operation.isDeprecated(), "The default value of deprecated must be false");
     }
 
     @Test


### PR DESCRIPTION
As described below, the default value of 'deprecated' is `false`.
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-operationDeprecated

So I think that `Operation.isDeprecated()` should behave same as the description: it should return true or false, never returns null.


related issue in swagger-parser: https://github.com/swagger-api/swagger-parser/issues/697