### PR TITLE
Make scanning all JAX-RS packages explicit

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/JaxrsAnnotationScanner.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/JaxrsAnnotationScanner.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class JaxrsAnnotationScanner<T extends JaxrsAnnotationScanner<T>> implements JaxrsOpenApiScanner {
+    private static final String ALL_PACKAGES = "*";
 
     static final Set<String> ignored = new HashSet();
 
@@ -76,15 +77,18 @@ public class JaxrsAnnotationScanner<T extends JaxrsAnnotationScanner<T>> impleme
 
         boolean allowAllPackages = false;
         if (openApiConfiguration.getResourcePackages() != null && !openApiConfiguration.getResourcePackages().isEmpty()) {
-            for (String pkg : openApiConfiguration.getResourcePackages()) {
-                if (!isIgnored(pkg)) {
-                    acceptablePackages.add(pkg);
-                    graph.whitelistPackages(pkg);
+            if (openApiConfiguration.getResourcePackages().contains(ALL_PACKAGES)) {
+                allowAllPackages = true;
+            } else {
+                for (String pkg : openApiConfiguration.getResourcePackages()) {
+                    if (!isIgnored(pkg)) {
+                        acceptablePackages.add(pkg);
+                        graph.whitelistPackages(pkg);
+                    }
                 }
             }
-        } else {
-            allowAllPackages = true;
-        }
+        } 
+
         final Set<Class<?>> classes;
         try (ScanResult scanResult = graph.scan()) {
             classes = new HashSet<>(scanResult.getClassesWithAnnotation(javax.ws.rs.Path.class.getName()).loadClasses());

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/JaxrsApplicationAndAnnotationScannerTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/JaxrsApplicationAndAnnotationScannerTest.java
@@ -1,0 +1,77 @@
+package io.swagger.v3.jaxrs2.integration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Application;
+
+import org.my.project.resources.ResourceInPackageB;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.my.project.resources.ResourceInPackageA;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.integration.SwaggerConfiguration;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class JaxrsApplicationAndAnnotationScannerTest {
+    private JaxrsApplicationAndAnnotationScanner scanner;
+
+    @Path("/app")
+    public static class ResourceInApplication {
+        @Operation(operationId = "test.")
+        @GET
+        public void getTest(@Parameter(name = "test") ArrayList<String> tenantId) {
+            return;
+        }
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        scanner = new JaxrsApplicationAndAnnotationScanner();
+        
+        scanner.setApplication(new Application() {
+            @Override
+            public Set<Class<?>> getClasses() {
+                return Collections.singleton(ResourceInApplication.class);
+            }
+        });
+    }
+    
+    @Test(description = "scan classes from Application")
+    public void shouldOnlyScanClassesFromApplication() throws Exception {
+        assertEquals(scanner.classes().size(), 1);
+        assertTrue(scanner.classes().contains(ResourceInApplication.class));
+    }
+    
+    @Test(description = "scan classes from all packages and Application")
+    public void shouldOnlyScanClassesFromAllPackagesAndApplication() throws Exception {
+        SwaggerConfiguration openApiConfiguration = new SwaggerConfiguration();
+        openApiConfiguration.setResourcePackages(Collections.singleton("*"));
+        scanner.setConfiguration(openApiConfiguration);
+        
+        assertNotEquals(scanner.classes().size(), 1);
+        assertTrue(scanner.classes().contains(ResourceInPackageA.class));
+        assertTrue(scanner.classes().contains(ResourceInPackageB.class));
+        assertTrue(scanner.classes().contains(ResourceInApplication.class));
+    }
+    
+    @Test(description = "scan classes from the packages and Application")
+    public void shouldOnlyScanClassesFromPackagesAndApplication() throws Exception {
+        SwaggerConfiguration openApiConfiguration = new SwaggerConfiguration();
+        openApiConfiguration.setResourcePackages(Collections.singleton("com.my.project.resources"));
+        scanner.setConfiguration(openApiConfiguration);
+        
+        assertEquals(scanner.classes().size(), 2);
+        assertTrue(scanner.classes().contains(ResourceInPackageA.class));
+        assertTrue(scanner.classes().contains(ResourceInApplication.class));
+    }
+}


### PR DESCRIPTION
#### Description
The regression [1] has been reported by one of the CXF users with respect to `Swagger Core` releases after `2.0.6` , here is the issue.

The JAX-RS service has instance of the `Application` class which has only one resource class returned by `getClasses()` method. The service uses Swagger `2.0.8` + OpenAPI v3 and does not specify any resources classes and resource packages to scan (assuming those will be taken from the  `Application` instance). Before `2.0.7` it was the case but since than the `Swagger Core`  changed implementation from `Reflections` to `ClassGraph`, and now **always** scan the complete class path if resource classes and resource packages are empty. The classes from the `Application`  instance are added on top and there is no way to tailor this behavior.

There are couple of solutions to make the behavior more controllable. The one presented in this PR is very simple but intuitive: introduce explicit marker to scan all packages.

```java
openApiConfiguration.setResourcePackages(Collections.singleton("*"));
```

Another option would be to check `Application`  instance for resource classes and allow the scanning of all packages only if this set is empty. 

The feedback would be really appreciated, for now the desired results could be achieved with some smelly workarounds but it would be great to make the scanning outcomes obvious. 

[1] https://issues.apache.org/jira/browse/CXF-8103

Thank you guys. 
CC @frantuma 
