### PR TITLE
 refs #3197 - resolve properties within allOf for composed schemas

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -65,7 +65,17 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -390,9 +390,7 @@ public abstract class AnnotationsUtils {
         if (arraySchema.schema() != null) {
             if (arraySchema.schema().implementation().equals(Void.class)) {
                 getSchemaFromAnnotation(arraySchema.schema(), components, jsonViewAnnotation).ifPresent(schema -> {
-                    if (StringUtils.isNotBlank(schema.getType()) || StringUtils.isNotBlank(schema.get$ref())) {
-                        arraySchemaObject.setItems(schema);
-                    }
+                    arraySchemaObject.setItems(schema);
                 });
             } // if present, schema implementation handled upstream
         }
@@ -938,11 +936,9 @@ public abstract class AnnotationsUtils {
         if (header.schema() != null) {
             if (header.schema().implementation().equals(Void.class)) {
                 AnnotationsUtils.getSchemaFromAnnotation(header.schema(), jsonViewAnnotation).ifPresent(schema -> {
-                    if (StringUtils.isNotBlank(schema.getType())) {
-                        headerObject.setSchema(schema);
-                        //schema inline no need to add to components
-                        //components.addSchemas(schema.getType(), schema);
-                    }
+                    headerObject.setSchema(schema);
+                    //schema inline no need to add to components
+                    //components.addSchemas(schema.getType(), schema);
                 });
             }
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedSchemaTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedSchemaTest.java
@@ -123,5 +123,4 @@ public class ComposedSchemaTest {
         model = schemas.get("objects");
         Assert.assertNull(model);
     }
-
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedSchemaTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedSchemaTest.java
@@ -39,16 +39,18 @@ public class ComposedSchemaTest {
 
         schemas = ModelConverters.getInstance().readAll(TestObjectTicket2620Subtypes.class);
         model = schemas.get("Child2TestObject");
-        properties = model.getProperties();
+        Assert.assertNull(model.getProperties());
+        properties = ((ComposedSchema)model).getAllOf().get(1).getProperties();
         Assert.assertNull(properties.get("name"));
         Assert.assertNotNull(properties.get("childName"));
         Assert.assertTrue(model instanceof ComposedSchema);
         model = schemas.get("ChildTestObject");
-        properties = model.getProperties();
+        Assert.assertNull(model.getProperties());
+        properties = ((ComposedSchema)model).getAllOf().get(1).getProperties();
         Assert.assertNull(properties.get("name"));
         Assert.assertNotNull(properties.get("childName"));
         Assert.assertTrue(model instanceof ComposedSchema);
-        Assert.assertTrue(((ComposedSchema)model).getAllOf().size() == 1);
+        Assert.assertTrue(((ComposedSchema)model).getAllOf().size() == 2);
 
         model = schemas.get("TestObjectTicket2620Subtypes");
         properties = model.getProperties();

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/InheritedBeanTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/InheritedBeanTest.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class InheritedBeanTest extends SwaggerTestBase {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/InheritedBeanTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/InheritedBeanTest.java
@@ -47,7 +47,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         assertEquals(cm.getAllOf().get(0).get$ref(), "#/components/schemas/BaseBean");
 
         // make sure parent properties are filtered out of subclass
-        assertSub1PropertiesValid(cm.getProperties());
+        assertSub1PropertiesValid(cm.getAllOf().get(1).getProperties());
     }
 
     @Test
@@ -60,7 +60,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         assertEquals(cm.getAllOf().get(0).get$ref(), "#/components/schemas/BaseBean");
 
         // make sure parent properties are filtered out of subclass
-        assertSub1PropertiesValid(cm.getProperties());
+        assertSub1PropertiesValid(cm.getAllOf().get(1).getProperties());
 
         final Schema baseModel = context.getDefinedModels().get("BaseBean");
         assertNotNull(baseModel);
@@ -77,7 +77,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         assertEquals(cm.getAllOf().get(0).get$ref(), "#/components/schemas/BaseBean2");
 
         // make sure parent properties are filtered out of subclass
-        assertSub1PropertiesValid(cm.getProperties());
+        assertSub1PropertiesValid(cm.getAllOf().get(1).getProperties());
 
         final Schema baseModel = context.getDefinedModels().get("BaseBean2");
         assertNotNull(baseModel);
@@ -119,7 +119,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         ComposedSchema cm = (ComposedSchema) subModel;
         assertEquals(cm.getAllOf().get(0).get$ref(), "#/components/schemas/BaseBean3");
         // make sure parent properties are filtered out of subclass
-        assertSub1PropertiesValid(cm.getProperties());
+        assertSub1PropertiesValid(cm.getAllOf().get(1).getProperties());
 
         // assert grandchild
         final Schema subSubModel = context.getDefinedModels().get("GrandChildBean3");
@@ -129,7 +129,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         cm = (ComposedSchema) subSubModel;
         assertEquals(cm.getAllOf().get(0).get$ref(), "#/components/schemas/ChildBean3");
         // make sure parent properties are filtered out of subclass
-        assertSub2PropertiesValid(cm.getProperties());
+        assertSub2PropertiesValid(cm.getAllOf().get(1).getProperties());
 
     }
 
@@ -310,7 +310,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         ComposedSchema cm1 = (ComposedSchema) sub1Model;
         assertEquals(cm1.getAllOf().get(0).get$ref(), "#/components/schemas/MultipleBaseBean");
         // make sure parent properties are filtered out of subclass
-        assertSub1PropertiesValid(cm1.getProperties());
+        assertSub1PropertiesValid(cm1.getAllOf().get(1).getProperties());
 
         final Schema sub2Model = context.getDefinedModels().get("MultipleSub2Bean");
         assertNotNull(sub2Model);
@@ -318,7 +318,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         ComposedSchema cm2 = (ComposedSchema) sub2Model;
         assertEquals(cm2.getAllOf().get(0).get$ref(), "#/components/schemas/MultipleBaseBean");
         // make sure parent properties are filtered out of subclass
-        assertSub2PropertiesValid(cm2.getProperties());
+        assertSub2PropertiesValid(cm2.getAllOf().get(1).getProperties());
     }
 
     @Test
@@ -330,7 +330,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         ComposedSchema cm = (ComposedSchema) subModel;
         assertEquals(cm.getAllOf().get(0).get$ref(), "#/components/schemas/MultipleBaseBean");
         // make sure parent properties are filtered out of subclass
-        assertSub1PropertiesValid(cm.getProperties());
+        assertSub1PropertiesValid(cm.getAllOf().get(1).getProperties());
 
         final Schema baseModel = context.getDefinedModels().get("MultipleBaseBean");
         assertNotNull(baseModel);
@@ -343,7 +343,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         ComposedSchema cm1 = (ComposedSchema) sub1Model;
         assertEquals(cm1.getAllOf().get(0).get$ref(), "#/components/schemas/MultipleBaseBean");
         // make sure parent properties are filtered out of subclass
-        assertSub1PropertiesValid(cm1.getProperties());
+        assertSub1PropertiesValid(cm1.getAllOf().get(1).getProperties());
 
         final Schema sub2Model = context.getDefinedModels().get("MultipleSub2Bean");
         assertNotNull(sub2Model);
@@ -351,7 +351,7 @@ public class InheritedBeanTest extends SwaggerTestBase {
         ComposedSchema cm2 = (ComposedSchema) sub2Model;
         assertEquals(cm2.getAllOf().get(0).get$ref(), "#/components/schemas/MultipleBaseBean");
         // make sure parent properties are filtered out of subclass
-        assertSub2PropertiesValid(cm2.getProperties());
+        assertSub2PropertiesValid(cm2.getAllOf().get(1).getProperties());
     }
 
     private void assertSub2PropertiesValid(Map<String, Schema> subProperties) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3030Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3030Test.java
@@ -1,0 +1,57 @@
+package io.swagger.v3.core.resolving;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+public class Ticket3030Test extends SwaggerTestBase {
+
+    private ModelResolver modelResolver;
+    private ModelConverterContextImpl context;
+
+    @BeforeTest
+    public void setup() {
+        modelResolver = new ModelResolver(new ObjectMapper());
+        context = new ModelConverterContextImpl(modelResolver);
+    }
+
+
+
+    @Test
+    public void testTicket3030() throws Exception {
+        final Schema model = context.resolve(new AnnotatedType(Child.class));
+        assertNotNull(model);
+        String yaml = "Child:\n" +
+                "  type: object\n" +
+                "  allOf:\n" +
+                "  - $ref: '#/components/schemas/Parent'\n" +
+                "  - type: object\n" +
+                "    properties:\n" +
+                "      property:\n" +
+                "        type: string\n" +
+                "Parent:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    sharedProperty:\n" +
+                "      type: string";
+
+        SerializationMatchers.assertEqualsToYaml(context.getDefinedModels(), yaml);
+    }
+
+    @io.swagger.v3.oas.annotations.media.Schema(subTypes = {Child.class})
+    static class Parent {
+        public String sharedProperty;
+    }
+
+    @io.swagger.v3.oas.annotations.media.Schema(allOf = Parent.class)
+    static class Child extends Parent {
+        public String property;
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3063Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3063Test.java
@@ -1,0 +1,90 @@
+package io.swagger.v3.core.resolving;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+public class Ticket3063Test extends SwaggerTestBase {
+
+    private ModelResolver modelResolver;
+    private ModelConverterContextImpl context;
+
+    @BeforeTest
+    public void setup() {
+        modelResolver = new ModelResolver(new ObjectMapper());
+        context = new ModelConverterContextImpl(modelResolver);
+    }
+
+
+
+    @Test
+    public void testTicket3063() throws Exception {
+        final Schema model = context.resolve(new AnnotatedType(BaseClass.class));
+        assertNotNull(model);
+        String yaml = "BaseClass:\n" +
+                "  required:\n" +
+                "  - type\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    type:\n" +
+                "      type: string\n" +
+                "      description: Type\n" +
+                "      example: AndroidDeviceRequirements\n" +
+                "  description: test\n" +
+                "  discriminator:\n" +
+                "    propertyName: type\n" +
+                "SubClass:\n" +
+                "  required:\n" +
+                "  - type\n" +
+                "  type: object\n" +
+                "  description: SubClass\n" +
+                "  allOf:\n" +
+                "  - $ref: '#/components/schemas/BaseClass'\n" +
+                "  - type: object\n" +
+                "    properties:\n" +
+                "      additionalPropertyWhichShouldBeThere:\n" +
+                "        type: integer\n" +
+                "        description: Test\n" +
+                "        format: int32";
+
+        SerializationMatchers.assertEqualsToYaml(context.getDefinedModels(), yaml);
+    }
+
+    @io.swagger.v3.oas.annotations.media.Schema(description = "SubClass")
+    public class SubClass extends BaseClass {
+        @io.swagger.v3.oas.annotations.media.Schema(required = false, description = "Test")
+        public int additionalPropertyWhichShouldBeThere = -1;
+
+    }
+
+    @io.swagger.v3.oas.annotations.media.Schema(description = "test", discriminatorProperty="type")
+    @JsonTypeInfo(
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.PROPERTY,
+            property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = SubClass.class, name = "SubClass")
+    })
+    public class BaseClass {
+
+        @io.swagger.v3.oas.annotations.media.Schema(required = true, description = "Type", example="AndroidDeviceRequirements")
+        public String type;
+
+        public BaseClass(String type) {
+            this.type = type;
+        }
+
+        public BaseClass() {
+        }
+
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3197Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3197Test.java
@@ -1,0 +1,177 @@
+package io.swagger.v3.core.resolving;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+public class Ticket3197Test extends SwaggerTestBase {
+
+    private ModelResolver modelResolver;
+    private ModelConverterContextImpl context;
+
+
+    @BeforeMethod
+    public void beforeMethod() {
+        ModelResolver.composedModelPropertiesAsSibling = false;
+        modelResolver = new ModelResolver(new ObjectMapper());
+        context = new ModelConverterContextImpl(modelResolver);
+    }
+
+    @AfterTest
+    public void afterTest() {
+        ModelResolver.composedModelPropertiesAsSibling = false;
+    }
+
+    @Test
+    public void testTicket3197() throws Exception {
+        final Schema model = context.resolve(new AnnotatedType(Car.class));
+        assertNotNull(model);
+        String yaml = "Car:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    carMetaData:\n" +
+                "      type: string\n" +
+                "  discriminator:\n" +
+                "    propertyName: type\n" +
+                "    mapping:\n" +
+                "      RaceCar: '#/components/schemas/RaceCar'\n" +
+                "      SportCar: '#/components/schemas/SportCar'\n" +
+                "  oneOf:\n" +
+                "  - $ref: '#/components/schemas/RaceCar'\n" +
+                "  - $ref: '#/components/schemas/SportCar'\n" +
+                "RaceCar:\n" +
+                "  required:\n" +
+                "  - carMetaData\n" +
+                "  - id\n" +
+                "  type: object\n" +
+                "  allOf:\n" +
+                "  - $ref: '#/components/schemas/Car'\n" +
+                "  - type: object\n" +
+                "    properties:\n" +
+                "      id:\n" +
+                "        type: integer\n" +
+                "        format: int64\n" +
+                "      model:\n" +
+                "        type: string\n" +
+                "SportCar:\n" +
+                "  required:\n" +
+                "  - id\n" +
+                "  type: object\n" +
+                "  allOf:\n" +
+                "  - $ref: '#/components/schemas/Car'\n" +
+                "  - type: object\n" +
+                "    properties:\n" +
+                "      id:\n" +
+                "        type: integer\n" +
+                "        format: int64\n" +
+                "      model:\n" +
+                "        type: string";
+
+        SerializationMatchers.assertEqualsToYaml(context.getDefinedModels(), yaml);
+    }
+
+    @Test
+    public void testTicket3197AsSibling() throws Exception {
+
+        ModelResolver.composedModelPropertiesAsSibling = true;
+        ModelResolver myModelResolver = new ModelResolver(new ObjectMapper());
+        ModelConverterContextImpl myContext = new ModelConverterContextImpl(myModelResolver);
+
+        final Schema model = myContext.resolve(new AnnotatedType(Car.class));
+        assertNotNull(model);
+        String yaml = "Car:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    carMetaData:\n" +
+                "      type: string\n" +
+                "  discriminator:\n" +
+                "    propertyName: type\n" +
+                "    mapping:\n" +
+                "      RaceCar: '#/components/schemas/RaceCar'\n" +
+                "      SportCar: '#/components/schemas/SportCar'\n" +
+                "  oneOf:\n" +
+                "  - $ref: '#/components/schemas/RaceCar'\n" +
+                "  - $ref: '#/components/schemas/SportCar'\n" +
+                "RaceCar:\n" +
+                "  required:\n" +
+                "  - carMetaData\n" +
+                "  - id\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    id:\n" +
+                "      type: integer\n" +
+                "      format: int64\n" +
+                "    model:\n" +
+                "      type: string\n" +
+                "  allOf:\n" +
+                "  - $ref: '#/components/schemas/Car'\n" +
+                "SportCar:\n" +
+                "  required:\n" +
+                "  - id\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    id:\n" +
+                "      type: integer\n" +
+                "      format: int64\n" +
+                "    model:\n" +
+                "      type: string\n" +
+                "  allOf:\n" +
+                "  - $ref: '#/components/schemas/Car'";
+
+        SerializationMatchers.assertEqualsToYaml(myContext.getDefinedModels(), yaml);
+        ModelResolver.composedModelPropertiesAsSibling = false;
+    }
+
+
+    @io.swagger.v3.oas.annotations.media.Schema(discriminatorProperty = "type", discriminatorMapping = {
+            @DiscriminatorMapping(value = "RaceCar", schema = RaceCar.class),
+            @DiscriminatorMapping(value = "SportCar", schema = SportCar.class)
+    },
+            oneOf = {
+                    RaceCar.class,
+                    SportCar.class
+            })
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+            property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = RaceCar.class),
+            @JsonSubTypes.Type(value = SportCar.class)
+    })
+    static abstract class Car {
+
+        private String carMetaData;
+
+        public String getCarMetaData() { return carMetaData; }
+    }
+
+    static class RaceCar extends Car {
+
+        @JsonProperty(required = true)
+        public Long id;
+
+        public String model;
+
+        @io.swagger.v3.oas.annotations.media.Schema(required = true)
+        public String carMetaData;
+    }
+
+    static class SportCar extends Car {
+
+        @JsonProperty(required = true)
+        public Long id;
+
+        public String model;
+    }
+}

--- a/modules/swagger-core/src/test/resources/AbstractBaseModelWithoutFields.json
+++ b/modules/swagger-core/src/test/resources/AbstractBaseModelWithoutFields.json
@@ -7,20 +7,22 @@
         "allOf": [
             {
                 "$ref": "#/components/schemas/AbstractBaseModelWithoutFields"
-            }
-        ],
-        "type": "object",
-        "properties": {
-            "a": {
-                "type": "string",
-                "description": "Additional field a"
             },
-            "x": {
-                "type": "integer",
-                "format": "int32",
-                "description": "Additional field x"
+            {
+                "type": "object",
+                "properties": {
+                    "a": {
+                        "type": "string",
+                        "description": "Additional field a"
+                    },
+                    "x": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Additional field x"
+                    }
+                },
+                "description": "Thing3"
             }
-        },
-        "description": "Thing3"
+        ]
     }
 }

