### PR TITLE
Remove Jaxb Dependency

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -54,11 +54,6 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>


### PR DESCRIPTION
As far as I know, the javax.xml.bind package is part of the JRE since at least version 6. As such, it should not be necessary to pull in a third party package containing an implementation of that very package.

I could successfully build swagger without it and I am not sure why it is necessary, so I'd suggest to remove it.