### PR TITLE
Fix for 2833 (Property requestBody should be of type String instead of RequestBody in Links.java (OAS 3.0))

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
@@ -33,7 +33,7 @@ public class Link {
     private String operationRef = null;
     private String operationId = null;
     private Map<String, String> parameters = null;
-    private RequestBody requestBody = null;
+    private String requestBody = null;
     private Map<String, Header> headers = null;
     private String description = null;
     private String $ref = null;
@@ -84,15 +84,15 @@ public class Link {
      * @return String operationId
      **/
 
-    public RequestBody getRequestBody() {
+    public String getRequestBody() {
         return requestBody;
     }
 
-    public void setRequestBody(RequestBody requestBody) {
+    public void setRequestBody(String requestBody) {
         this.requestBody = requestBody;
     }
 
-    public Link requestBody(RequestBody requestBody) {
+    public Link requestBody(String requestBody) {
         this.requestBody = requestBody;
         return this;
     }


### PR DESCRIPTION
Hi team,

This PR is to solve the issue #2833 
Please review the PR and merge the same.

Thanks,
Mohammed