### PR TITLE
Supporting  inside allOf properties

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/PropertyDeserializer.java
@@ -212,12 +212,7 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
 
         JsonNode detailNode = node.get("$ref");
         if (detailNode != null) {
-            RefProperty refProperty = new RefProperty(detailNode.asText());
-            refProperty.setDescription(description);
-            refProperty.setTitle(title);
-            refProperty.setReadOnly(readOnly);
-            refProperty.setXml(xml);
-            return refProperty;
+            return getRefProperty(title, readOnly, description, xml, detailNode);
         }
 
         if (ObjectProperty.isType(type) || node.get("properties") != null || node.get("allOf") != null) {
@@ -259,19 +254,26 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
                         }
                     }
                 } else if (allOfNode != null) {
-                    ComposedProperty cp = new ComposedProperty().description(description).title(title);
-                    cp.setExample(example);
-                    cp.setDescription(description);
-                    cp.setVendorExtensions(getVendorExtensions(node));
+                    JsonNode refAllOf = allOfNode.get(0).get("$ref");
+                    if (refAllOf != null) {
+                        RefProperty refProperty = getRefProperty(title, readOnly, description, xml, refAllOf);
+                        refProperty.setVendorExtensions(getVendorExtensions(node));
+                        return refProperty;
+                    } else {
+                        ComposedProperty cp = new ComposedProperty().description(description).title(title);
+                        cp.setExample(example);
+                        cp.setDescription(description);
+                        cp.setVendorExtensions(getVendorExtensions(node));
 
-                    List<Property> allOf = new ArrayList<Property>();
-                    for (JsonNode innerNode : allOfNode) {
-                        allOf.add(propertyFromNode(innerNode));
+                        List<Property> allOf = new ArrayList<Property>();
+                        for (JsonNode innerNode : allOfNode) {
+                            allOf.add(propertyFromNode(innerNode));
+                        }
+
+                        cp.setAllOf(allOf);
+
+                        return cp;
                     }
-
-                    cp.setAllOf(allOf);
-
-                    return cp;
                 }
 
                 if("array".equals(detailNodeType)) {
@@ -337,5 +339,14 @@ public class PropertyDeserializer extends JsonDeserializer<Property> {
         output.setDescription(description);
 
         return output;
+    }
+
+    private RefProperty getRefProperty(String title, Boolean readOnly, String description, Xml xml, JsonNode detailNode) {
+        RefProperty refProperty = new RefProperty(detailNode.asText());
+        refProperty.setDescription(description);
+        refProperty.setTitle(title);
+        refProperty.setReadOnly(readOnly);
+        refProperty.setXml(xml);
+        return refProperty;
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/properties/PropertyDeserializerTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/properties/PropertyDeserializerTest.java
@@ -5,6 +5,7 @@ import io.swagger.models.properties.ArrayProperty;
 import io.swagger.models.properties.IntegerProperty;
 import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
+import io.swagger.models.properties.RefProperty;
 import io.swagger.util.Json;
 
 import org.testng.annotations.DataProvider;
@@ -14,6 +15,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class PropertyDeserializerTest {
@@ -97,6 +99,28 @@ public class PropertyDeserializerTest {
         assertEquals(((ObjectProperty) result).getProperties().get("collectors").getXml().getName(), "cols");
         assertEquals(((ArrayProperty)((ObjectProperty) result).getProperties().get("collectors")).getItems().getXml().getName(), "collector");
     }
+
+    @Test(description = "it should deserialize an allOf property")
+    public void testAllOfProperty() throws IOException {
+        String ref = "#/definitions/Actor";
+        final String json = "{\n" +
+                "  \"allOf\": [\n" +
+                "    {\n" +
+                "      \"$ref\": \"" + ref + "\"\n" +
+                "    }\n" +
+                "  ],\n" +
+                "  \"x-foo\": \"vendor x\",\n" +
+                "  \"readOnly\": true\n" +
+                "}";
+        final Property result = Json.mapper().readValue(json, Property.class);
+        assertTrue(result instanceof RefProperty);
+        assertEquals(((RefProperty) result).get$ref(), ref);
+        assertTrue(result.getVendorExtensions() != null);
+        assertNotNull(result.getVendorExtensions().get("x-foo"));
+        assertEquals(result.getVendorExtensions().get("x-foo"), "vendor x");
+        assertTrue(result.getReadOnly());
+    }
+
 
     @DataProvider
     public Object[][] readOnlyDataProvider() {


### PR DESCRIPTION
Currently, composed properties are not working correctly with `allOf` properties that contain $ref. It adds them as properties, but not matching correctly with the sibling properties. As mentioned in https://github.com/swagger-api/swagger-core/issues/2621 the following structure is valid:

```
defWithDep:
  type: object
  properties:
    def:
      x-thingy: thing
      allOf:
      - $ref: "#/definitions/standaloneDef"
```

This PR contains a proposal for handling this case.