### PR TITLE
Support hidden SubResources to still appear under a Resource

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -250,11 +250,11 @@ public class Reader implements OpenApiReader {
                         List<Parameter> parentParameters,
                         Set<Class<?>> scannedResources) {
 
-        Hidden hidden = cls.getAnnotation(Hidden.class);
+        Hidden hidden = ReflectionUtils.getAnnotation(cls, Hidden.class);
         // class path
         final javax.ws.rs.Path apiPath = ReflectionUtils.getAnnotation(cls, javax.ws.rs.Path.class);
 
-        if (hidden != null) { //  || (apiPath == null && !isSubresource)) {
+        if (hidden != null && !isSubresource) { //  || (apiPath == null && !isSubresource)) {
             return openAPI;
         }
 
@@ -1349,7 +1349,7 @@ public class Reader implements OpenApiReader {
         if (apiOperation != null && apiOperation.hidden()) {
             return true;
         }
-        Hidden hidden = method.getAnnotation(Hidden.class);
+        Hidden hidden = ReflectionUtils.getAnnotation(method, Hidden.class);
         if (hidden != null) {
             return true;
         }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -1406,7 +1406,7 @@ public class Reader implements OpenApiReader {
             type = rawType;
         }
 
-        if (method.getAnnotation(javax.ws.rs.Path.class) != null) {
+        if (ReflectionUtils.getAnnotation(method, javax.ws.rs.Path.class) != null) {
             if (ReaderUtils.extractOperationMethod(method, null) == null) {
                 return type;
             }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -1372,14 +1372,13 @@ public class Reader implements OpenApiReader {
         } else if (StringUtils.isBlank(path) && StringUtils.isNotBlank(parentPath)) {
             return false;
         }
-        if (parentPath != null && !"".equals(parentPath) && !"/".equals(parentPath)) {
-            if (!parentPath.startsWith("/")) {
-                parentPath = "/" + parentPath;
-            }
-            if (parentPath.endsWith("/")) {
-                parentPath = parentPath.substring(0, parentPath.length() - 1);
-            }
-        }
+        final String parentOperationPath = toOperationPath(parentPath);
+        final String operationPath = toOperationPath(path);
+
+        return parentOperationPath.equals(operationPath);
+    }
+
+    private String toOperationPath(String path) {
         if (path != null && !"".equals(path) && !"/".equals(path)) {
             if (!path.startsWith("/")) {
                 path = "/" + path;
@@ -1388,10 +1387,7 @@ public class Reader implements OpenApiReader {
                 path = path.substring(0, path.length() - 1);
             }
         }
-        if (path.equals(parentPath)) {
-            return true;
-        }
-        return false;
+        return path;
     }
 
     protected Class<?> getSubResourceWithJaxRsSubresourceLocatorSpecs(Method method) {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -50,6 +50,7 @@ import io.swagger.v3.jaxrs2.resources.SubResourceHead;
 import io.swagger.v3.jaxrs2.resources.TagsResource;
 import io.swagger.v3.jaxrs2.resources.Test2607;
 import io.swagger.v3.jaxrs2.resources.TestResource;
+import io.swagger.v3.jaxrs2.resources.Ticket2116Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket2644ConcreteImplementation;
 import io.swagger.v3.jaxrs2.resources.Ticket2763Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket2793Resource;
@@ -843,6 +844,32 @@ public class ReaderTest {
     public void test2607() {
         Reader reader = new Reader(new OpenAPI());
         OpenAPI openAPI = reader.read(Test2607.class);
+
+        Paths paths = openAPI.getPaths();
+        assertEquals(paths.size(), 2);
+        PathItem pathItem = paths.get("/swaggertest/name");
+        assertNotNull(pathItem);
+        Operation operation = pathItem.getGet();
+        assertNotNull(operation);
+        assertTrue(operation.getResponses().getDefault().getContent().keySet().contains("text/plain"));
+        Schema schema = operation.getResponses().getDefault().getContent().values().iterator().next().getSchema();
+        assertNotNull(schema);
+        assertEquals(schema.getType(), "string");
+
+        pathItem = paths.get("/swaggertest/subresource/version");
+        assertNotNull(pathItem);
+        operation = pathItem.getGet();
+        assertNotNull(operation);
+        assertTrue(operation.getResponses().getDefault().getContent().keySet().contains("text/plain"));
+        schema = operation.getResponses().getDefault().getContent().values().iterator().next().getSchema();
+        assertNotNull(schema);
+        assertEquals(schema.getType(), "string");
+    }
+
+    @Test(description = "test ticket #2116 resource with interface subresource")
+    public void test2116() {
+        Reader reader = new Reader(new OpenAPI());
+        OpenAPI openAPI = reader.read(Ticket2116Resource.class);
 
         Paths paths = openAPI.getPaths();
         assertEquals(paths.size(), 2);

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/AnnotatedOperationMethodTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/AnnotatedOperationMethodTest.java
@@ -7,6 +7,8 @@ import io.swagger.v3.jaxrs2.resources.HiddenUserResource;
 import io.swagger.v3.jaxrs2.resources.PetResource;
 import io.swagger.v3.jaxrs2.resources.PetResourceSlashesinPath;
 import io.swagger.v3.jaxrs2.resources.SimpleUserResource;
+import io.swagger.v3.jaxrs2.resources.Ticket2116Resource;
+import io.swagger.v3.jaxrs2.resources.Ticket2116SubResource;
 import io.swagger.v3.jaxrs2.resources.UserResource;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -1052,6 +1054,42 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                 "        foo:\n" +
                 "          type: string");
 
+    }
+
+    @Test(description = "reads and skips the hidden sub resource")
+    public void testHiddenSubResource() {
+        String openApiYAML = readIntoYaml(Ticket2116SubResource.class);
+        assertEquals(openApiYAML, "openapi: 3.0.1\n");
+    }
+
+    @Test(description = "reads resource but does not skip the hidden sub resource")
+    public void testReadResourceWithHiddenSubResource() throws IOException {
+        compareAsYaml(Ticket2116Resource.class, "openapi: 3.0.1\n" +
+                "info:\n" +
+                "  title: TEST\n" +
+                "  description: Test API\n" +
+                "  version: \"0.0\"\n" +
+                "paths:\n" +
+                "  /swaggertest/name:\n" +
+                "    get:\n" +
+                "      operationId: getName\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            text/plain:\n" +
+                "              schema:\n" +
+                "                type: string\n" +
+                "  /swaggertest/subresource/version:\n" +
+                "    get:\n" +
+                "      operationId: getSubResourceVersion\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            text/plain:\n" +
+                "              schema:\n" +
+                "                type: string");
     }
 
     @Test

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116Resource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116Resource.java
@@ -12,4 +12,9 @@ public class Ticket2116Resource implements Ticket2116ResourceApi {
         return new Ticket2116SubResource();
     }
 
+    @Override
+    public Ticket2116SubResourceApi getAnotherSubResource() {
+        return new Ticket2116SubResource();
+    }
+
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116Resource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116Resource.java
@@ -1,0 +1,15 @@
+package io.swagger.v3.jaxrs2.resources;
+
+public class Ticket2116Resource implements Ticket2116ResourceApi {
+
+    @Override
+    public String getName() {
+        return "SwaggerTest";
+    }
+
+    @Override
+    public Ticket2116SubResourceApi getSubResource() {
+        return new Ticket2116SubResource();
+    }
+
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116ResourceApi.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116ResourceApi.java
@@ -5,6 +5,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.info.Info;
@@ -23,5 +24,10 @@ public interface Ticket2116ResourceApi {
     @Path("subresource")
     @Operation
     Ticket2116SubResourceApi getSubResource();
+
+    @Hidden
+    @Path("hidden-subresource")
+    @Operation
+    Ticket2116SubResourceApi getAnotherSubResource();
 
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116ResourceApi.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116ResourceApi.java
@@ -1,0 +1,27 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Info;
+
+@OpenAPIDefinition(
+        info = @Info(title = "TEST", version = "0.0", description = "Test API")
+)
+@Path("/swaggertest/")
+public interface Ticket2116ResourceApi {
+
+    @GET
+    @Path("name")
+    @Produces(MediaType.TEXT_PLAIN)
+    String getName();
+
+    @Path("subresource")
+    @Operation
+    Ticket2116SubResourceApi getSubResource();
+
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116SubResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116SubResource.java
@@ -1,0 +1,8 @@
+package io.swagger.v3.jaxrs2.resources;
+
+public class Ticket2116SubResource implements Ticket2116SubResourceApi {
+    @Override
+    public String getSubResourceVersion() {
+        return "1.0.0";
+    }
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116SubResourceApi.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116SubResourceApi.java
@@ -5,6 +5,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.v3.oas.annotations.Hidden;
+
+@Hidden
 @Produces(MediaType.APPLICATION_JSON)
 public interface Ticket2116SubResourceApi {
     @GET

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116SubResourceApi.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2116SubResourceApi.java
@@ -1,0 +1,14 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Produces(MediaType.APPLICATION_JSON)
+public interface Ticket2116SubResourceApi {
+    @GET
+    @Path("version")
+    @Produces(MediaType.TEXT_PLAIN)
+    String getSubResourceVersion();
+}


### PR DESCRIPTION
This PR addresses #2116 by adding support for SubResources that are marked as @Hidden to still appear under a resource.

It also fixes an issue with OpenAPI JAX-RS SubResource support #2607 so that annotated interfaces are supported correctly.