### PR TITLE
fix DateTimeSchema example serialization by updating type to OffsetDateTime

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -79,6 +79,10 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-annotations</artifactId>
             <version>${project.parent.version}</version>

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/DateTimeSchemaMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/DateTimeSchemaMixin.java
@@ -1,9 +1,0 @@
-package io.swagger.v3.core.jackson.mixin;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
-
-public abstract class DateTimeSchemaMixin {
-
-    @JsonFormat (shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
-    public abstract Object getExample();
-}

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ObjectMapperFactory.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ObjectMapperFactory.java
@@ -13,10 +13,10 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.swagger.v3.core.jackson.SchemaSerializer;
 import io.swagger.v3.core.jackson.mixin.ComponentsMixin;
 import io.swagger.v3.core.jackson.mixin.DateSchemaMixin;
-import io.swagger.v3.core.jackson.mixin.DateTimeSchemaMixin;
 import io.swagger.v3.core.jackson.mixin.ExtensionsMixin;
 import io.swagger.v3.core.jackson.mixin.OpenAPIMixin;
 import io.swagger.v3.core.jackson.mixin.OperationMixin;
@@ -96,6 +96,7 @@ public class ObjectMapperFactory {
 
         Module deserializerModule = new DeserializationModule();
         mapper.registerModule(deserializerModule);
+        mapper.registerModule(new JavaTimeModule());
 
         Map<Class<?>, Class<?>> sourceMixins = new LinkedHashMap<>();
 
@@ -131,7 +132,6 @@ public class ObjectMapperFactory {
         sourceMixins.put(XML.class, ExtensionsMixin.class);
         sourceMixins.put(Schema.class, ExtensionsMixin.class);
         sourceMixins.put(DateSchema.class, DateSchemaMixin.class);
-        sourceMixins.put(DateTimeSchema.class, DateTimeSchemaMixin.class);
 
         mapper.setMixIns(sourceMixins);
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -1003,7 +1003,12 @@ public class ReaderTest {
                 "paths:\n" +
                 "  /test/test:\n" +
                 "    post:\n" +
-                "      operationId: getBook\n" +
+                "      operationId: getAnimal\n" +
+                "      requestBody:\n" +
+                "        content:\n" +
+                "          application/json:\n" +
+                "            schema:\n" +
+                "              $ref: '#/components/schemas/Animal'\n" +
                 "      responses:\n" +
                 "        default:\n" +
                 "          description: default response\n" +

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2340Resource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket2340Resource.java
@@ -3,8 +3,8 @@ package io.swagger.v3.jaxrs2.resources;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 
+import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -14,9 +14,10 @@ import javax.ws.rs.core.MediaType;
 public class Ticket2340Resource {
 
     @Produces({ MediaType.APPLICATION_JSON })
+    @Consumes({ MediaType.APPLICATION_JSON })
     @Path("/test")
     @POST
-    public String getBook(@RequestBody Animal animal) {
+    public String getAnimal(Animal animal) {
         return "ok";
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateTimeSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateTimeSchema.java
@@ -16,7 +16,8 @@
 
 package io.swagger.v3.oas.models.media;
 
-import java.text.SimpleDateFormat;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -25,7 +26,7 @@ import java.util.Objects;
  * DateTimeSchema
  */
 
-public class DateTimeSchema extends Schema<Date> {
+public class DateTimeSchema extends Schema<OffsetDateTime> {
 
     public DateTimeSchema() {
         super("string", "date-time");
@@ -47,13 +48,15 @@ public class DateTimeSchema extends Schema<Date> {
     }
 
     @Override
-    protected Date cast(Object value) {
+    protected OffsetDateTime cast(Object value) {
         if (value != null) {
             try {
                 if (value instanceof Date) {
-                    return (Date) value;
+                    return ((Date)value).toInstant().atOffset(ZoneOffset.UTC);
                 } else if (value instanceof String) {
-                    return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse((String) value);
+                    return OffsetDateTime.parse((String)value);
+                } else if (value instanceof OffsetDateTime) {
+                    return (OffsetDateTime)value;
                 }
             } catch (Exception e) {
             }
@@ -61,12 +64,12 @@ public class DateTimeSchema extends Schema<Date> {
         return null;
     }
 
-    public DateTimeSchema _enum(List<Date> _enum) {
+    public DateTimeSchema _enum(List<OffsetDateTime> _enum) {
         super.setEnum(_enum);
         return this;
     }
 
-    public DateTimeSchema addEnumItem(Date _enumItem) {
+    public DateTimeSchema addEnumItem(OffsetDateTime _enumItem) {
         super.addEnumItemObject(_enumItem);
         return this;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -455,6 +455,11 @@
                 <version>${jackson-version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson-version}</version>
+            </dependency>
+            <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
                 <version>${logback-version}</version>


### PR DESCRIPTION
"minor" breaking change, in cases of client projects using swagger-models or swagger-core , and relying on the java generic type of DateTimeSchema being Date, as the fix changes that to correctly use java 8 OffsetDateTime instead.
