### PR TITLE
Respect required status of form parameters.

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -533,6 +533,9 @@ public class Reader implements OpenApiReader {
                         Schema mergedSchema = new ObjectSchema();
                         for (Parameter formParam: formParameters) {
                             mergedSchema.addProperties(formParam.getName(), formParam.getSchema());
+                            if (null != formParam.getRequired() && formParam.getRequired()) {
+                                mergedSchema.addRequiredItem(formParam.getName());
+                            }
                         }
                         Parameter merged = new Parameter().schema(mergedSchema);
                         processRequestBody(


### PR DESCRIPTION
When merging form parameters to one schema for the response body, the information about whether a parameter is taken over to the merged schema.