--- a/modules/swagger-core/src/test/resources/AbstractBaseModelWithoutFields.json
+++ b/modules/swagger-core/src/test/resources/AbstractBaseModelWithoutFields.json
@@ -4,6 +4,8 @@
         "description": "I am an Abstract Base Model without any declared fields and with Sub-Types"
     },
     "Thing3": {
+        "type": "object",
+        "description": "Thing3",
         "allOf": [
             {
                 "$ref": "#/components/schemas/AbstractBaseModelWithoutFields"
@@ -20,8 +22,7 @@
                         "format": "int32",
                         "description": "Additional field x"
                     }
-                },
-                "description": "Thing3"
+                }
             }
         ]
     }

--- a/modules/swagger-core/src/test/resources/Animal.json
+++ b/modules/swagger-core/src/test/resources/Animal.json
@@ -18,41 +18,47 @@
         "allOf": [
             {
                 "$ref": "#/components/schemas/Animal"
-            }
-        ],
-        "properties": {
-            "firstName": {
-                "type": "string"
             },
-            "lastName": {
-                "type": "string"
+            {
+                "type": "object",
+                "properties": {
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    }
+                }
             }
-        }
+        ]
     },
     "Pet": {
         "type": "object",
         "allOf": [
             {
                 "$ref": "#/components/schemas/Animal"
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "The pet type"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the pet"
+                    },
+                    "isDomestic": {
+                        "type": "boolean"
+                    }
+                }
             }
         ],
         "required": [
             "isDomestic",
             "name",
             "type"
-        ],
-        "properties": {
-            "type": {
-                "type": "string",
-                "description": "The pet type"
-            },
-            "name": {
-                "type": "string",
-                "description": "The name of the pet"
-            },
-            "isDomestic": {
-                "type": "boolean"
-            }
-        }
+        ]
     }
 }

