### PR TITLE
fix #3111 Some primitive types in @ApiResponse.content are reported i…

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -523,10 +523,12 @@ public abstract class AnnotationsUtils {
     }
 
     public static Schema resolveSchemaFromType(Class<?> schemaImplementation, Components components, JsonView jsonViewAnnotation) {
-        Schema schemaObject = new Schema();
-        if (schemaImplementation.getName().startsWith("java.lang")) {
-            schemaObject.setType(schemaImplementation.getSimpleName().toLowerCase());
+        Schema schemaObject;
+        PrimitiveType primitiveType = PrimitiveType.fromType(schemaImplementation);
+        if (primitiveType != null) {
+            schemaObject = primitiveType.createProperty();
         } else {
+            schemaObject = new Schema();
             ResolvedSchema resolvedSchema = ModelConverters.getInstance().readAllAsResolvedSchema(new AnnotatedType().type(schemaImplementation).jsonViewAnnotation(jsonViewAnnotation));
             Map<String, Schema> schemaMap;
             if (resolvedSchema != null) {
@@ -536,7 +538,11 @@ public abstract class AnnotationsUtils {
                         components.addSchemas(key, referencedSchema);
                     }
                 });
-                schemaObject.set$ref(COMPONENTS_REF + resolvedSchema.schema.getName());
+                if (StringUtils.isNotBlank(resolvedSchema.schema.getName())) {
+                    schemaObject.set$ref(COMPONENTS_REF + resolvedSchema.schema.getName());
+                } else {
+                    schemaObject = resolvedSchema.schema;
+                }
             }
         }
         if (StringUtils.isBlank(schemaObject.get$ref()) && StringUtils.isBlank(schemaObject.getType())) {
@@ -1084,29 +1090,8 @@ public abstract class AnnotationsUtils {
                                                        Class<?> schemaImplementation,
                                                        Components components,
                                                        JsonView jsonViewAnnotation) {
-        Map<String, Schema> schemaMap;
         if (schemaImplementation != Void.class) {
-            Schema schemaObject = new Schema();
-            if (schemaImplementation.getName().startsWith("java.lang")) {
-                schemaObject.setType(schemaImplementation.getSimpleName().toLowerCase());
-            } else {
-                ResolvedSchema resolvedSchema = ModelConverters.getInstance().readAllAsResolvedSchema(new AnnotatedType().type(schemaImplementation).jsonViewAnnotation(jsonViewAnnotation));
-                if (resolvedSchema != null) {
-                    schemaMap = resolvedSchema.referencedSchemas;
-                    schemaMap.forEach((key, schema) -> {
-                        components.addSchemas(key, schema);
-                    });
-                    if (resolvedSchema.schema != null && StringUtils.isNotBlank(resolvedSchema.schema.getName())) {
-                        schemaObject.set$ref(COMPONENTS_REF + resolvedSchema.schema.getName());
-                    } else if (resolvedSchema.schema != null){
-                        schemaObject = resolvedSchema.schema;
-                    }
-                }
-            }
-            if (StringUtils.isBlank(schemaObject.get$ref()) && StringUtils.isBlank(schemaObject.getType())) {
-                // default to string
-                schemaObject.setType("string");
-            }
+            Schema schemaObject = resolveSchemaFromType(schemaImplementation, components, jsonViewAnnotation);
             if (isArray) {
                 Optional<ArraySchema> arraySchema = AnnotationsUtils.getArraySchema(arrayAnnotation, components, jsonViewAnnotation);
                 if (arraySchema.isPresent()) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/util/AnnotationsUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/util/AnnotationsUtilsTest.java
@@ -1,0 +1,58 @@
+package io.swagger.v3.core.util;
+
+import com.google.common.collect.ImmutableMap;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
+import java.net.URL;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+public class AnnotationsUtilsTest {
+
+    @DataProvider
+    private Object[][] expectedSchemaFromTypes() {
+        return new Object[][]{
+                {String.class, ImmutableMap.of("type", "string")},
+                {Character.class, ImmutableMap.of("type", "string")},
+                {Boolean.class, ImmutableMap.of("type", "boolean")},
+                {Byte.class, ImmutableMap.of("type", "string", "format", "byte")},
+                {URI.class, ImmutableMap.of("type", "string", "format", "uri")},
+                {URL.class, ImmutableMap.of("type", "string", "format", "url")},
+                {UUID.class, ImmutableMap.of("type", "string", "format", "uuid")},
+                {Short.class, ImmutableMap.of("type", "integer", "format", "int32")},
+                {Integer.class, ImmutableMap.of("type", "integer", "format", "int32")},
+                {Long.class, ImmutableMap.of("type", "integer", "format", "int64")},
+                {Float.class, ImmutableMap.of("type", "number", "format", "float")},
+                {Double.class, ImmutableMap.of("type", "number", "format", "double")},
+                {BigInteger.class, ImmutableMap.of("type", "integer")},
+                {BigDecimal.class, ImmutableMap.of("type", "number")},
+                {Number.class, ImmutableMap.of("type", "number")},
+                {Date.class, ImmutableMap.of("type", "string", "format", "date-time")},
+                {File.class, ImmutableMap.of("type", "string", "format", "binary")},
+                {Object.class, ImmutableMap.of("type", "object")},
+                {DummyClass.class, ImmutableMap.of("$ref", "#/components/schemas/DummyClass")}
+        };
+    }
+
+    @Test(dataProvider = "expectedSchemaFromTypes")
+    public void resolveSchemaFromType(Class<?> aClass, Map<String, Object> expected) {
+        Schema schema = AnnotationsUtils.resolveSchemaFromType(aClass, new Components(), null);
+
+        Assert.assertEquals(schema.getType(), expected.get("type"));
+        Assert.assertEquals(schema.getFormat(), expected.get("format"));
+        Assert.assertEquals(schema.get$ref(), expected.get("$ref"));
+    }
+
+    class DummyClass implements Serializable {}
+
+}


### PR DESCRIPTION
For reporting ApiResponse.content().schema() types, I'm using the corresponding PrimitiveType when possible or else the current getName().toLowerCase() method.

Thanks team !