### PR TITLE
ref #2937 - always add default @ApiResponse generated from return type

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -961,6 +961,12 @@ public class Reader implements OpenApiReader {
                             )
                     );
                 }
+                if (operation.getResponses().getDefault() == null) {
+                    operation.getResponses()._default(
+                            new ApiResponse().description(DEFAULT_DESCRIPTION)
+                                    .content(content)
+                    );
+                }
                 if (operation.getResponses().getDefault() != null &&
                         StringUtils.isBlank(operation.getResponses().getDefault().get$ref())) {
                     if (operation.getResponses().getDefault().getContent() == null) {


### PR DESCRIPTION
A default response is now always generated from the method return type, even if custom `@ApiResponse`s exist.