### PR TITLE
take servlet context path into account when building OpenAPI instance (fixes #3025)

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -77,6 +77,7 @@ public class Reader implements OpenApiReader {
 
     protected OpenAPIConfiguration config;
 
+    private String contextPath = null;
     private Application application;
     private OpenAPI openAPI;
     private Components components;
@@ -165,8 +166,18 @@ public class Reader implements OpenApiReader {
             }
         }
 
+        String appPath = resolveApplicationPath();
         for (Class<?> cls : sortedClasses) {
-            read(cls, resolveApplicationPath(), null, false, null, null, new LinkedHashSet<String>(), new ArrayList<Parameter>(), new HashSet<Class<?>>());
+            read(cls, appPath, null, false, null, null, new LinkedHashSet<String>(), new ArrayList<Parameter>(), new HashSet<Class<?>>());
+        }
+
+        if (contextPath != null && !contextPath.isEmpty()) {
+            List<io.swagger.v3.oas.models.servers.Server> servers = openAPI.getServers();
+            if (servers == null || servers.isEmpty()) {
+                io.swagger.v3.oas.models.servers.Server server = new io.swagger.v3.oas.models.servers.Server();
+                server.setUrl(contextPath);
+                openAPI.addServersItem(server);
+            }
         }
 
         for (ReaderListener listener : listeners.values()) {
@@ -1301,6 +1312,10 @@ public class Reader implements OpenApiReader {
             return true;
         }
         return false;
+    }
+
+    public void setContextPath(String contextPath) {
+        this.contextPath = contextPath;
     }
 
     public void setApplication(Application application) {

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/XmlWebOpenApiContext.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/XmlWebOpenApiContext.java
@@ -1,7 +1,10 @@
 package io.swagger.v3.jaxrs2.integration;
 
+import io.swagger.v3.jaxrs2.Reader;
 import io.swagger.v3.jaxrs2.integration.api.WebOpenApiContext;
+import io.swagger.v3.oas.integration.api.OpenAPIConfiguration;
 import io.swagger.v3.oas.integration.api.OpenApiConfigurationLoader;
+import io.swagger.v3.oas.integration.api.OpenApiReader;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,4 +70,14 @@ public class XmlWebOpenApiContext<T extends XmlWebOpenApiContext<T>> extends Jax
         return map;
     }
 
+    @Override
+    protected OpenApiReader buildReader(OpenAPIConfiguration openApiConfiguration) throws Exception {
+        OpenApiReader reader = super.buildReader(openApiConfiguration);
+        if (reader instanceof Reader) {
+            if (servletConfig != null) {
+                ((Reader) reader).setContextPath(servletConfig.getServletContext().getContextPath());
+            }
+        }
+        return reader;
+    }
 }


### PR DESCRIPTION
if the application is deployed under a non-empty context path (tomcat typically deploys file.war as host:port/file), and no "servers" section otherwise generated, generates a server with the same url as the context path.