### PR TITLE
Fix for Issue #2966

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -198,7 +198,13 @@ public class Reader implements OpenApiReader {
 
     protected String resolveApplicationPath() {
         if (application != null) {
-            ApplicationPath applicationPath = application.getClass().getAnnotation(ApplicationPath.class);
+            Class<?> applicationToScan = this.application.getClass();
+            ApplicationPath applicationPath;
+            //search up in the hierarchy until we find one with the annotation, this is needed because for example Weld proxies will not have the annotation and the right class will be the superClass
+            while ((applicationPath = applicationToScan.getAnnotation(ApplicationPath.class)) == null && !applicationToScan.getSuperclass().equals(Application.class)) {
+                applicationToScan = applicationToScan.getSuperclass();
+            }
+
             if (applicationPath != null) {
                 if (StringUtils.isNotBlank(applicationPath.value())) {
                     return applicationPath.value();


### PR DESCRIPTION
The annotation @ApplicationPath is now scanned on the superclasses in order to work as intended with Weld proxies.