### PR TITLE
Ticket-3115: Documentation for the swagger-gradle-plugin appears to give incorrect artifact path

### DIFF
--- a/modules/swagger-gradle-plugin/README.md
+++ b/modules/swagger-gradle-plugin/README.md
@@ -18,7 +18,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.io.swagger.core.v3.swagger-gradle-plugin:2.0.8-SNAPSHOT"
+    classpath "io.swagger.core.v3:swagger-gradle-plugin:2.0.8-SNAPSHOT"
   }
 }
 


### PR DESCRIPTION
- Fix: show correct GAV coordinates for swagger-gradle-plugin when using the Gradle buildscript Syntax