### PR TITLE
Fix bug "always true" condition.

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -311,7 +311,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         //If JsonSerialize(as=...) is specified then use that bean to figure out all the json-like bits
         JsonSerialize jasonSerialize = beanDesc.getClassAnnotations().get(JsonSerialize.class);
         if (jasonSerialize != null) {
-            if (jasonSerialize.as() != null) {
+            if (jasonSerialize.as() != null && jasonSerialize.as() != java.lang.Void.class) {
                 JavaType asType = _mapper.constructType(jasonSerialize.as());
                 beanDesc = _mapper.getSerializationConfig().introspect(asType);
             }


### PR DESCRIPTION
jasonSerialize.as() never return null according API. So there is replacing correct JavaType class to java.lang.Void in case missed parameter "as". As result I've got empty body of example on UI.
See, https://static.javadoc.io/com.fasterxml.jackson.core/jackson-databind/2.9.8/com/fasterxml/jackson/databind/annotation/JsonSerialize.html#as--