### PR TITLE
The feature for definition of the multidimensional array is added in the @ApiResponse

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ArraySchema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ArraySchema.java
@@ -50,6 +50,13 @@ public @interface ArraySchema {
     Schema arraySchema() default @Schema;
 
     /**
+     * Sets the dimension of an array.
+     *
+     * @return integer representing dimension of array
+     **/
+    int dimension() default 1;
+
+    /**
      * sets the maximum number of items in an array.  Ignored if value is Integer.MIN_VALUE.
      *
      * @return integer representing maximum number of items in array

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -11,54 +11,9 @@ import io.swagger.v3.core.filter.SpecFilter;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.core.model.ApiDescription;
 import io.swagger.v3.core.util.PrimitiveType;
+import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.jaxrs2.matchers.SerializationMatchers;
-import io.swagger.v3.jaxrs2.resources.BasicFieldsResource;
-import io.swagger.v3.jaxrs2.resources.BookStoreTicket2646;
-import io.swagger.v3.jaxrs2.resources.ClassPathParentResource;
-import io.swagger.v3.jaxrs2.resources.ClassPathSubResource;
-import io.swagger.v3.jaxrs2.resources.CompleteFieldsResource;
-import io.swagger.v3.jaxrs2.resources.DeprecatedFieldsResource;
-import io.swagger.v3.jaxrs2.resources.DuplicatedOperationIdResource;
-import io.swagger.v3.jaxrs2.resources.DuplicatedOperationMethodNameResource;
-import io.swagger.v3.jaxrs2.resources.DuplicatedSecurityResource;
-import io.swagger.v3.jaxrs2.resources.EnhancedResponsesResource;
-import io.swagger.v3.jaxrs2.resources.ExternalDocsReference;
-import io.swagger.v3.jaxrs2.resources.MyClass;
-import io.swagger.v3.jaxrs2.resources.MyOtherClass;
-import io.swagger.v3.jaxrs2.resources.RefCallbackResource;
-import io.swagger.v3.jaxrs2.resources.RefExamplesResource;
-import io.swagger.v3.jaxrs2.resources.RefHeaderResource;
-import io.swagger.v3.jaxrs2.resources.RefLinksResource;
-import io.swagger.v3.jaxrs2.resources.RefParameter3029Resource;
-import io.swagger.v3.jaxrs2.resources.RefParameter3074Resource;
-import io.swagger.v3.jaxrs2.resources.RefParameterResource;
-import io.swagger.v3.jaxrs2.resources.RefRequestBodyResource;
-import io.swagger.v3.jaxrs2.resources.RefResponsesResource;
-import io.swagger.v3.jaxrs2.resources.RefSecurityResource;
-import io.swagger.v3.jaxrs2.resources.ResourceWithSubResource;
-import io.swagger.v3.jaxrs2.resources.ResponseContentWithArrayResource;
-import io.swagger.v3.jaxrs2.resources.ResponsesResource;
-import io.swagger.v3.jaxrs2.resources.SecurityResource;
-import io.swagger.v3.jaxrs2.resources.ServersResource;
-import io.swagger.v3.jaxrs2.resources.SimpleCallbackResource;
-import io.swagger.v3.jaxrs2.resources.SimpleExamplesResource;
-import io.swagger.v3.jaxrs2.resources.SimpleMethods;
-import io.swagger.v3.jaxrs2.resources.SimpleParameterResource;
-import io.swagger.v3.jaxrs2.resources.SimpleRequestBodyResource;
-import io.swagger.v3.jaxrs2.resources.SimpleResponsesResource;
-import io.swagger.v3.jaxrs2.resources.SubResourceHead;
-import io.swagger.v3.jaxrs2.resources.TagsResource;
-import io.swagger.v3.jaxrs2.resources.Test2607;
-import io.swagger.v3.jaxrs2.resources.TestResource;
-import io.swagger.v3.jaxrs2.resources.Ticket2644ConcreteImplementation;
-import io.swagger.v3.jaxrs2.resources.Ticket2763Resource;
-import io.swagger.v3.jaxrs2.resources.Ticket2793Resource;
-import io.swagger.v3.jaxrs2.resources.Ticket2794Resource;
-import io.swagger.v3.jaxrs2.resources.Ticket2806Resource;
-import io.swagger.v3.jaxrs2.resources.Ticket2818Resource;
-import io.swagger.v3.jaxrs2.resources.Ticket2848Resource;
-import io.swagger.v3.jaxrs2.resources.Ticket3015Resource;
-import io.swagger.v3.jaxrs2.resources.UserAnnotationResource;
+import io.swagger.v3.jaxrs2.resources.*;
 import io.swagger.v3.jaxrs2.resources.extensions.ExtensionsResource;
 import io.swagger.v3.jaxrs2.resources.extensions.OperationExtensionsResource;
 import io.swagger.v3.jaxrs2.resources.extensions.ParameterExtensionsResource;
@@ -1286,6 +1241,16 @@ public class ReaderTest {
                 "          items:\n" +
                 "            type: string\n";
         SerializationMatchers.assertEqualsToYaml(openAPI, yaml);
+    }
+
+    @Test(description = "array schema required property")
+    public void testMultiDimention() {
+        Reader reader1 = new Reader(new OpenAPI());
+        Reader reader2 = new Reader(new OpenAPI());
+        OpenAPI openAPI1 = reader1.read(MultiDimensionJavaTypeResource.class);
+        OpenAPI openAPI2 = reader2.read(MultiDimensionAnnotationResource.class);
+        String s = Yaml.pretty(openAPI2);
+        assertEquals(Yaml.pretty(openAPI2), Yaml.pretty(openAPI1));
     }
 
     @Test(description = "RequestBody with ref")

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/MultiDimensionAnnotationResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/MultiDimensionAnnotationResource.java
@@ -1,0 +1,33 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+public class MultiDimensionAnnotationResource {
+
+    @GET
+    @Path("/test")
+    @ApiResponse(
+            description = "test action",
+            content = @Content(
+
+                    mediaType = "application/json",
+                    array = @ArraySchema(
+                            dimension = 5,
+                            schema = @Schema(
+                                    implementation = Number.class
+                            )
+                    )
+            ))
+    public Response getter() {
+        return null;
+    }
+
+
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/MultiDimensionJavaTypeResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/MultiDimensionJavaTypeResource.java
@@ -1,0 +1,21 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+public class MultiDimensionJavaTypeResource {
+
+    @GET
+    @Path("/test")
+    @ApiResponse(
+            description = "test action"
+    )
+    @Produces("application/json")
+    public Number[][][][][] getter() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
Hi!

In my project the customer asked to make the description of service through Swagger.
I use Jersey 2 and answers are formed programmatically. For an example 
 @GET
 @Path("/test")
 @ApiResponse(
            description = "test action",
            content = @Content(

                    mediaType = "application/json",
                    array = @ArraySchema(
                            schema = @Schema(
                                    implementation = BigDecimal[][][].class
                            )
                    )
            ))
  public Response getter() {
        BigDecimal[][][] result = new BigDecimal[3][3][3];
        ....
        return Response.ok().entity(result).build();
 }

Generates the description 
openapi: 3.0.1
paths:
  /test:
    get:
      operationId: getter
      responses:
        default:
          description: test action
          content:
            application/json:
              schema:
                type: array
                items:
                  type: string

If type of result to define statically, then the description correct
   @GET
    @Path("/test")
    @ApiResponse(
            description = "test action"
    )
    @Produces("application/json")
    public Number[][][] getter() {
        return null;
    }

openapi: 3.0.1
paths:
  /test:
    get:
      operationId: getter
      responses:
        default:
          description: test action
          content:
            application/json:
              schema:
                type: array
                items:
                  type: array
                  items:
                    type: array
                    items:
                      type: number

I spent a little time and corrected this shortcoming. Please consider my realization.

Yours faithfully,
Vasily Menshev