### PR TITLE
refactor and fix references handling

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -27,6 +27,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSchema;
 
+import io.swagger.models.refs.RefFormat;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -173,7 +174,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 }
                 if (innerModel instanceof ModelImpl) {
                     ModelImpl mi = (ModelImpl) innerModel;
-                    property = new RefProperty(StringUtils.isNotEmpty(mi.getReference()) ? mi.getReference() : mi.getName());
+                    if (StringUtils.isNotEmpty(mi.getReference())) {
+                        property = new RefProperty(mi.getReference());
+                    } else {
+                        property = new RefProperty(mi.getName(), RefFormat.INTERNAL);
+                    }
                 }
             }
         }
@@ -970,7 +975,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 }
 
                 impl.setDiscriminator(null);
-                ComposedModel child = new ComposedModel().parent(new RefModel(model.getName())).child(impl);
+                ComposedModel child = new ComposedModel().parent(new RefModel(model.getName(), RefFormat.INTERNAL)).child(impl);
                 context.defineModel(impl.getName(), child, subtypeType, null);
                 ++count;
             }

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/mixin/IgnoreOriginalRefMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/mixin/IgnoreOriginalRefMixin.java
@@ -1,0 +1,10 @@
+package io.swagger.jackson.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public abstract class IgnoreOriginalRefMixin {
+
+    @JsonIgnore
+    public abstract String getOriginalRef();
+
+}

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/mixin/OriginalRefMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/mixin/OriginalRefMixin.java
@@ -1,0 +1,14 @@
+package io.swagger.jackson.mixin;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public abstract class OriginalRefMixin {
+
+    @JsonIgnore
+    public abstract String get$ref();
+
+    @JsonGetter("$ref")
+    public abstract String getOriginalRef();
+
+}

--- a/modules/swagger-core/src/main/java/io/swagger/util/ObjectMapperFactory.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ObjectMapperFactory.java
@@ -10,9 +10,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.swagger.jackson.mixin.ResponseSchemaMixin;
 import io.swagger.models.Response;
 
