### PR TITLE
:triangular_ruler: Preserve order in maps accross the OAS model

### DIFF
--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/examples/ExamplesTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/examples/ExamplesTest.java
@@ -1,8 +1,6 @@
 package io.swagger.v3.jaxrs2.annotations.examples;
 
-import io.swagger.v3.jaxrs2.Reader;
 import io.swagger.v3.jaxrs2.annotations.AbstractAnnotationTest;
-import io.swagger.v3.jaxrs2.matchers.SerializationMatchers;
 import io.swagger.v3.jaxrs2.resources.model.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -13,7 +11,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.models.OpenAPI;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.Consumes;
@@ -23,7 +20,6 @@ import javax.ws.rs.Path;
 import static org.testng.Assert.assertEquals;
 
 public class ExamplesTest extends AbstractAnnotationTest {
-
 
     @Test
     public void testRequestBodyContentExample() {
@@ -411,6 +407,11 @@ public class ExamplesTest extends AbstractAnnotationTest {
                 "                  externalValue: Subscription Response value 1\n" +
                 "components:\n" +
                 "  schemas:\n" +
+                "    SubscriptionResponse:\n" +
+                "      type: object\n" +
+                "      properties:\n" +
+                "        subscriptionId:\n" +
+                "          type: string\n" +
                 "    User:\n" +
                 "      type: object\n" +
                 "      properties:\n" +
@@ -434,12 +435,7 @@ public class ExamplesTest extends AbstractAnnotationTest {
                 "          description: User Status\n" +
                 "          format: int32\n" +
                 "      xml:\n" +
-                "        name: User\n" +
-                "    SubscriptionResponse:\n" +
-                "      type: object\n" +
-                "      properties:\n" +
-                "        subscriptionId:\n" +
-                "          type: string";
+                "        name: User";
         assertEquals(extractedYAML, expectedYAML);
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -69,7 +70,7 @@ public class Components {
 
     public Components addSchemas(String key, Schema schemasItem) {
         if (this.schemas == null) {
-            this.schemas = new HashMap<String, Schema>();
+            this.schemas = new LinkedHashMap<>();
         }
         this.schemas.put(key, schemasItem);
         return this;
@@ -96,7 +97,7 @@ public class Components {
 
     public Components addResponses(String key, ApiResponse responsesItem) {
         if (this.responses == null) {
-            this.responses = new HashMap<String, ApiResponse>();
+            this.responses = new LinkedHashMap<>();
         }
         this.responses.put(key, responsesItem);
         return this;
@@ -123,7 +124,7 @@ public class Components {
 
     public Components addParameters(String key, Parameter parametersItem) {
         if (this.parameters == null) {
-            this.parameters = new HashMap<String, Parameter>();
+            this.parameters = new LinkedHashMap<>();
         }
         this.parameters.put(key, parametersItem);
         return this;
@@ -150,7 +151,7 @@ public class Components {
 
     public Components addExamples(String key, Example examplesItem) {
         if (this.examples == null) {
-            this.examples = new HashMap<String, Example>();
+            this.examples = new LinkedHashMap<>();
         }
         this.examples.put(key, examplesItem);
         return this;
@@ -177,7 +178,7 @@ public class Components {
 
     public Components addRequestBodies(String key, RequestBody requestBodiesItem) {
         if (this.requestBodies == null) {
-            this.requestBodies = new HashMap<String, RequestBody>();
+            this.requestBodies = new LinkedHashMap<>();
         }
         this.requestBodies.put(key, requestBodiesItem);
         return this;
@@ -204,7 +205,7 @@ public class Components {
 
     public Components addHeaders(String key, Header headersItem) {
         if (this.headers == null) {
-            this.headers = new HashMap<String, Header>();
+            this.headers = new LinkedHashMap<>();
         }
         this.headers.put(key, headersItem);
         return this;
@@ -231,7 +232,7 @@ public class Components {
 
     public Components addSecuritySchemes(String key, SecurityScheme securitySchemesItem) {
         if (this.securitySchemes == null) {
-            this.securitySchemes = new HashMap<String, SecurityScheme>();
+            this.securitySchemes = new LinkedHashMap<>();
         }
         this.securitySchemes.put(key, securitySchemesItem);
         return this;
@@ -258,7 +259,7 @@ public class Components {
 
     public Components addLinks(String key, Link linksItem) {
         if (this.links == null) {
-            this.links = new HashMap<String, Link>();
+            this.links = new LinkedHashMap<>();
         }
         this.links.put(key, linksItem);
         return this;
@@ -285,7 +286,7 @@ public class Components {
 
     public Components addCallbacks(String key, Callback callbacksItem) {
         if (this.callbacks == null) {
-            this.callbacks = new HashMap<String, Callback>();
+            this.callbacks = new LinkedHashMap<>();
         }
         this.callbacks.put(key, callbacksItem);
         return this;
@@ -326,7 +327,7 @@ public class Components {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/ExternalDocumentation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/ExternalDocumentation.java
@@ -95,7 +95,7 @@ public class ExternalDocumentation {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
@@ -283,7 +283,7 @@ public class OpenAPI {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Operation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Operation.java
@@ -347,7 +347,7 @@ public class Operation {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
@@ -401,7 +401,7 @@ public class PathItem {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Paths.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Paths.java
@@ -63,7 +63,7 @@ public class Paths extends LinkedHashMap<String, PathItem> {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/callbacks/Callback.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/callbacks/Callback.java
@@ -95,7 +95,7 @@ public class Callback extends LinkedHashMap<String, PathItem> {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/examples/Example.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/examples/Example.java
@@ -129,7 +129,7 @@ public class Example {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/headers/Header.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/headers/Header.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.Schema;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -197,7 +198,7 @@ public class Header {
 
     public Header addExample(String key, Example examplesItem) {
         if (this.examples == null) {
-            this.examples = new HashMap<String, Example>();
+            this.examples = new LinkedHashMap<>();
         }
         this.examples.put(key, examplesItem);
         return this;
@@ -277,7 +278,7 @@ public class Header {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Contact.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Contact.java
@@ -116,7 +116,7 @@ public class Contact {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Info.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Info.java
@@ -177,7 +177,7 @@ public class Info {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/License.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/License.java
@@ -95,7 +95,7 @@ public class License {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.servers.Server;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -126,7 +127,7 @@ public class Link {
 
     public Link parameters(String name, String parameter) {
         if (this.parameters == null) {
-            this.parameters = new HashMap<>();
+            this.parameters = new LinkedHashMap<>();
         }
         this.parameters.put(name, parameter);
 
@@ -154,7 +155,7 @@ public class Link {
 
     public Link addHeaderObject(String name, Header header) {
         if (this.headers == null) {
-            headers = new HashMap<>();
+            headers = new LinkedHashMap<>();
         }
         headers.put(name, header);
         return this;
@@ -257,7 +258,7 @@ public class Link {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/LinkParameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/LinkParameter.java
@@ -72,7 +72,7 @@ public class LinkParameter {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Discriminator.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Discriminator.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.oas.models.media;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class Discriminator {
@@ -22,7 +23,7 @@ public class Discriminator {
 
     public Discriminator mapping(String name, String value) {
         if (this.mapping == null) {
-            this.mapping = new HashMap<>();
+            this.mapping = new LinkedHashMap<>();
         }
         this.mapping.put(name, value);
         return this;

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Encoding.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Encoding.java
@@ -130,7 +130,7 @@ public class Encoding {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/EncodingProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/EncodingProperty.java
@@ -19,6 +19,7 @@ package io.swagger.v3.oas.models.media;
 import io.swagger.v3.oas.models.headers.Header;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -101,7 +102,7 @@ public class EncodingProperty {
 
     public EncodingProperty addHeaderObject(String name, Header header) {
         if (this.headers == null) {
-            headers = new HashMap<>();
+            headers = new LinkedHashMap<>();
         }
         headers.put(name, header);
         return this;
@@ -195,7 +196,7 @@ public class EncodingProperty {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/MediaType.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/MediaType.java
@@ -19,6 +19,7 @@ package io.swagger.v3.oas.models.media;
 import io.swagger.v3.oas.models.examples.Example;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -75,7 +76,7 @@ public class MediaType {
 
     public MediaType addExamples(String key, Example examplesItem) {
         if (this.examples == null) {
-            this.examples = new HashMap<String, Example>();
+            this.examples = new LinkedHashMap<>();
         }
         this.examples.put(key, examplesItem);
         return this;
@@ -121,7 +122,7 @@ public class MediaType {
 
     public MediaType addEncoding(String key, Encoding encodingItem) {
         if (this.encoding == null) {
-            this.encoding = new HashMap<String, Encoding>();
+            this.encoding = new LinkedHashMap<>();
         }
         this.encoding.put(key, encodingItem);
         return this;
@@ -157,7 +158,7 @@ public class MediaType {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -525,7 +525,7 @@ public class Schema<T> {
 
     public Schema addProperties(String key, Schema propertiesItem) {
         if (this.properties == null) {
-            this.properties = new LinkedHashMap<String, Schema>();
+            this.properties = new LinkedHashMap<>();
         }
         this.properties.put(key, propertiesItem);
         return this;
@@ -806,7 +806,7 @@ public class Schema<T> {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/XML.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/XML.java
@@ -158,7 +158,7 @@ public class XML {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/Parameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/Parameter.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.Schema;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -286,7 +287,7 @@ public class Parameter {
 
     public Parameter addExample(String key, Example examplesItem) {
         if (this.examples == null) {
-            this.examples = new HashMap<String, Example>();
+            this.examples = new LinkedHashMap<>();
         }
         this.examples.put(key, examplesItem);
         return this;
@@ -386,7 +387,7 @@ public class Parameter {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/RequestBody.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/RequestBody.java
@@ -97,7 +97,7 @@ public class RequestBody {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponse.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponse.java
@@ -21,6 +21,7 @@ import io.swagger.v3.oas.models.links.Link;
 import io.swagger.v3.oas.models.media.Content;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -78,7 +79,7 @@ public class ApiResponse {
 
     public ApiResponse addHeaderObject(String name, Header header) {
         if (this.headers == null) {
-            headers = new HashMap<>();
+            headers = new LinkedHashMap<>();
         }
         headers.put(name, header);
         return this;
@@ -119,7 +120,7 @@ public class ApiResponse {
 
     public ApiResponse link(String name, Link link) {
         if (this.links == null) {
-            this.links = new HashMap<>();
+            this.links = new LinkedHashMap<>();
         }
         this.links.put(name, link);
         return this;
@@ -177,7 +178,7 @@ public class ApiResponse {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponses.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponses.java
@@ -64,7 +64,7 @@ public class ApiResponses extends LinkedHashMap<String, ApiResponse> {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlow.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlow.java
@@ -137,7 +137,7 @@ public class OAuthFlow {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlows.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlows.java
@@ -137,7 +137,7 @@ public class OAuthFlows {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/Scopes.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/Scopes.java
@@ -71,7 +71,7 @@ public class Scopes extends LinkedHashMap<String, String> {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityScheme.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityScheme.java
@@ -239,7 +239,7 @@ public class SecurityScheme {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/Server.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/Server.java
@@ -116,7 +116,7 @@ public class Server {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariable.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariable.java
@@ -126,7 +126,7 @@ public class ServerVariable {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariables.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariables.java
@@ -71,7 +71,7 @@ public class ServerVariables extends LinkedHashMap<String, ServerVariable> {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/tags/Tag.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/tags/Tag.java
@@ -118,7 +118,7 @@ public class Tag {
             return;
         }
         if (this.extensions == null) {
-            this.extensions = new java.util.HashMap<>();
+            this.extensions = new java.util.LinkedHashMap<>();
         }
         this.extensions.put(name, value);
     }


### PR DESCRIPTION
### Affects: [2.0.5](https://github.com/swagger-api/swagger-core/tree/v2.0.5)

### Issue

When adding elements in a map in the OAS POJOs then serializing, the order in which the elements were added is not preserved.

Although JSON maps are supposed not to enforce an order on their elements, in practice this is implemented in all serializers and used in lots of products. 

We are converting API definitions from different languages and need the order to be preserved.

We already contributed [a similar fix](https://github.com/swagger-api/swagger-core/pull/2022) in version 2 of OAS.