--- a/modules/swagger-core/src/test/resources/AnimalClass.json
+++ b/modules/swagger-core/src/test/resources/AnimalClass.json
@@ -18,41 +18,47 @@
         "allOf": [
             {
                 "$ref": "#/components/schemas/AnimalClass"
-            }
-        ],
-        "properties": {
-            "firstName": {
-                "type": "string"
             },
-            "lastName": {
-                "type": "string"
+            {
+                "type": "object",
+                "properties": {
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    }
+                }
             }
-        }
+        ]
     },
     "PetClass": {
         "type": "object",
         "allOf": [
             {
                 "$ref": "#/components/schemas/AnimalClass"
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "The pet type"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the pet"
+                    },
+                    "isDomestic": {
+                        "type": "boolean"
+                    }
+                }
             }
         ],
         "required": [
             "isDomestic",
             "name",
             "type"
-        ],
-        "properties": {
-            "type": {
-                "type": "string",
-                "description": "The pet type"
-            },
-            "name": {
-                "type": "string",
-                "description": "The name of the pet"
-            },
-            "isDomestic": {
-                "type": "boolean"
-            }
-        }
+        ]
     }
 }

--- a/modules/swagger-core/src/test/resources/AnimalWithSchemaSubtypes.json
+++ b/modules/swagger-core/src/test/resources/AnimalWithSchemaSubtypes.json
@@ -18,41 +18,48 @@
         "allOf": [
             {
                 "$ref": "#/components/schemas/AnimalWithSchemaSubtypes"
-            }
-        ],
-        "properties": {
-            "firstName": {
-                "type": "string"
             },
-            "lastName": {
-                "type": "string"
+            {
+                "type": "object",
+                "properties": {
+                    "firstName": {
+                        "type": "string"
+                    },
+                    "lastName": {
+                        "type": "string"
+                    }
+                }
             }
-        }
+        ]
     },
     "PetWithSchemaSubtypes": {
         "type": "object",
         "allOf": [
             {
                 "$ref": "#/components/schemas/AnimalWithSchemaSubtypes"
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "The pet type"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the pet"
+                    },
+                    "isDomestic": {
+                        "type": "boolean"
+                    }
+                }
+
             }
         ],
         "required": [
             "isDomestic",
             "name",
             "type"
-        ],
-        "properties": {
-            "type": {
-                "type": "string",
-                "description": "The pet type"
-            },
-            "name": {
-                "type": "string",
-                "description": "The name of the pet"
-            },
-            "isDomestic": {
-                "type": "boolean"
-            }
-        }
+        ]
     }
 }