-
-
-
 public class ObjectMapperFactory {
 
     protected static ObjectMapper createJson() {
@@ -42,6 +39,8 @@ public class ObjectMapperFactory {
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
         mapper.addMixIn(Response.class, ResponseSchemaMixin.class);
+
+        ReferenceSerializationConfigurer.serializeAsComputedRef(mapper);
 
         return mapper;
     }

--- a/modules/swagger-core/src/main/java/io/swagger/util/ReferenceSerializationConfigurer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ReferenceSerializationConfigurer.java
@@ -1,0 +1,43 @@
+package io.swagger.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.jackson.mixin.IgnoreOriginalRefMixin;
+import io.swagger.jackson.mixin.OriginalRefMixin;
+import io.swagger.models.RefModel;
+import io.swagger.models.RefPath;
+import io.swagger.models.RefResponse;
+import io.swagger.models.parameters.RefParameter;
+import io.swagger.models.properties.RefProperty;
+
+/**
+ * @since 1.5.21
+ */
+public abstract class ReferenceSerializationConfigurer {
+
+    private static void serializeAs(Class<?> cls, ObjectMapper mapper) {
+        mapper.addMixIn(RefModel.class, cls);
+        mapper.addMixIn(RefProperty.class, cls);
+        mapper.addMixIn(RefPath.class, cls);
+        mapper.addMixIn(RefParameter.class, cls);
+        mapper.addMixIn(RefResponse.class, cls);
+    }
+
+    public static void serializeAsOriginalRef() {
+        serializeAs(OriginalRefMixin.class, Json.mapper());
+        serializeAs(OriginalRefMixin.class, Yaml.mapper());
+    }
+
+    public static void serializeAsComputedRef() {
+        serializeAs(IgnoreOriginalRefMixin.class, Json.mapper());
+        serializeAs(IgnoreOriginalRefMixin.class, Yaml.mapper());
+    }
+
+    public static void serializeAsOriginalRef(ObjectMapper mapper) {
+        serializeAs(OriginalRefMixin.class, mapper);
+    }
+
+    public static void serializeAsComputedRef(ObjectMapper mapper) {
+        serializeAs(IgnoreOriginalRefMixin.class, mapper);
+    }
+
+}

--- a/modules/swagger-core/src/test/java/io/swagger/matchers/SerializationMatchers.java
+++ b/modules/swagger-core/src/test/java/io/swagger/matchers/SerializationMatchers.java
@@ -26,6 +26,10 @@ public class SerializationMatchers {
         apply(objectToSerialize, jsonStr, Json.mapper());
     }
 
+    public static void assertEqualsToString(Object objectToSerialize, String jsonStr, ObjectMapper mapper) {
+        apply(objectToSerialize, jsonStr, mapper);
+    }
+
     private static void apply(Object objectToSerialize, String str, ObjectMapper mapper) {
         final ObjectNode lhs = mapper.convertValue(objectToSerialize, ObjectNode.class);
         ObjectNode rhs = null;

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/ReferenceTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/ReferenceTest.java
@@ -1,5 +1,6 @@
 package io.swagger;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.converter.ModelConverters;
 import io.swagger.jaxrs.Reader;
 import io.swagger.matchers.SerializationMatchers;
@@ -7,7 +8,11 @@ import io.swagger.models.Pet;
 import io.swagger.models.Swagger;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
+import io.swagger.models.refs.GenericRef;
+import io.swagger.resources.ResourceWithMoreReferences;
 import io.swagger.resources.ResourceWithReferences;
+import io.swagger.util.Json;
+import io.swagger.util.ReferenceSerializationConfigurer;
 import io.swagger.util.ResourceUtils;
 import org.testng.annotations.Test;
 
@@ -32,8 +37,54 @@ public class ReferenceTest {
 
     @Test(description = "Scan API with operation and response references")
     public void scanAPI() throws IOException {
+
         final Swagger swagger = new Reader(new Swagger()).read(ResourceWithReferences.class);
         final String json = ResourceUtils.loadClassResource(getClass(), "ResourceWithReferences.json");
         SerializationMatchers.assertEqualsToJson(swagger, json);
     }
+
+    @Test(description = "Scan API with references")
+    public void scanRef() throws IOException {
+
+        final Swagger swagger = new Reader(new Swagger()).read(ResourceWithMoreReferences.class);
+        final String json = ResourceUtils.loadClassResource(getClass(), "ResourceWithMoreReferences.json");
+        SerializationMatchers.assertEqualsToJson(swagger, json);
+    }
+
+    @Test(description = "Serialize API with references and OriginalRefMixin activated")
+    public void serializeRefWithOriginalRef() throws Exception {
+
+        // workaround for https://github.com/FasterXML/jackson-databind/issues/1998
+        ObjectMapper mapper = Json.mapper().copy();
+        ReferenceSerializationConfigurer.serializeAsOriginalRef(mapper);
+
+        final String json = ResourceUtils.loadClassResource(getClass(), "ResourceWithMoreReferencesAsOriginalRef.json");
+        Swagger swagger = Json.mapper().readValue(json, Swagger.class);
+        SerializationMatchers.assertEqualsToString(swagger, json, mapper);
+    }
+
+    @Test(description = "Serialize API with references and internal ref also with dots activated")
+    public void serializeRefWithInternalRef() throws Exception {
+        try {
+            GenericRef.internalRefWithAnyDot();
+            final String json = ResourceUtils.loadClassResource(getClass(), "ResourceWithMoreReferencesWithInternalRef.json");
+            Swagger swagger = Json.mapper().readValue(json, Swagger.class);
+            SerializationMatchers.assertEqualsToJson(swagger, json);
+        } finally {
+            GenericRef.relativeRefWithAnyDot();
+        }
+    }
+
+    @Test(description = "Scan API with references and OriginalRefMixin activated")
+    public void scanRefWithOriginalRef() throws IOException {
+
+        // workaround for https://github.com/FasterXML/jackson-databind/issues/1998
+        ObjectMapper mapper = Json.mapper().copy();
+        ReferenceSerializationConfigurer.serializeAsOriginalRef(mapper);
+
+        final Swagger swagger = new Reader(new Swagger()).read(ResourceWithMoreReferences.class);
+        final String json = ResourceUtils.loadClassResource(getClass(), "ResourceWithMoreReferencesAsOriginalRef.json");
+        SerializationMatchers.assertEqualsToString(swagger, json, mapper);
+    }
+
 }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/models/ModelWithReferences.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/models/ModelWithReferences.java
@@ -1,0 +1,34 @@
+package io.swagger.models;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class ModelWithReferences {
+    public String getOne() {
+        return null;
+    }
+
+    @ApiModelProperty(reference = "http://swagger.io/schemas.json#/Models/AnotherModel")
+    public String getAnother() {
+        return null;
+    }
+
+    @ApiModelProperty(reference = "Three")
+    public String getThree() {
+        return null;
+    }
+
+    @ApiModelProperty(reference = "Four.json")
+    public String getFour() {
+        return null;
+    }
+
+    @ApiModelProperty(reference = "Five.json.MyClass")
+    public String getFive() {
+        return null;
+    }
+
+    @ApiModelProperty(reference = "./Six")
+    public String getSix() {
+        return null;
+    }
+}

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithMoreReferences.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/ResourceWithMoreReferences.java
@@ -1,0 +1,77 @@
+package io.swagger.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.models.ModelContainingModelWithReference;
+import io.swagger.models.ModelWithReference;
+import io.swagger.models.ModelWithReferences;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+@Api(value = "/basic")
+@Path("/")
+public class ResourceWithMoreReferences {
+
+    @GET
+    @Path("/test")
+    @ApiResponses({
+            @ApiResponse(code = 500, message = "Error", reference = "http://swagger.io/schemas.json#/Models/ErrorResponse")
+    })
+    public Response getTest() throws WebApplicationException {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/some")
+    @ApiOperation(value = "Get Some", responseReference = "http://swagger.io/schemas.json#/Models/SomeResponse")
+    public Response getSome() throws WebApplicationException {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/testSome")
+    @ApiOperation(value = "Get Some", responseReference = "http://swagger.io/schemas.json#/Models/SomeResponse")
+    @ApiResponses({
+            @ApiResponse(code = 500, message = "Error", reference = "http://swagger.io/schemas.json#/Models/ErrorResponse")
+    })
+    public Response getTestSome() throws WebApplicationException {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/testSomeOther")
+    @ApiOperation(value = "Get Some Other", responseReference = "foo")
+    @ApiResponses({
+            @ApiResponse(code = 500, message = "Error", reference = "foo.json"),
+            @ApiResponse(code = 502, message = "Error", reference = "foo.json.MyClass")
+    })
+    public Response getTestSomeOther() throws WebApplicationException {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/model")
+    @ApiOperation(value = "Get Model", response = ModelContainingModelWithReference.class)
+    public Response getModel() throws WebApplicationException {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/anotherModel")
+    @ApiOperation(value = "Get Another Model", response = ModelWithReference.class)
+    public Response getAnotherModel() throws WebApplicationException {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/aThirdModel")
+    @ApiOperation(value = "Get A Third Model", response = ModelWithReferences.class)
+    public Response getAThirdModel() throws WebApplicationException {
+        return Response.ok().build();
+    }
+}

--- a/modules/swagger-jaxrs/src/test/resources/ResourceWithMoreReferences.json
+++ b/modules/swagger-jaxrs/src/test/resources/ResourceWithMoreReferences.json
@@ -1,0 +1,222 @@
+{
+    "swagger": "2.0",
+    "tags": [
+        {
+            "name": "basic"
+        }
+    ],
+    "paths": {
+        "/test": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "operationId": "getTest",
+                "parameters": [],
+                "responses": {
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/some": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Some",
+                "description": "",
+                "operationId": "getSome",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/testSome": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Some",
+                "description": "",
+                "operationId": "getTestSome",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/testSomeOther": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Some Other",
+                "description": "",
+                "operationId": "getTestSomeOther",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/foo"
+                        }
+                    },
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "foo.json"
+                        }
+                    },
+                    "502": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "foo.json.MyClass"
+                        }
+                    }
+                }
+            }
+        },
+        "/model": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Model",
+                "description": "",
+                "operationId": "getModel",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ModelContainingModelWithReference"
+                        }
+                    }
+                }
+            }
+        },
+        "/anotherModel": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Another Model",
+                "description": "",
+                "operationId": "getAnotherModel",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models"
+                        }
+                    }
+                }
+            }
+        },
+        "/aThirdModel": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get A Third Model",
+                "description": "",
+                "operationId": "getAThirdModel",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ModelWithReferences"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "ModelContainingModelWithReference": {
+            "type": "object",
+            "properties": {
+                "model": {
+                    "$ref": "http://swagger.io/schemas.json#/Models"
+                },
+                "anotherModel": {
+                    "$ref": "http://swagger.io/schemas.json#/Models/AnotherModel"
+                }
+            }
+        },
+        "ModelWithReference": {
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "type": "array",
+                    "description": "SubModelWithSelfReference",
+                    "items": {
+                        "$ref": "#/definitions/SubModelWithSelfReference"
+                    }
+                },
+                "description": {
+                    "$ref": "http://swagger.io/schemas.json#/Models/Description"
+                }
+            }
+        },
+        "SubModelWithSelfReference": {
+            "type": "object",
+            "properties": {
+                "references": {
+                    "type": "array",
+                    "description": "References",
+                    "items": {
+                        "$ref": "#/definitions/SubModelWithSelfReference"
+                    }
+                }
+            }
+        },
+        "ModelWithReferences": {
+            "type": "object",
+            "properties": {
+                "one": {
+                    "type": "string"
+                },
+                "five": {
+                    "$ref": "Five.json.MyClass"
+                },
+                "four": {
+                    "$ref": "Four.json"
+                },
+                "six": {
+                    "$ref": "./Six"
+                },
+                "three": {
+                    "$ref": "#/definitions/Three"
+                },
+                "another": {
+                    "$ref": "http://swagger.io/schemas.json#/Models/AnotherModel"
+                }
+            }
+        }
+    }
+}

