### PR TITLE
 refs #2783 - avoid NumberFormatException warning with empty String in param example

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
@@ -404,7 +404,7 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
 
     @JsonProperty("x-example")
     public Object getExample() {
-        if (example == null) {
+        if (example == null || example.isEmpty()) {
             return null;
         }
         try {

--- a/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/parameters/AbstractSerializableParameter.java
@@ -405,7 +405,7 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
     @JsonProperty("x-example")
     public Object getExample() {
         if (example == null || example.isEmpty()) {
-            return null;
+            return example;
         }
         try {
             if (BaseIntegerProperty.TYPE.equals(type)) {

--- a/modules/swagger-models/src/test/java/io/swagger/models/parameters/AbstractSerializableParameterTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/parameters/AbstractSerializableParameterTest.java
@@ -340,13 +340,20 @@ public class AbstractSerializableParameterTest {
     public void testGetExampleWithEmptyString() {
         // given
         instance.setProperty(new LongProperty());
-        example = "";
+        example = null;
 
         // when
         instance.setExample(example);
 
         // then
-        assertEquals(instance.getExample(), null, "The example must be null if the value is an empty string");
+        assertEquals(instance.getExample(), null, "The example must be null if the value is null");
+
+        // given
+        instance.setProperty(new LongProperty());
+        example = "";
+        
+        // then
+        assertEquals(instance.getExample(), null, "The example must be empty string if the value is an empty string");
     }
 
     @Test

--- a/modules/swagger-models/src/test/java/io/swagger/models/parameters/AbstractSerializableParameterTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/models/parameters/AbstractSerializableParameterTest.java
@@ -4,6 +4,7 @@ import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.BaseIntegerProperty;
 import io.swagger.models.properties.BooleanProperty;
 import io.swagger.models.properties.DecimalProperty;
+import io.swagger.models.properties.LongProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
 import org.testng.annotations.BeforeMethod;
@@ -333,6 +334,19 @@ public class AbstractSerializableParameterTest {
         // then
         assertEquals(instance.getExample(), example,
                 "The example value must not change when when set an array property");
+    }
+
+    @Test
+    public void testGetExampleWithEmptyString() {
+        // given
+        instance.setProperty(new LongProperty());
+        example = "";
+
+        // when
+        instance.setExample(example);
+
+        // then
+        assertEquals(instance.getExample(), null, "The example must be null if the value is an empty string");
     }
 
     @Test


### PR DESCRIPTION
includes and replaces #2865 (fixes the warning, but doesn't modify the original value)