### PR TITLE
use JakartaEE Maven coordinates

### DIFF
--- a/modules/swagger-annotations/pom.xml
+++ b/modules/swagger-annotations/pom.xml
@@ -120,8 +120,8 @@
     </profiles>
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -49,9 +49,9 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/modules/swagger-integration/pom.xml
+++ b/modules/swagger-integration/pom.xml
@@ -18,8 +18,8 @@
 			<artifactId>reflections</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>javax.ws.rs</groupId>
-			<artifactId>javax.ws.rs-api</artifactId>
+			<groupId>jakarta.ws.rs</groupId>
+			<artifactId>jakarta.ws.rs-api</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/modules/swagger-jaxrs2-servlet-initializer/pom.xml
+++ b/modules/swagger-jaxrs2-servlet-initializer/pom.xml
@@ -119,9 +119,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -179,6 +178,10 @@
                 <exclusion>
                     <groupId>org.javassist</groupId>
                     <artifactId>javassist</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/modules/swagger-jaxrs2/pom.xml
+++ b/modules/swagger-jaxrs2/pom.xml
@@ -117,9 +117,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -250,6 +249,10 @@
                 <exclusion>
                     <groupId>org.javassist</groupId>
                     <artifactId>javassist</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>javax.ws.rs-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/modules/swagger-maven-plugin/pom.xml
+++ b/modules/swagger-maven-plugin/pom.xml
@@ -155,9 +155,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
                                     <onlyWhenRelease>true</onlyWhenRelease>
                                     <message>No Snapshots Allowed!</message>
                                 </requireReleaseDeps>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>javax.ws.rs:javax.ws.rs-api</exclude>
+                                        <exclude>javax.xml.bind:jaxb-api</exclude>
+                                    </excludes>
+                                </bannedDependencies>
                             </rules>
                         </configuration>
                     </execution>
@@ -482,8 +488,8 @@
                 <version>${snakeyaml-version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
                 <version>${javax.ws-version}</version>
             </dependency>
         </dependencies>
@@ -492,7 +498,7 @@
         <joda-version>1.9.2</joda-version>
         <joda-time-version>2.9.9</joda-time-version>
         <snakeyaml-version>1.18</snakeyaml-version>
-        <javax.ws-version>2.1</javax.ws-version>
+        <javax.ws-version>2.1.4</javax.ws-version>
         <felix-version>3.5.0</felix-version>
         <servlet-api-version>3.1.0</servlet-api-version>
         <jersey2-version>2.26</jersey2-version>


### PR DESCRIPTION
The Maven coordinates for JAXB und REST API changed and should be update. See also https://wiki.eclipse.org/New_Maven_Coordinates

The new Servlet API artifact is not available on central and can be changed later. See also discussion here: https://www.eclipse.org/lists/servlet-dev/msg00069.html