### PR TITLE
refs #2833 - fixes and resolves Links requestBody

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -831,6 +831,20 @@ public abstract class AnnotationsUtils {
         if (linkParameters.size() > 0) {
             linkObject.setParameters(linkParameters);
         }
+
+        if (StringUtils.isNotBlank(link.requestBody())) {
+            JsonNode processedValue = null;
+            try {
+                processedValue = Json.mapper().readTree(link.requestBody());
+            } catch (Exception e) {
+                // not a json string
+            }
+            if (processedValue == null) {
+                linkObject.requestBody(link.requestBody());
+            } else {
+                linkObject.requestBody(processedValue);
+            }
+        }
         return Optional.of(linkObject);
     }
 

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/pathItems/OperationsWithLinksTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/pathItems/OperationsWithLinksTest.java
@@ -6,10 +6,12 @@ import io.swagger.v3.oas.annotations.links.Link;
 import io.swagger.v3.oas.annotations.links.LinkParameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import java.io.IOException;
@@ -78,6 +80,67 @@ public class OperationsWithLinksTest extends AbstractAnnotationTest {
         compareAsYaml(ClassWithOperationAndLinks.class, expectedYAML);
     }
 
+    @Test(description = "Shows creating simple links with request body")
+    public void createOperationWithLinksAndRequestBody() throws IOException {
+
+        String expectedYAML = "openapi: 3.0.1\n" +
+                "paths:\n" +
+                "  /users:\n" +
+                "    get:\n" +
+                "      operationId: getUser\n" +
+                "      parameters:\n" +
+                "      - name: userId\n" +
+                "        in: query\n" +
+                "        schema:\n" +
+                "          type: string\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: test description\n" +
+                "          content:\n" +
+                "            '*/*':\n" +
+                "              schema:\n" +
+                "                $ref: '#/components/schemas/User'\n" +
+                "          links:\n" +
+                "            address:\n" +
+                "              operationId: addAddress\n" +
+                "              requestBody: $request.query.userId\n" +
+                "  /addresses:\n" +
+                "    post:\n" +
+                "      operationId: addAddress\n" +
+                "      requestBody:\n" +
+                "        description: userId\n" +
+                "        content:\n" +
+                "          '*/*':\n" +
+                "            schema:\n" +
+                "              type: string\n" +
+                "        required: true\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: test description\n" +
+                "          content:\n" +
+                "            '*/*':\n" +
+                "              schema:\n" +
+                "                $ref: '#/components/schemas/Address'\n" +
+                "components:\n" +
+                "  schemas:\n" +
+                "    User:\n" +
+                "      type: object\n" +
+                "      properties:\n" +
+                "        id:\n" +
+                "          type: string\n" +
+                "        username:\n" +
+                "          type: string\n" +
+                "    Address:\n" +
+                "      type: object\n" +
+                "      properties:\n" +
+                "        street:\n" +
+                "          type: string\n" +
+                "        zip:\n" +
+                "          type: string";
+
+        compareAsYaml(ClassWithOperationAndLinksWithRequestBody.class, expectedYAML);
+    }
+
     @Test(description = "Shows creating operation response without annotation")
     public void createOperationWithResponseNoAnnotation() throws IOException {
 
@@ -141,6 +204,38 @@ public class OperationsWithLinksTest extends AbstractAnnotationTest {
                 })
         @GET
         public Address getAddress(@QueryParam("userId") String userId) {
+            return null;
+        }
+    }
+
+    static class ClassWithOperationAndLinksWithRequestBody {
+        @Path("/users")
+        @Operation(operationId = "getUser",
+                responses = {
+                        @ApiResponse(description = "test description",
+                                content = @Content(mediaType = "*/*", schema = @Schema(ref = "#/components/schemas/User")),
+                                links = {
+                                        @Link(
+                                                name = "address",
+                                                operationId = "addAddress",
+                                                requestBody = "$request.query.userId")
+                                })}
+        )
+        @GET
+        public User getUser(@QueryParam("userId") String userId) {
+            return null;
+        }
+
+        @Path("/addresses")
+        @Operation(operationId = "addAddress",
+
+                responses = {
+                        @ApiResponse(content = @Content(mediaType = "*/*",
+                                schema = @Schema(ref = "#/components/schemas/Address")),
+                                description = "test description")
+                })
+        @POST
+        public Address addAddress(@RequestBody(description = "userId", required = true) String userId) {
             return null;
         }
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
@@ -33,7 +33,7 @@ public class Link {
     private String operationRef = null;
     private String operationId = null;
     private Map<String, String> parameters = null;
-    private RequestBody requestBody = null;
+    private Object requestBody = null;
     private Map<String, Header> headers = null;
     private String description = null;
     private String $ref = null;
@@ -81,18 +81,18 @@ public class Link {
     /**
      * returns the requestBody property from a Link instance.
      *
-     * @return String operationId
+     * @return Object requestBody
      **/
 
-    public RequestBody getRequestBody() {
+    public Object getRequestBody() {
         return requestBody;
     }
 
-    public void setRequestBody(RequestBody requestBody) {
+    public void setRequestBody(Object requestBody) {
         this.requestBody = requestBody;
     }
 
-    public Link requestBody(RequestBody requestBody) {
+    public Link requestBody(Object requestBody) {
         this.requestBody = requestBody;
         return this;
     }


### PR DESCRIPTION
**IMPORTANT NOTE**: this PR addresses #2833, by updating `requestBody` member datatype of swagger-models `Link` to be `Object` instead of previous `RequestBody`, as it correctly maps to OpenAPI definition https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#linkObject.

This is a breaking change, but it makes sense as the previous datatype was basically wrong and  meaningless. An alternative would be deprecating requestBody, and introducing a new `requestBodyObject` serialized as JSON `requestBody` via mixin and jackson annotations.