### PR TITLE
fix #3094 - avoid duplicate fields in schema classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ atlassian-ide-plugin.xml
 *.iml
 .java-version
 sonar-project.properties
+test-output/

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ArraySchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ArraySchema.java
@@ -22,26 +22,15 @@ import java.util.Objects;
  * ArraySchema
  */
 
-public class ArraySchema extends Schema {
-    private String type = "array";
-    private Schema items = null;
+public class ArraySchema extends Schema<Object> {
+    private Schema<?> items = null;
 
-    /**
-     * returns the type property from a ArraySchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public ArraySchema() {
+        super("array", null);
     }
 
     public ArraySchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
@@ -51,15 +40,15 @@ public class ArraySchema extends Schema {
      * @return Schema items
      **/
 
-    public Schema getItems() {
+    public Schema<?> getItems() {
         return items;
     }
 
-    public void setItems(Schema items) {
+    public void setItems(Schema<?> items) {
         this.items = items;
     }
 
-    public ArraySchema items(Schema items) {
+    public ArraySchema items(Schema<?> items) {
         this.items = items;
         return this;
     }
@@ -73,14 +62,13 @@ public class ArraySchema extends Schema {
             return false;
         }
         ArraySchema arraySchema = (ArraySchema) o;
-        return Objects.equals(this.type, arraySchema.type) &&
-                Objects.equals(this.items, arraySchema.items) &&
+        return Objects.equals(this.items, arraySchema.items) &&
                 super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, items, super.hashCode());
+        return Objects.hash(items, super.hashCode());
     }
 
     @Override
@@ -88,22 +76,9 @@ public class ArraySchema extends Schema {
         StringBuilder sb = new StringBuilder();
         sb.append("class ArraySchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    items: ").append(toIndentedString(items)).append("\n");
+        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/BinarySchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/BinarySchema.java
@@ -16,7 +16,6 @@
 
 package io.swagger.v3.oas.models.media;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -25,44 +24,18 @@ import java.util.Objects;
  */
 
 public class BinarySchema extends Schema<byte[]> {
-    private String type = "string";
-    private String format = "binary";
 
-    /**
-     * returns the type property from a BinarySchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public BinarySchema() {
+        super("string", "binary");
     }
 
     public BinarySchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    /**
-     * returns the format property from a BinarySchema instance.
-     *
-     * @return String format
-     **/
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public BinarySchema format(String format) {
-        this.format = format;
+        super.setFormat(format);;
         return this;
     }
 
@@ -85,15 +58,12 @@ public class BinarySchema extends Schema<byte[]> {
     }
 
     public BinarySchema _enum(List<byte[]> _enum) {
-        this._enum = _enum;
+        super.setEnum(_enum);
         return this;
     }
 
     public BinarySchema addEnumItem(byte[] _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<byte[]>();
-        }
-        this._enum.add(_enumItem);
+        super.addEnumItemObject(_enumItem);
         return this;
     }
 
@@ -105,17 +75,12 @@ public class BinarySchema extends Schema<byte[]> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        BinarySchema binarySchema = (BinarySchema) o;
-        return Objects.equals(this.type, binarySchema.type) &&
-                Objects.equals(this.format, binarySchema.format) &&
-                Objects.equals(this._default, binarySchema._default) &&
-                Objects.equals(this._enum, binarySchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, format, _default, _enum, super.hashCode());
+        return Objects.hash(_default, _enum, super.hashCode());
     }
 
     @Override
@@ -123,24 +88,8 @@ public class BinarySchema extends Schema<byte[]> {
         StringBuilder sb = new StringBuilder();
         sb.append("class BinarySchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/BooleanSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/BooleanSchema.java
@@ -24,25 +24,14 @@ import java.util.Objects;
  * BooleanSchema
  */
 
-public class BooleanSchema extends Schema {
-    private String type = "boolean";
+public class BooleanSchema extends Schema<Boolean> {
 
-    /**
-     * returns the type property from a BooleanSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public BooleanSchema() {
+        super("boolean", null);
     }
 
     public BooleanSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
@@ -83,16 +72,12 @@ public class BooleanSchema extends Schema {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        BooleanSchema booleanSchema = (BooleanSchema) o;
-        return Objects.equals(this.type, booleanSchema.type) &&
-                Objects.equals(this._default, booleanSchema._default) &&
-                Objects.equals(this._enum, booleanSchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -100,23 +85,8 @@ public class BooleanSchema extends Schema {
         StringBuilder sb = new StringBuilder();
         sb.append("class BooleanSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ByteArraySchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ByteArraySchema.java
@@ -16,7 +16,6 @@
 
 package io.swagger.v3.oas.models.media;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -25,44 +24,18 @@ import java.util.Objects;
  */
 
 public class ByteArraySchema extends Schema<byte[]> {
-    private String type = "string";
-    private String format = "byte";
 
-    /**
-     * returns the type property from a ByteArraySchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public ByteArraySchema() {
+        super("string", "byte");
     }
 
     public ByteArraySchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    /**
-     * returns the format property from a ByteArraySchema instance.
-     *
-     * @return String format
-     **/
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public ByteArraySchema format(String format) {
-        this.format = format;
+        super.setFormat(format);
         return this;
     }
 
@@ -85,15 +58,12 @@ public class ByteArraySchema extends Schema<byte[]> {
     }
 
     public ByteArraySchema _enum(List<byte[]> _enum) {
-        this._enum = _enum;
+        super.setEnum(_enum);
         return this;
     }
 
     public ByteArraySchema addEnumItem(byte[] _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<byte[]>();
-        }
-        this._enum.add(_enumItem);
+        super.addEnumItemObject(_enumItem);
         return this;
     }
 
@@ -105,17 +75,12 @@ public class ByteArraySchema extends Schema<byte[]> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ByteArraySchema byteArraySchema = (ByteArraySchema) o;
-        return Objects.equals(this.type, byteArraySchema.type) &&
-                Objects.equals(this.format, byteArraySchema.format) &&
-                Objects.equals(this._default, byteArraySchema._default) &&
-                Objects.equals(this._enum, byteArraySchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, format, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -123,24 +88,7 @@ public class ByteArraySchema extends Schema<byte[]> {
         StringBuilder sb = new StringBuilder();
         sb.append("class ByteArraySchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ComposedSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ComposedSchema.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  * ComposedSchema
  */
 
-public class ComposedSchema extends Schema {
+public class ComposedSchema extends Schema<Object> {
     private List<Schema> allOf = null;
     private List<Schema> anyOf = null;
     private List<Schema> oneOf = null;
@@ -50,7 +50,7 @@ public class ComposedSchema extends Schema {
 
     public ComposedSchema addAllOfItem(Schema allOfItem) {
         if (this.allOf == null) {
-            this.allOf = new ArrayList<Schema>();
+            this.allOf = new ArrayList<>();
         }
         this.allOf.add(allOfItem);
         return this;
@@ -77,7 +77,7 @@ public class ComposedSchema extends Schema {
 
     public ComposedSchema addAnyOfItem(Schema anyOfItem) {
         if (this.anyOf == null) {
-            this.anyOf = new ArrayList<Schema>();
+            this.anyOf = new ArrayList<>();
         }
         this.anyOf.add(anyOfItem);
         return this;
@@ -104,7 +104,7 @@ public class ComposedSchema extends Schema {
 
     public ComposedSchema addOneOfItem(Schema oneOfItem) {
         if (this.oneOf == null) {
-            this.oneOf = new ArrayList<Schema>();
+            this.oneOf = new ArrayList<>();
         }
         this.oneOf.add(oneOfItem);
         return this;
@@ -141,17 +141,4 @@ public class ComposedSchema extends Schema {
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateSchema.java
@@ -16,9 +16,7 @@
 
 package io.swagger.v3.oas.models.media;
 
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -26,44 +24,18 @@ import java.util.Objects;
  */
 
 public class DateSchema extends Schema<Date> {
-    private String type = "string";
-    private String format = "date";
 
-    /**
-     * returns the type property from a DateSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public DateSchema() {
+        super("string", "date");
     }
 
     public DateSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    /**
-     * returns the format property from a DateSchema instance.
-     *
-     * @return String format
-     **/
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public DateSchema format(String format) {
-        this.format = format;
+        super.setFormat(format);
         return this;
     }
 
@@ -85,16 +57,8 @@ public class DateSchema extends Schema<Date> {
         return null;
     }
 
-    public DateSchema _enum(List<Date> _enum) {
-        this._enum = _enum;
-        return this;
-    }
-
     public DateSchema addEnumItem(Date _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<Date>();
-        }
-        this._enum.add(_enumItem);
+        super.addEnumItemObject(_enumItem);
         return this;
     }
 
@@ -106,17 +70,12 @@ public class DateSchema extends Schema<Date> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DateSchema dateSchema = (DateSchema) o;
-        return Objects.equals(this.type, dateSchema.type) &&
-                Objects.equals(this.format, dateSchema.format) &&
-                Objects.equals(this._default, dateSchema._default) &&
-                Objects.equals(this._enum, dateSchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, format, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -124,24 +83,8 @@ public class DateSchema extends Schema<Date> {
         StringBuilder sb = new StringBuilder();
         sb.append("class DateSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateTimeSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateTimeSchema.java
@@ -16,7 +16,6 @@
 
 package io.swagger.v3.oas.models.media;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -26,44 +25,18 @@ import java.util.Objects;
  */
 
 public class DateTimeSchema extends Schema<Date> {
-    private String type = "string";
-    private String format = "date-time";
 
-    /**
-     * returns the type property from a DateTimeSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public DateTimeSchema() {
+        super("string", "date-time");
     }
 
     public DateTimeSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    /**
-     * returns the format property from a DateTimeSchema instance.
-     *
-     * @return String format
-     **/
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public DateTimeSchema format(String format) {
-        this.format = format;
+        super.setFormat(format);
         return this;
     }
 
@@ -86,15 +59,12 @@ public class DateTimeSchema extends Schema<Date> {
     }
 
     public DateTimeSchema _enum(List<Date> _enum) {
-        this._enum = _enum;
+        super.setEnum(_enum);
         return this;
     }
 
     public DateTimeSchema addEnumItem(Date _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<Date>();
-        }
-        this._enum.add(_enumItem);
+        super.addEnumItemObject(_enumItem);
         return this;
     }
 
@@ -106,17 +76,12 @@ public class DateTimeSchema extends Schema<Date> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DateTimeSchema dateTimeSchema = (DateTimeSchema) o;
-        return Objects.equals(this.type, dateTimeSchema.type) &&
-                Objects.equals(this.format, dateTimeSchema.format) &&
-                Objects.equals(this._default, dateTimeSchema._default) &&
-                Objects.equals(this._enum, dateTimeSchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, format, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -124,24 +89,7 @@ public class DateTimeSchema extends Schema<Date> {
         StringBuilder sb = new StringBuilder();
         sb.append("class DateTimeSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/EmailSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/EmailSchema.java
@@ -16,8 +16,6 @@
 
 package io.swagger.v3.oas.models.media;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -25,44 +23,18 @@ import java.util.Objects;
  */
 
 public class EmailSchema extends Schema<String> {
-    private String type = "string";
-    private String format = "email";
 
-    /**
-     * returns the type property from a EmailSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public EmailSchema() {
+        super("string", "email");
     }
 
     public EmailSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    /**
-     * returns the format property from a EmailSchema instance.
-     *
-     * @return String format
-     **/
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public EmailSchema format(String format) {
-        this.format = format;
+        super.setFormat(format);
         return this;
     }
 
@@ -82,16 +54,8 @@ public class EmailSchema extends Schema<String> {
         return null;
     }
 
-    public EmailSchema _enum(List<String> _enum) {
-        this._enum = _enum;
-        return this;
-    }
-
     public EmailSchema addEnumItem(String _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<String>();
-        }
-        this._enum.add(_enumItem);
+        super.addEnumItemObject(_enumItem);
         return this;
     }
 
@@ -103,17 +67,12 @@ public class EmailSchema extends Schema<String> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        EmailSchema emailSchema = (EmailSchema) o;
-        return Objects.equals(this.type, emailSchema.type) &&
-                Objects.equals(this.format, emailSchema.format) &&
-                Objects.equals(this._default, emailSchema._default) &&
-                Objects.equals(this._enum, emailSchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, format, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -121,24 +80,7 @@ public class EmailSchema extends Schema<String> {
         StringBuilder sb = new StringBuilder();
         sb.append("class EmailSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/FileSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/FileSchema.java
@@ -23,44 +23,18 @@ import java.util.Objects;
  */
 
 public class FileSchema extends Schema<String> {
-    private String type = "string";
-    private String format = "binary";
 
-    /**
-     * returns the type property from a FileSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public FileSchema() {
+        super("string", "binary");
     }
 
     public FileSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    /**
-     * returns the format property from a FileSchema instance.
-     *
-     * @return String format
-     **/
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public FileSchema format(String format) {
-        this.format = format;
+        super.setFormat(format);
         return this;
     }
 
@@ -72,15 +46,12 @@ public class FileSchema extends Schema<String> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        FileSchema fileSchema = (FileSchema) o;
-        return Objects.equals(this.type, fileSchema.type) &&
-                Objects.equals(this.format, fileSchema.format) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, format, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -88,22 +59,7 @@ public class FileSchema extends Schema<String> {
         StringBuilder sb = new StringBuilder();
         sb.append("class FileSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/IntegerSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/IntegerSchema.java
@@ -17,8 +17,6 @@
 package io.swagger.v3.oas.models.media;
 
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -26,44 +24,18 @@ import java.util.Objects;
  */
 
 public class IntegerSchema extends Schema<Number> {
-    private String type = "integer";
-    private String format = "int32";
 
-    /**
-     * returns the type property from a IntegerSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public IntegerSchema() {
+        super("integer", "int32");
     }
 
     public IntegerSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    /**
-     * returns the format property from a IntegerSchema instance.
-     *
-     * @return String format
-     **/
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public IntegerSchema format(String format) {
-        this.format = format;
+        super.setFormat(format);
         return this;
     }
 
@@ -88,16 +60,8 @@ public class IntegerSchema extends Schema<Number> {
         return null;
     }
 
-    public IntegerSchema _enum(List<Number> _enum) {
-        this._enum = _enum;
-        return this;
-    }
-
     public IntegerSchema addEnumItem(Number _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<>();
-        }
-        this._enum.add(_enumItem);
+        super.addEnumItemObject(_enumItem);
         return this;
     }
 
@@ -109,17 +73,12 @@ public class IntegerSchema extends Schema<Number> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        IntegerSchema integerSchema = (IntegerSchema) o;
-        return Objects.equals(this.type, integerSchema.type) &&
-                Objects.equals(this.format, integerSchema.format) &&
-                Objects.equals(this._default, integerSchema._default) &&
-                Objects.equals(this._enum, integerSchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, format, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -127,24 +86,7 @@ public class IntegerSchema extends Schema<Number> {
         StringBuilder sb = new StringBuilder();
         sb.append("class IntegerSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/MapSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/MapSchema.java
@@ -22,25 +22,14 @@ import java.util.Objects;
  * MapSchema
  */
 
-public class MapSchema extends Schema {
-    private String type = "object";
+public class MapSchema extends Schema<Object> {
 
-    /**
-     * returns the type property from a MapSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public MapSchema() {
+        super("object", null);
     }
 
     public MapSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
@@ -52,14 +41,12 @@ public class MapSchema extends Schema {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        MapSchema mapSchema = (MapSchema) o;
-        return Objects.equals(this.type, mapSchema.type) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -67,21 +54,7 @@ public class MapSchema extends Schema {
         StringBuilder sb = new StringBuilder();
         sb.append("class MapSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/NumberSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/NumberSchema.java
@@ -17,7 +17,6 @@
 package io.swagger.v3.oas.models.media;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -26,29 +25,28 @@ import java.util.Objects;
  */
 
 public class NumberSchema extends Schema<BigDecimal> {
-    private String type = "number";
 
-    /**
-     * returns the type property from a NumberSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public NumberSchema() {
+        super("number", null);
     }
 
     public NumberSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
     public NumberSchema _default(BigDecimal _default) {
         super.setDefault(_default);
+        return this;
+    }
+
+    public NumberSchema _enum(List<BigDecimal> _enum) {
+        super.setEnum(_enum);
+        return this;
+    }
+
+    public NumberSchema addEnumItem(BigDecimal _enumItem) {
+        super.addEnumItemObject(_enumItem);
         return this;
     }
 
@@ -63,19 +61,6 @@ public class NumberSchema extends Schema<BigDecimal> {
         return null;
     }
 
-    public NumberSchema _enum(List<BigDecimal> _enum) {
-        this._enum = _enum;
-        return this;
-    }
-
-    public NumberSchema addEnumItem(BigDecimal _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<BigDecimal>();
-        }
-        this._enum.add(_enumItem);
-        return this;
-    }
-
     @Override
     public boolean equals(java.lang.Object o) {
         if (this == o) {
@@ -84,16 +69,12 @@ public class NumberSchema extends Schema<BigDecimal> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        NumberSchema numberSchema = (NumberSchema) o;
-        return Objects.equals(this.type, numberSchema.type) &&
-                Objects.equals(this._default, numberSchema._default) &&
-                Objects.equals(this._enum, numberSchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -101,23 +82,7 @@ public class NumberSchema extends Schema<BigDecimal> {
         StringBuilder sb = new StringBuilder();
         sb.append("class NumberSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ObjectSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ObjectSchema.java
@@ -23,31 +23,19 @@ import java.util.Objects;
  */
 
 public class ObjectSchema extends Schema<Object> {
-    private String type = "object";
-    private Object defaultObject = null;
 
-    /**
-     * returns the type property from a ObjectSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public ObjectSchema() {
+        super("object", null);
     }
 
     public ObjectSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    public Schema example(Object example) {
+    public ObjectSchema example(Object example) {
         if (example != null) {
-            super.example = example.toString();
+            super.setExample(example.toString());
         }
         return this;
     }
@@ -65,15 +53,12 @@ public class ObjectSchema extends Schema<Object> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ObjectSchema objectSchema = (ObjectSchema) o;
-        return Objects.equals(this.type, objectSchema.type) &&
-                Objects.equals(this.defaultObject, objectSchema.defaultObject) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, defaultObject, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -81,22 +66,7 @@ public class ObjectSchema extends Schema<Object> {
         StringBuilder sb = new StringBuilder();
         sb.append("class ObjectSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    defaultObject: ").append(toIndentedString(defaultObject)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/PasswordSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/PasswordSchema.java
@@ -16,8 +16,6 @@
 
 package io.swagger.v3.oas.models.media;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -25,49 +23,23 @@ import java.util.Objects;
  */
 
 public class PasswordSchema extends Schema<String> {
-    private String type = "string";
-    private String format = "password";
 
-    /**
-     * returns the type property from a PasswordSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public PasswordSchema() {
+        super("string", "password");
     }
 
     public PasswordSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    /**
-     * returns the format property from a PasswordSchema instance.
-     *
-     * @return String format
-     **/
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public PasswordSchema format(String format) {
-        this.format = format;
+        super.setFormat(format);
         return this;
     }
 
     public PasswordSchema _default(String _default) {
-        this._default = _default;
+        super.setDefault(_default);
         return this;
     }
 
@@ -82,16 +54,8 @@ public class PasswordSchema extends Schema<String> {
         return null;
     }
 
-    public PasswordSchema _enum(List<String> _enum) {
-        this._enum = _enum;
-        return this;
-    }
-
     public PasswordSchema addEnumItem(String _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<String>();
-        }
-        this._enum.add(_enumItem);
+        super.addEnumItemObject(_enumItem);
         return this;
     }
 
@@ -103,17 +67,12 @@ public class PasswordSchema extends Schema<String> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        PasswordSchema passwordSchema = (PasswordSchema) o;
-        return Objects.equals(this.type, passwordSchema.type) &&
-                Objects.equals(this.format, passwordSchema.format) &&
-                Objects.equals(this._default, passwordSchema._default) &&
-                Objects.equals(this._enum, passwordSchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, format, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -121,24 +80,7 @@ public class PasswordSchema extends Schema<String> {
         StringBuilder sb = new StringBuilder();
         sb.append("class PasswordSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -70,6 +70,14 @@ public class Schema<T> {
     protected List<T> _enum = null;
     private Discriminator discriminator = null;
 
+    public Schema() {
+    }
+
+    protected Schema(String type, String format) {
+        this.type = type;
+        this.format = format;
+    }
+
     /**
      * returns the name property from a from a Schema instance. Ignored in serialization.
      *
@@ -141,6 +149,7 @@ public class Schema<T> {
         this._default = cast(_default);
     }
 
+    @SuppressWarnings("unchecked")
     protected T cast(Object value) {
         return (T) value;
     }
@@ -812,7 +821,7 @@ public class Schema<T> {
         this.extensions = extensions;
     }
 
-    public Schema<T> extensions(java.util.Map<String, Object> extensions) {
+    public Schema extensions(java.util.Map<String, Object> extensions) {
         this.extensions = extensions;
         return this;
     }
@@ -821,7 +830,10 @@ public class Schema<T> {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("class Schema {\n");
-
+        sb.append("    type: ").append(toIndentedString(type)).append("\n");
+        sb.append("    format: ").append(toIndentedString(format)).append("\n");
+        sb.append("    $ref: ").append(toIndentedString($ref)).append("\n");
+        sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    title: ").append(toIndentedString(title)).append("\n");
         sb.append("    multipleOf: ").append(toIndentedString(multipleOf)).append("\n");
         sb.append("    maximum: ").append(toIndentedString(maximum)).append("\n");
@@ -837,13 +849,9 @@ public class Schema<T> {
         sb.append("    maxProperties: ").append(toIndentedString(maxProperties)).append("\n");
         sb.append("    minProperties: ").append(toIndentedString(minProperties)).append("\n");
         sb.append("    required: ").append(toIndentedString(required)).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
         sb.append("    not: ").append(toIndentedString(not)).append("\n");
         sb.append("    properties: ").append(toIndentedString(properties)).append("\n");
         sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
-        sb.append("    description: ").append(toIndentedString(description)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
-        sb.append("    $ref: ").append(toIndentedString($ref)).append("\n");
         sb.append("    nullable: ").append(toIndentedString(nullable)).append("\n");
         sb.append("    readOnly: ").append(toIndentedString(readOnly)).append("\n");
         sb.append("    writeOnly: ").append(toIndentedString(writeOnly)).append("\n");
@@ -860,7 +868,7 @@ public class Schema<T> {
      * Convert the given object to string with each line indented by 4 spaces
      * (except the first line).
      */
-    private String toIndentedString(java.lang.Object o) {
+    protected String toIndentedString(java.lang.Object o) {
         if (o == null) {
             return "null";
         }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/StringSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/StringSchema.java
@@ -16,7 +16,6 @@
 
 package io.swagger.v3.oas.models.media;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -25,29 +24,28 @@ import java.util.Objects;
  */
 
 public class StringSchema extends Schema<String> {
-    private String type = "string";
 
-    /**
-     * returns the type property from a StringSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public StringSchema() {
+        super("string", null);
     }
 
     public StringSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
     public StringSchema _default(String _default) {
         super.setDefault(_default);
+        return this;
+    }
+
+    public StringSchema _enum(List<String> _enum) {
+        super.setEnum(_enum);
+        return this;
+    }
+
+    public StringSchema addEnumItem(String _enumItem) {
+        super.addEnumItemObject(_enumItem);
         return this;
     }
 
@@ -62,19 +60,6 @@ public class StringSchema extends Schema<String> {
         return null;
     }
 
-    public StringSchema _enum(List<String> _enum) {
-        super.setEnum(_enum);
-        return this;
-    }
-
-    public StringSchema addEnumItem(String _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<String>();
-        }
-        this._enum.add(_enumItem);
-        return this;
-    }
-
     @Override
     public boolean equals(java.lang.Object o) {
         if (this == o) {
@@ -83,16 +68,12 @@ public class StringSchema extends Schema<String> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        StringSchema stringSchema = (StringSchema) o;
-        return Objects.equals(this.type, stringSchema.type) &&
-                Objects.equals(this._default, stringSchema._default) &&
-                Objects.equals(this._enum, stringSchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -100,23 +81,7 @@ public class StringSchema extends Schema<String> {
         StringBuilder sb = new StringBuilder();
         sb.append("class StringSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/UUIDSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/UUIDSchema.java
@@ -16,7 +16,6 @@
 
 package io.swagger.v3.oas.models.media;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -26,44 +25,18 @@ import java.util.UUID;
  */
 
 public class UUIDSchema extends Schema<UUID> {
-    private String type = "string";
-    private String format = "uuid";
 
-    /**
-     * returns the type property from a UUIDSchema instance.
-     *
-     * @return String type
-     **/
-
-    public String getType() {
-        return type;
-    }
-
-    public void setType(String type) {
-        this.type = type;
+    public UUIDSchema() {
+        super("string", "uuid");
     }
 
     public UUIDSchema type(String type) {
-        this.type = type;
+        super.setType(type);
         return this;
     }
 
-    /**
-     * returns the format property from a UUIDSchema instance.
-     *
-     * @return String format
-     **/
-
-    public String getFormat() {
-        return format;
-    }
-
-    public void setFormat(String format) {
-        this.format = format;
-    }
-
     public UUIDSchema format(String format) {
-        this.format = format;
+        super.setFormat(format);
         return this;
     }
 
@@ -79,6 +52,16 @@ public class UUIDSchema extends Schema<UUID> {
         return this;
     }
 
+    public UUIDSchema _enum(List<UUID> _enum) {
+        super.setEnum(_enum);
+        return this;
+    }
+
+    public UUIDSchema addEnumItem(UUID _enumItem) {
+        super.addEnumItemObject(_enumItem);
+        return this;
+    }
+
     @Override
     protected UUID cast(Object value) {
         if (value != null) {
@@ -90,19 +73,6 @@ public class UUIDSchema extends Schema<UUID> {
         return null;
     }
 
-    public UUIDSchema _enum(List<UUID> _enum) {
-        this._enum = _enum;
-        return this;
-    }
-
-    public UUIDSchema addEnumItem(UUID _enumItem) {
-        if (this._enum == null) {
-            this._enum = new ArrayList<UUID>();
-        }
-        this._enum.add(_enumItem);
-        return this;
-    }
-
     @Override
     public boolean equals(java.lang.Object o) {
         if (this == o) {
@@ -111,17 +81,12 @@ public class UUIDSchema extends Schema<UUID> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        UUIDSchema uuIDSchema = (UUIDSchema) o;
-        return Objects.equals(this.type, uuIDSchema.type) &&
-                Objects.equals(this.format, uuIDSchema.format) &&
-                Objects.equals(this._default, uuIDSchema._default) &&
-                Objects.equals(this._enum, uuIDSchema._enum) &&
-                super.equals(o);
+        return super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, format, _default, _enum, super.hashCode());
+        return Objects.hash(super.hashCode());
     }
 
     @Override
@@ -129,24 +94,7 @@ public class UUIDSchema extends Schema<UUID> {
         StringBuilder sb = new StringBuilder();
         sb.append("class UUIDSchema {\n");
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
-        sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    format: ").append(toIndentedString(format)).append("\n");
-        sb.append("    _default: ").append(toIndentedString(_default)).append("\n");
-        sb.append("    _enum: ").append(toIndentedString(_enum)).append("\n");
         sb.append("}");
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(java.lang.Object o) {
-        if (o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
-


### PR DESCRIPTION
Why:
The various Schema subclasses (ArraySchema, BinarySchema, etc.) are
defined such that they actually duplicate some of the fields from
the Schema super class (e.g. type, format, default, etc.).  This
can create confusion when examining instances of these classes within
a debugger as you will see two "type" fields for example, the base class'
"type" field will be set to null and the subclass' "type" field will be set
to "array" (or "binary", or "boolean", etc.).   We have similar issues with
the format and default fields.

What:
In this PR, I've fixed this by adding a protected ctor to Schema, and default ctors to
the subclasses, plus I've removed some getters/setters from the subclasses
that are no longer needed.