### PR TITLE
fix #3088 - fixes boolean @type annotation

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
@@ -212,7 +212,7 @@ public enum PrimitiveType {
         dms.put("string_date-time", "date-time");
         dms.put("string_partial-time", "partial-time");
         dms.put("string_password", "password");
-        dms.put("boolean", "boolean");
+        dms.put("boolean_", "boolean");
         dms.put("object_", "object");
         datatypeMappings = Collections.unmodifiableMap(dms);
 


### PR DESCRIPTION
`@Schema(`type` = "boolean") test_boolean:MyBooleanClass = false`

Specifying type=boolean in the schema always produces type:Object in the resulting json. I have tracked the issue down to PrimitiveType.java in package io.swagger.v3.core.util

It appears that
`dms.put("boolean", "boolean");`
Should be :
`dms.put("boolean_", "boolean");`