### PR TITLE
use version 27.0.1-jre of guava instead of 27.0.1-android

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -603,7 +603,7 @@
         <jackson-version>2.9.8</jackson-version>
         <logback-version>1.2.3</logback-version>
         <reflections-version>0.9.11</reflections-version>
-        <guava-version>27.0.1-android</guava-version>
+        <guava-version>27.0.1-jre</guava-version>
         <javassist-version>3.21.0-GA</javassist-version>
 
         <testng-version>6.14.3</testng-version>


### PR DESCRIPTION
The dependency on guava 27.0.1-android instead of 27.0.1-jre is causing problems in a gradle project that uses swagger-core 1.5.22.  With the android guava, I get errors like:
```
* What went wrong:
A problem occurred configuring project ':app'.
> Failed to notify project evaluation listener.
   > Could not create task ':app:extractDebugAnnotations'.
      > com.google.common.collect.ImmutableList.toImmutableList()Ljava/util/stream/Collector;
   > com.google.common.collect.ImmutableList.toImmutableList()Ljava/util/stream/Collector;

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org
```
This error goes away with 27.0.1-jre.  https://github.com/google/guava/issues/2914 explains a bit about why.

I'm a little confused how we got to the android version in the first place.  https://github.com/swagger-api/swagger-core/pull/3122 is the PR that did it, motivated by https://github.com/swagger-api/swagger-core/issues/3079, but there's another PR linked to that issue that made a change against master (https://github.com/swagger-api/swagger-core/pull/3121) that used 27.0.1-jre.

Thanks for your help.