### PR TITLE
refs #3283 - add scanner limited to defined resourcePackages

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/JaxrsAnnotationScanner.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/JaxrsAnnotationScanner.java
@@ -28,6 +28,7 @@ public class JaxrsAnnotationScanner<T extends JaxrsAnnotationScanner<T>> impleme
     protected OpenAPIConfiguration openApiConfiguration;
     protected Application application;
     protected static Logger LOGGER = LoggerFactory.getLogger(JaxrsAnnotationScanner.class);
+    protected boolean onlyConsiderResourcePackages = false;
 
     public JaxrsAnnotationScanner application(Application application) {
         this.application = application;
@@ -83,7 +84,9 @@ public class JaxrsAnnotationScanner<T extends JaxrsAnnotationScanner<T>> impleme
                 }
             }
         } else {
-            allowAllPackages = true;
+            if (!onlyConsiderResourcePackages) {
+                allowAllPackages = true;
+            }
         }
         final Set<Class<?>> classes;
         try (ScanResult scanResult = graph.scan()) {

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/JaxrsApplicationAndResourcePackagesAnnotationScanner.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/JaxrsApplicationAndResourcePackagesAnnotationScanner.java
@@ -1,0 +1,40 @@
+package io.swagger.v3.jaxrs2.integration;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @since 2.0.10
+ */
+public class JaxrsApplicationAndResourcePackagesAnnotationScanner extends JaxrsAnnotationScanner<JaxrsApplicationAndResourcePackagesAnnotationScanner> {
+
+    public JaxrsApplicationAndResourcePackagesAnnotationScanner() {
+        onlyConsiderResourcePackages = true;
+    }
+
+    @Override
+    public Set<Class<?>> classes() {
+        Set<Class<?>> classes = super.classes();
+        Set<Class<?>> output = new HashSet<Class<?>>();
+        if (application != null) {
+            Set<Class<?>> clzs = application.getClasses();
+            if (clzs != null) {
+                for (Class<?> clz : clzs) {
+                    if (!isIgnored(clz.getName())) {
+                        output.add(clz);
+                    }
+                }
+            }
+            Set<Object> singletons = application.getSingletons();
+            if (singletons != null) {
+                for (Object o : singletons) {
+                    if (!isIgnored(o.getClass().getName())) {
+                        output.add(o.getClass());
+                    }
+                }
+            }
+        }
+        classes.addAll(output);
+        return classes;
+    }
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/IntegrationTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/IntegrationTest.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 public class IntegrationTest {
 
@@ -50,6 +51,36 @@ public class IntegrationTest {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    @Test
+    public void shouldScanOnlyResourcePackagesClasses() throws Exception {
+        SwaggerConfiguration config = new SwaggerConfiguration()
+                .openAPI(new OpenAPI().info(new Info().description("TEST INFO DESC")));
+        OpenApiContext ctx = new GenericOpenApiContext()
+                .openApiConfiguration(config)
+                .openApiReader(new Reader(config))
+                .openApiScanner(new JaxrsApplicationAndResourcePackagesAnnotationScanner().openApiConfiguration(config))
+                .init();
+
+        OpenAPI openApi = ctx.read();
+
+        assertNotNull(openApi);
+        assertNull(openApi.getPaths());
+
+        config = new SwaggerConfiguration()
+                .resourcePackages(Stream.of("com.my.project.resources", "org.my.project.resources").collect(Collectors.toSet()))
+                .openAPI(new OpenAPI().info(new Info().description("TEST INFO DESC")));
+
+        ctx = new GenericOpenApiContext()
+                .openApiConfiguration(config)
+                .openApiReader(new Reader(config))
+                .openApiScanner(new JaxrsApplicationAndResourcePackagesAnnotationScanner().openApiConfiguration(config))
+                .init();
+
+        openApi = ctx.read();
+        assertNotNull(openApi);
+        assertEquals(openApi.getPaths().keySet(), expectedKeys);
     }
 
 }


### PR DESCRIPTION
As mentioned in #3283, since version `2.0.7` default resource scanning behaviour has changed in scenarios where no resource packages or classes are defined; in versions up to `2.0.6` no resources would have been added except the ones defined in custom `Application.classes()`; since `2.0.7` the whole classpath is instead scanned. 

This PR adds a [scanner implementation](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-configuration#resource-scanning)  `JaxrsApplicationAndResourcePackagesAnnotationScanner` which behaves as pre `2.0.7` default mechanism