### PR TITLE
Make parseMethod protected thus improving extensibility.

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -832,7 +832,7 @@ public class Reader implements OpenApiReader {
                 annotatedMethod);
     }
 
-    private Operation parseMethod(
+    protected Operation parseMethod(
             Class<?> cls,
             Method method,
             List<Parameter> globalParameters,


### PR DESCRIPTION
Making the main Reader.parseMethod protected greatly improves extensibility.

The method being private requires me to override the 3 corresponding public methods. Additionally, I need a callback reference (`java.util.function.Function`) for each of them just to simulate a `super` call in the one “overriding“ method.