### PR TITLE
Make ModelResolver _isOptionalType protected

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -808,7 +808,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     }
 
 
-    private boolean _isOptionalType(JavaType propType) {
+    protected boolean _isOptionalType(JavaType propType) {
         return Arrays.asList("com.google.common.base.Optional", "java.util.Optional")
                 .contains(propType.getRawClass().getCanonicalName());
     }


### PR DESCRIPTION
So it can be overridden in subclasses (eg a scala model resolver)