### PR TITLE
Added ability to apply Reflections filtering by package.

### DIFF
--- a/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/ResourceFilter.java
+++ b/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/ResourceFilter.java
@@ -1,0 +1,37 @@
+package io.swagger.v3.oas.integration;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ResourceFilter {
+  private Set<String> includePackages = new HashSet<String>();
+  private Set<String> excludePackages = new HashSet<String>();
+
+  public ResourceFilter includePackage(String... prefixes) {
+    for(String prefix : prefixes) {
+      includePackages.add(prefix);
+    }
+    return this;
+  }
+
+  public ResourceFilter excludePackage(String... prefixes) {
+    for(String prefix : prefixes) {
+      // Reflections filtering applies a value (including packages) if it matches a pattern with '/' or with '.'.
+      // This means that if you exclude a package using one or the other the filter will always apply it as if it fails one it will pass the other.
+      // Therefore when excluding a package make sure it matches both the '/' and '.' patterns.
+      String dotPrefix = prefix.replace('/', '.');
+      excludePackages.add(dotPrefix);
+      String slashPrefix = prefix.replace('.', '/');
+      excludePackages.add(slashPrefix);
+    }
+    return this;
+  }
+
+  public Set<String> getIncludePackages() {
+    return includePackages;
+  }
+
+  public Set<String> getExcludePackages() {
+    return excludePackages;
+  }
+}

--- a/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/SwaggerConfiguration.java
+++ b/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/SwaggerConfiguration.java
@@ -15,6 +15,7 @@ public class SwaggerConfiguration implements OpenAPIConfiguration {
     private String id;
     private Set<String> resourcePackages;
     private Set<String> resourceClasses;
+    private ResourceFilter resourceFilter;
     private String filterClass;
     private String readerClass;
     private String scannerClass;
@@ -156,6 +157,20 @@ public class SwaggerConfiguration implements OpenAPIConfiguration {
 
     public SwaggerConfiguration resourceClasses(Set<String> resourceClasses) {
         this.resourceClasses = resourceClasses;
+        return this;
+    }
+
+    @Override
+    public ResourceFilter getResourceFilter() {
+        return resourceFilter;
+    }
+
+    public void setResourceFilter(ResourceFilter resourceFilter) {
+        this.resourceFilter = resourceFilter;
+    }
+
+    public SwaggerConfiguration resourceFilter(ResourceFilter resourceFilter) {
+        this.resourceFilter = resourceFilter;
         return this;
     }
 

--- a/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/api/OpenAPIConfiguration.java
+++ b/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/api/OpenAPIConfiguration.java
@@ -1,5 +1,6 @@
 package io.swagger.v3.oas.integration.api;
 
+import io.swagger.v3.oas.integration.ResourceFilter;
 import io.swagger.v3.oas.models.OpenAPI;
 
 import java.util.Collection;
@@ -10,6 +11,8 @@ public interface OpenAPIConfiguration {
     Set<String> getResourcePackages();
 
     Set<String> getResourceClasses();
+
+    ResourceFilter getResourceFilter();
 
     String getReaderClass();
 

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/IntegrationTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/IntegrationTest.java
@@ -2,6 +2,7 @@ package io.swagger.v3.jaxrs2.integration;
 
 import io.swagger.v3.jaxrs2.Reader;
 import io.swagger.v3.oas.integration.GenericOpenApiContext;
+import io.swagger.v3.oas.integration.ResourceFilter;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.integration.api.OpenApiContext;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -19,10 +20,9 @@ import static org.testng.Assert.assertNotNull;
 
 public class IntegrationTest {
 
-    private final Set expectedKeys = new HashSet<String>(Arrays.asList("/packageA", "/packageB"));
-
     @Test(description = "scan a simple resource")
     public void shouldScanWithNewInitialization() throws Exception {
+        Set expectedKeys = new HashSet<String>(Arrays.asList("/packageA", "/packageB"));
         SwaggerConfiguration config = new SwaggerConfiguration()
                 .resourcePackages(Stream.of("com.my.project.resources", "org.my.project.resources").collect(Collectors.toSet()))
                 .openAPI(new OpenAPI().info(new Info().description("TEST INFO DESC")));
@@ -50,6 +50,44 @@ public class IntegrationTest {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    @Test(description = "scan a simple resource with an inclusion filter")
+    public void shouldScanWithInclusionFilter() throws Exception {
+        Set expectedKeys = new HashSet<String>(Arrays.asList("/packageB"));
+        SwaggerConfiguration config = new SwaggerConfiguration()
+                .resourcePackages(Stream.of("com.my.project.resources", "org.my.project.resources").collect(Collectors.toSet()))
+                .resourceFilter(new ResourceFilter().includePackage("org.my.project.resources"))
+                .openAPI(new OpenAPI().info(new Info().description("TEST INFO DESC")));
+        OpenApiContext ctx = new GenericOpenApiContext()
+                .openApiConfiguration(config)
+                .openApiReader(new Reader(config))
+                .openApiScanner(new JaxrsApplicationAndAnnotationScanner().openApiConfiguration(config))
+                .init();
+
+        OpenAPI openApi = ctx.read();
+
+        assertNotNull(openApi);
+        assertEquals(openApi.getPaths().keySet(), expectedKeys);
+    }
+
+    @Test(description = "scan a simple resource with an exclusion filter")
+    public void shouldScanWithExclusionFilter() throws Exception {
+        Set expectedKeys = new HashSet<String>(Arrays.asList("/packageA"));
+        SwaggerConfiguration config = new SwaggerConfiguration()
+                .resourcePackages(Stream.of("com.my.project.resources", "org.my.project.resources").collect(Collectors.toSet()))
+                .resourceFilter(new ResourceFilter().excludePackage("org.my.project.resources"))
+                .openAPI(new OpenAPI().info(new Info().description("TEST INFO DESC")));
+        OpenApiContext ctx = new GenericOpenApiContext()
+                .openApiConfiguration(config)
+                .openApiReader(new Reader(config))
+                .openApiScanner(new JaxrsApplicationAndAnnotationScanner().openApiConfiguration(config))
+                .init();
+
+        OpenAPI openApi = ctx.read();
+
+        assertNotNull(openApi);
+        assertEquals(openApi.getPaths().keySet(), expectedKeys);
     }
 
 }


### PR DESCRIPTION
When using a "fat" application (e.g. Dropwizard) Reflections parses the entire JAR not just the resource package requested, this is slow and produces large numbers of keys and values.
This PR adds the ability to configure Reflections package filtering so that we can ensure that only the packages  we require are actually parsed.

**Example Result**
Before:
Reflections took 1203 ms to scan 1 urls, producing 15550 keys and 29087 values
After:
Reflections took 66 ms to scan 1 urls, producing 18 keys and 19 values