--- a/modules/swagger-jaxrs/src/test/resources/ResourceWithMoreReferencesAsOriginalRef.json
+++ b/modules/swagger-jaxrs/src/test/resources/ResourceWithMoreReferencesAsOriginalRef.json
@@ -1,0 +1,222 @@
+{
+    "swagger": "2.0",
+    "tags": [
+        {
+            "name": "basic"
+        }
+    ],
+    "paths": {
+        "/test": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "operationId": "getTest",
+                "parameters": [],
+                "responses": {
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/some": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Some",
+                "description": "",
+                "operationId": "getSome",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/testSome": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Some",
+                "description": "",
+                "operationId": "getTestSome",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/testSomeOther": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Some Other",
+                "description": "",
+                "operationId": "getTestSomeOther",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "foo"
+                        }
+                    },
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "foo.json"
+                        }
+                    },
+                    "502": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "foo.json.MyClass"
+                        }
+                    }
+                }
+            }
+        },
+        "/model": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Model",
+                "description": "",
+                "operationId": "getModel",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "ModelContainingModelWithReference"
+                        }
+                    }
+                }
+            }
+        },
+        "/anotherModel": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Another Model",
+                "description": "",
+                "operationId": "getAnotherModel",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models"
+                        }
+                    }
+                }
+            }
+        },
+        "/aThirdModel": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get A Third Model",
+                "description": "",
+                "operationId": "getAThirdModel",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "ModelWithReferences"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "ModelContainingModelWithReference": {
+            "type": "object",
+            "properties": {
+                "model": {
+                    "$ref": "http://swagger.io/schemas.json#/Models"
+                },
+                "anotherModel": {
+                    "$ref": "http://swagger.io/schemas.json#/Models/AnotherModel"
+                }
+            }
+        },
+        "ModelWithReference": {
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "type": "array",
+                    "description": "SubModelWithSelfReference",
+                    "items": {
+                        "$ref": "SubModelWithSelfReference"
+                    }
+                },
+                "description": {
+                    "$ref": "http://swagger.io/schemas.json#/Models/Description"
+                }
+            }
+        },
+        "SubModelWithSelfReference": {
+            "type": "object",
+            "properties": {
+                "references": {
+                    "type": "array",
+                    "description": "References",
+                    "items": {
+                        "$ref": "SubModelWithSelfReference"
+                    }
+                }
+            }
+        },
+        "ModelWithReferences": {
+            "type": "object",
+            "properties": {
+                "six": {
+                    "$ref": "./Six"
+                },
+                "four": {
+                    "$ref": "Four.json"
+                },
+                "another": {
+                    "$ref": "http://swagger.io/schemas.json#/Models/AnotherModel"
+                },
+                "three": {
+                    "$ref": "Three"
+                },
+                "five": {
+                    "$ref": "Five.json.MyClass"
+                },
+                "one": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/modules/swagger-jaxrs/src/test/resources/ResourceWithMoreReferencesWithInternalRef.json
+++ b/modules/swagger-jaxrs/src/test/resources/ResourceWithMoreReferencesWithInternalRef.json
@@ -1,0 +1,222 @@
+{
+    "swagger": "2.0",
+    "tags": [
+        {
+            "name": "basic"
+        }
+    ],
+    "paths": {
+        "/test": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "operationId": "getTest",
+                "parameters": [],
+                "responses": {
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/some": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Some",
+                "description": "",
+                "operationId": "getSome",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/testSome": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Some",
+                "description": "",
+                "operationId": "getTestSome",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/SomeResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/testSomeOther": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Some Other",
+                "description": "",
+                "operationId": "getTestSomeOther",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/foo"
+                        }
+                    },
+                    "500": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/foo.json"
+                        }
+                    },
+                    "502": {
+                        "description": "Error",
+                        "schema": {
+                            "$ref": "#/definitions/foo.json.MyClass"
+                        }
+                    }
+                }
+            }
+        },
+        "/model": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Model",
+                "description": "",
+                "operationId": "getModel",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ModelContainingModelWithReference"
+                        }
+                    }
+                }
+            }
+        },
+        "/anotherModel": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get Another Model",
+                "description": "",
+                "operationId": "getAnotherModel",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "http://swagger.io/schemas.json#/Models"
+                        }
+                    }
+                }
+            }
+        },
+        "/aThirdModel": {
+            "get": {
+                "tags": [
+                    "basic"
+                ],
+                "summary": "Get A Third Model",
+                "description": "",
+                "operationId": "getAThirdModel",
+                "parameters": [],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "$ref": "#/definitions/ModelWithReferences"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "ModelContainingModelWithReference": {
+            "type": "object",
+            "properties": {
+                "model": {
+                    "$ref": "http://swagger.io/schemas.json#/Models"
+                },
+                "anotherModel": {
+                    "$ref": "http://swagger.io/schemas.json#/Models/AnotherModel"
+                }
+            }
+        },
+        "ModelWithReference": {
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "type": "array",
+                    "description": "SubModelWithSelfReference",
+                    "items": {
+                        "$ref": "#/definitions/SubModelWithSelfReference"
+                    }
+                },
+                "description": {
+                    "$ref": "http://swagger.io/schemas.json#/Models/Description"
+                }
+            }
+        },
+        "SubModelWithSelfReference": {
+            "type": "object",
+            "properties": {
+                "references": {
+                    "type": "array",
+                    "description": "References",
+                    "items": {
+                        "$ref": "#/definitions/SubModelWithSelfReference"
+                    }
+                }
+            }
+        },
+        "ModelWithReferences": {
+            "type": "object",
+            "properties": {
+                "six": {
+                    "$ref": "./Six"
+                },
+                "four": {
+                    "$ref": "#/definitions/Four.json"
+                },
+                "another": {
+                    "$ref": "http://swagger.io/schemas.json#/Models/AnotherModel"
+                },
+                "three": {
+                    "$ref": "#/definitions/Three"
+                },
+                "five": {
+                    "$ref": "#/definitions/Five.json.MyClass"
+                },
+                "one": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/modules/swagger-models/src/main/java/io/swagger/models/RefModel.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/RefModel.java
@@ -23,6 +23,10 @@ public class RefModel implements Model {
         set$ref(ref);
     }
 
+    public RefModel(String ref, RefFormat refFormat) {
+        this.genericRef = new GenericRef(RefType.DEFINITION, ref, refFormat);
+    }
+
     public RefModel asDefault(String ref) {
         this.set$ref(RefType.DEFINITION.getInternalPrefix() + ref);
         return this;
@@ -62,6 +66,18 @@ public class RefModel implements Model {
     @JsonIgnore
     public String getSimpleRef() {
         return genericRef.getSimpleRef();
+    }
+
+    /**
+     * @since 1.5.21
+     * @return originalRef
+     */
+    public String getOriginalRef() {
+        if (genericRef != null) {
+            return genericRef.getOriginalRef();
+        } else {
+            return null;
+        }
     }
 
     public String get$ref() {

--- a/modules/swagger-models/src/main/java/io/swagger/models/RefPath.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/RefPath.java
@@ -27,12 +27,28 @@ public class RefPath extends Path {
         set$ref(ref);
     }
 
+    public RefPath(String ref, RefFormat refFormat) {
+        this.genericRef = new GenericRef(RefType.PATH, ref, refFormat);
+    }
+
     public void set$ref(String ref) {
         this.genericRef = new GenericRef(RefType.PATH, ref);
     }
 
     public String get$ref() {
         return genericRef.getRef();
+    }
+
+    /**
+     * @since 1.5.21
+     * @return originalRef
+     */
+    public String getOriginalRef() {
+        if (genericRef != null) {
+            return genericRef.getOriginalRef();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/modules/swagger-models/src/main/java/io/swagger/models/RefResponse.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/RefResponse.java
@@ -36,6 +36,18 @@ public class RefResponse extends Response {
         return genericRef.getSimpleRef();
     }
 
+    /**
+     * @since 1.5.21
+     * @return originalRef
+     */
+    public String getOriginalRef() {
+        if (genericRef != null) {
+            return genericRef.getOriginalRef();
+        } else {
+            return null;
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/RefParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/RefParameter.java
@@ -12,6 +12,10 @@ public class RefParameter extends AbstractParameter implements Parameter {
         set$ref(ref);
     }
 
+    public RefParameter(String ref, RefFormat refFormat) {
+        this.genericRef = new GenericRef(RefType.PARAMETER, ref, refFormat);
+    }
+
     public static boolean isType(String type, String format) {
         if ("$ref".equals(type)) {
             return true;
@@ -52,6 +56,18 @@ public class RefParameter extends AbstractParameter implements Parameter {
     @JsonIgnore
     public String getSimpleRef() {
         return genericRef.getSimpleRef();
+    }
+
+    /**
+     * @since 1.5.21
+     * @return originalRef
+     */
+    public String getOriginalRef() {
+        if (genericRef != null) {
+            return genericRef.getOriginalRef();
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/PropertyBuilder.java
@@ -464,7 +464,7 @@ public class PropertyBuilder {
             public Model toModel(Property property) {
                 if (property instanceof RefProperty) {
                     final RefProperty resolved = (RefProperty) property;
-                    final RefModel model = new RefModel(resolved.get$ref());
+                    final RefModel model = new RefModel(resolved.getOriginalRef(), resolved.getRefFormat());
                     model.setDescription(resolved.getDescription());
                     return model;
                 }

--- a/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/properties/RefProperty.java
@@ -16,8 +16,12 @@ public class RefProperty extends AbstractProperty implements Property {
     }
 
     public RefProperty(String ref) {
+        this(ref, null);
+    }
+
+    public RefProperty(String ref, RefFormat refFormat) {
         this();
-        set$ref(ref);
+        this.genericRef = new GenericRef(RefType.DEFINITION, ref, refFormat);
     }
 
     public static boolean isType(String type, String format) {
@@ -71,6 +75,18 @@ public class RefProperty extends AbstractProperty implements Property {
     public String getSimpleRef() {
         if (genericRef != null) {
             return this.genericRef.getSimpleRef();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @since 1.5.21
+     * @return originalRef
+     */
+    public String getOriginalRef() {
+        if (genericRef != null) {
+            return genericRef.getOriginalRef();
         } else {
             return null;
         }

--- a/modules/swagger-models/src/main/java/io/swagger/models/utils/PropertyModelConverter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/utils/PropertyModelConverter.java
@@ -92,7 +92,7 @@ public class PropertyModelConverter {
 
         } else if(model instanceof RefModel) {
             RefModel ref = (RefModel) model;
-            RefProperty refProperty = new RefProperty(ref.get$ref());
+            RefProperty refProperty = new RefProperty(ref.get$ref(), ref.getRefFormat());
             return refProperty;
 
         } else if(model instanceof ComposedModel) {
@@ -182,7 +182,7 @@ public class PropertyModelConverter {
 
         if(property instanceof RefProperty){
             RefProperty ref = (RefProperty) property;
-            RefModel refModel = new RefModel(ref.get$ref());
+            RefModel refModel = new RefModel(ref.getOriginalRef(), ref.getRefFormat());
             return refModel;
         }
 


### PR DESCRIPTION
This PR addresses issues related to "reference items" instantiation, serialization and resolving, triggered originally by swagger-api/swagger-parser/issues/727 and swagger-api/swagger-parser/issues/713; it would replace #2847

It updates related code mainly:

- providing an `originalRef` getter in "reference items" (e.g. `RefModel`, `RefProperty`, etc)
- allowing to have this `originalRef` mapped to `$ref` JSON property via MixIn or added `ReferenceSerializationConfigurer` helper class
- updating the ref parsing logic to identify as relative ref (and therefore not treating it as internal, which modifies the reference by adding the related prefix) non absolute nor explicitly internal properties containing a dot
- allowing to maintain  previous parsing behaviour by invoking at bootstrap `GenericRef.internalRefWithAnyDot()`

please see tests added in PR for some examples.

