### PR TITLE
Removed guava from swagger-jaxrs

### DIFF
--- a/modules/swagger-jaxrs/pom.xml
+++ b/modules/swagger-jaxrs/pom.xml
@@ -210,10 +210,6 @@
             <artifactId>reflections</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
My proposal is to remove guava from swagger-jaxrs, because:

- not needed at compile time
- not needed at test time
- not needed a runtime

As main benefit, guava jar will not be part of dependencies and also all transitive dependencies 