### PR TITLE
#3082 jaxrs generic return type is abstract class

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -458,8 +458,8 @@ public class Reader implements OpenApiReader {
                         parentRequestBody,
                         parentResponses,
                         jsonViewAnnotation,
-                        classResponses
-                        );
+                        classResponses,
+                        annotatedMethod);
                 if (operation != null) {
 
                     List<Parameter> operationParameters = new ArrayList<>();
@@ -749,6 +749,7 @@ public class Reader implements OpenApiReader {
                 null,
                 null,
                 jsonViewAnnotation,
+                null,
                 null);
     }
 
@@ -767,7 +768,8 @@ public class Reader implements OpenApiReader {
             RequestBody parentRequestBody,
             ApiResponses parentResponses,
             JsonView jsonViewAnnotation,
-            io.swagger.v3.oas.annotations.responses.ApiResponse[] classResponses) {
+            io.swagger.v3.oas.annotations.responses.ApiResponse[] classResponses,
+            AnnotatedMethod annotatedMethod) {
         JavaType classType = TypeFactory.defaultInstance().constructType(method.getDeclaringClass());
         return parseMethod(
                 classType.getClass(),
@@ -785,7 +787,8 @@ public class Reader implements OpenApiReader {
                 parentRequestBody,
                 parentResponses,
                 jsonViewAnnotation,
-                classResponses);
+                classResponses,
+                annotatedMethod);
     }
 
     private Operation parseMethod(
@@ -804,7 +807,8 @@ public class Reader implements OpenApiReader {
             RequestBody parentRequestBody,
             ApiResponses parentResponses,
             JsonView jsonViewAnnotation,
-            io.swagger.v3.oas.annotations.responses.ApiResponse[] classResponses) {
+            io.swagger.v3.oas.annotations.responses.ApiResponse[] classResponses,
+            AnnotatedMethod annotatedMethod) {
         Operation operation = new Operation();
 
         io.swagger.v3.oas.annotations.Operation apiOperation = ReflectionUtils.getAnnotation(method, io.swagger.v3.oas.annotations.Operation.class);
@@ -962,6 +966,9 @@ public class Reader implements OpenApiReader {
 
         // handle return type, add as response in case.
         Type returnType = method.getGenericReturnType();
+        if (annotatedMethod != null) {
+            returnType = annotatedMethod.getType();
+        }
         final Class<?> subResource = getSubResourceWithJaxRsSubresourceLocatorSpecs(method);
         if (!shouldIgnoreClass(returnType.getTypeName()) && !returnType.equals(subResource)) {
             ResolvedSchema resolvedSchema = ModelConverters.getInstance().resolveAsResolvedSchema(new AnnotatedType(returnType).resolveAsRef(true).jsonViewAnnotation(jsonViewAnnotation));


### PR DESCRIPTION
Issue #3082 

I check the Reader class in the jaxrs module. The parameter types are taken from the AnnotatedMethod object. For the return type, the type from the java method is used. 
I create simple fix and a pull request.

Could you please look at it if it is ok or create another solution for this issue.

Thanks
Andrej