--- a/modules/swagger-core/src/test/resources/ModelWithFieldWithSubTypes.json
+++ b/modules/swagger-core/src/test/resources/ModelWithFieldWithSubTypes.json
@@ -30,42 +30,46 @@
         "description": "Class that has a field that is the AbstractBaseModelWithSubTypes"
     },
     "Thing1": {
-        "type": "object",
         "allOf": [
             {
                 "$ref": "#/components/schemas/AbstractBaseModelWithSubTypes"
-            }
-        ],
-        "properties": {
-            "a": {
-                "type": "string",
-                "description": "Override the abstract a"
             },
-            "x": {
-                "type": "integer",
-                "format": "int32",
-                "description": "Thing1 has an additional field"
+            {
+                "type": "object",
+                "properties": {
+                    "a": {
+                        "type": "string",
+                        "description": "Override the abstract a"
+                    },
+                    "x": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Thing1 has an additional field"
+                    }
+                },
+                "description": "Shake hands with Thing1"
             }
-        },
-        "description": "Shake hands with Thing1"
+        ]
     },
     "Thing2": {
-        "type": "object",
         "allOf": [
             {
                 "$ref": "#/components/schemas/AbstractBaseModelWithSubTypes"
-            }
-        ],
-        "properties": {
-            "a": {
-                "type": "string",
-                "description": "Override the abstract a"
             },
-            "s": {
-                "type": "string",
-                "description": "Thing2 has an additional field"
+            {
+                "type": "object",
+                "properties": {
+                    "a": {
+                        "type": "string",
+                        "description": "Override the abstract a"
+                    },
+                    "s": {
+                        "type": "string",
+                        "description": "Thing2 has an additional field"
+                    }
+                },
+                "description": "and Thing2"
             }
-        },
-        "description": "and Thing2"
+        ]
     }
 }

