### PR TITLE
#2809 Allow filtering of specific definitions in SpecFilter.

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/core/filter/AbstractSpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/core/filter/AbstractSpecFilter.java
@@ -29,6 +29,14 @@ public abstract class AbstractSpecFilter implements SwaggerSpecFilter {
         return true;
     }
 
+    public boolean isDefinitionAllowed(
+            Model model,
+            Map<String, List<String>> params,
+            Map<String, String> cookies,
+            Map<String, List<String>> headers) {
+        return true;
+    }
+
     public boolean isPropertyAllowed(
             Model model,
             Property property,

--- a/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/core/filter/SpecFilter.java
@@ -211,6 +211,16 @@ public class SpecFilter {
 
         for (String key : definitions.keySet()) {
             Model definition = definitions.get(key);
+
+            // isDefinitionAllowed is not defined in SwaggerSpecFilter to avoid breaking compatibility with
+            // existing client filters directly implementing SwaggerSpecFilter.
+            if (filter instanceof AbstractSpecFilter) {
+                boolean shouldIncludeDefinition = ((AbstractSpecFilter)filter).isDefinitionAllowed(definition, params, cookies, headers);
+                if (!shouldIncludeDefinition) {
+                    continue;
+                }
+            }
+
             Map<String, Property> clonedProperties = new LinkedHashMap<String, Property>();
             if (definition.getProperties() != null) {
                 for (String propName : definition.getProperties().keySet()) {


### PR DESCRIPTION
This addresses the use cases where filtering out specific definitions is required.

#2809 