--- a/modules/swagger-core/src/test/resources/ModelWithFieldWithSubTypes.json
+++ b/modules/swagger-core/src/test/resources/ModelWithFieldWithSubTypes.json
@@ -30,6 +30,8 @@
         "description": "Class that has a field that is the AbstractBaseModelWithSubTypes"
     },
     "Thing1": {
+        "type": "object",
+        "description": "Shake hands with Thing1",
         "allOf": [
             {
                 "$ref": "#/components/schemas/AbstractBaseModelWithSubTypes"
@@ -46,12 +48,13 @@
                         "format": "int32",
                         "description": "Thing1 has an additional field"
                     }
-                },
-                "description": "Shake hands with Thing1"
+                }
             }
         ]
     },
     "Thing2": {
+        "type": "object",
+        "description": "and Thing2",
         "allOf": [
             {
                 "$ref": "#/components/schemas/AbstractBaseModelWithSubTypes"
@@ -67,8 +70,7 @@
                         "type": "string",
                         "description": "Thing2 has an additional field"
                     }
-                },
-                "description": "and Thing2"
+                }
             }
         ]
     }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -469,17 +469,30 @@ public class ReaderTest {
                 "                - $ref: '#/components/schemas/MultipleSub2Bean'\n" +
                 "components:\n" +
                 "  schemas:\n" +
+                "    SampleResponseSchema:\n" +
+                "      type: object\n" +
+                "    GenericError:\n" +
+                "      type: object\n" +
+                "    MultipleSub1Bean:\n" +
+                "      type: object\n" +
+                "      description: MultipleSub1Bean\n" +
+                "      allOf:\n" +
+                "      - $ref: '#/components/schemas/MultipleBaseBean'\n" +
+                "      - type: object\n" +
+                "        properties:\n" +
+                "          c:\n" +
+                "            type: integer\n" +
+                "            format: int32\n" +
                 "    MultipleSub2Bean:\n" +
                 "      type: object\n" +
-                "      properties:\n" +
-                "        d:\n" +
-                "          type: integer\n" +
-                "          format: int32\n" +
                 "      description: MultipleSub2Bean\n" +
                 "      allOf:\n" +
                 "      - $ref: '#/components/schemas/MultipleBaseBean'\n" +
-                "    GenericError:\n" +
-                "      type: object\n" +
+                "      - type: object\n" +
+                "        properties:\n" +
+                "          d:\n" +
+                "            type: integer\n" +
+                "            format: int32\n" +
                 "    MultipleBaseBean:\n" +
                 "      type: object\n" +
                 "      properties:\n" +
@@ -490,18 +503,7 @@ public class ReaderTest {
                 "          format: int32\n" +
                 "        b:\n" +
                 "          type: string\n" +
-                "      description: MultipleBaseBean\n" +
-                "    MultipleSub1Bean:\n" +
-                "      type: object\n" +
-                "      properties:\n" +
-                "        c:\n" +
-                "          type: integer\n" +
-                "          format: int32\n" +
-                "      description: MultipleSub1Bean\n" +
-                "      allOf:\n" +
-                "      - $ref: '#/components/schemas/MultipleBaseBean'\n" +
-                "    SampleResponseSchema:\n" +
-                "      type: object";
+                "      description: MultipleBaseBean";
         SerializationMatchers.assertEqualsToYaml(openAPI, yaml);
     }
 


### PR DESCRIPTION
includes and replaces #3228. Also fixes #3030, #3063 and #2989.

available in upcoming  version `2.0.9`, default behaviour for scenarios as in tickets #3030, #3063, #3197 change: 

properties of schemas resolved as `ComposedSchema` with non empty `allOf` are resolved as part of an object schema within the `allOf`.

This is semantically equivalent to the previous behaviour but better supported by other tools.

Previous behaviour can be maintained by providing a system property `composed-model-properties-as-sibiling` or by setting `ModelResolver.composedModelPropertiesAsSibling = true` programmatically