### PR TITLE
fix #3286 - prioritize schema name resolving by `ApiModel.value`

### DIFF
--- a/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/SimpleReaderTest.java
@@ -31,6 +31,7 @@ import io.swagger.resources.ClassWithExamplePost;
 import io.swagger.resources.ClassWithExamplePostClass;
 import io.swagger.resources.HiddenResource;
 import io.swagger.resources.Issue1979Resource;
+import io.swagger.resources.Issue3286Resource;
 import io.swagger.resources.NicknamedOperation;
 import io.swagger.resources.NotValidRootResource;
 import io.swagger.resources.Resource1041;
@@ -715,5 +716,15 @@ public class SimpleReaderTest {
 
         SerializableParameter allowEmptyParam = (SerializableParameter) swagger.getPath("/fun/allowEmpty").getGet().getParameters().get(0);
         assertTrue(allowEmptyParam.getAllowEmptyValue());
+    }
+
+    @Test
+    public void testTicket3286() {
+        Swagger swagger = getSwagger(Issue3286Resource.class);
+        BodyParameter bodyParam = (BodyParameter)swagger.getPath("/fun/{id}").getPost().getParameters().get(1);
+        assertEquals(bodyParam.getSchema().getReference(), "#/definitions/BookRequest");
+        assertEquals(swagger.getPath("/fun/{id}").getPost().getResponses().get("200").getResponseSchema().getReference(), "#/definitions/BookResponse");
+        assertTrue(swagger.getDefinitions().containsKey("BookRequest"));
+        assertTrue(swagger.getDefinitions().containsKey("BookResponse"));
     }
 }

--- a/modules/swagger-jaxrs/src/test/java/io/swagger/resources/Issue3286Resource.java
+++ b/modules/swagger-jaxrs/src/test/java/io/swagger/resources/Issue3286Resource.java
@@ -1,0 +1,49 @@
+package io.swagger.resources;
+
+import com.fasterxml.jackson.annotation.JsonRootName;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@Api(value = "test")
+@Path("fun")
+public class Issue3286Resource {
+
+    @POST
+    @Path("/{id}")
+    @ApiOperation(value = "test")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Ok", response = BookResponse.class),
+            @ApiResponse(code = 400, message = "Ko", response = Error.class),
+    })
+    public Response test(@PathParam(value = "id") String bookId, BookRequest book) {
+        return Response.ok().build();
+    }
+
+
+    @ApiModel(value = "BookResponse", description = "descResponse")
+    @XmlRootElement(name = "book")
+    @JsonRootName("book")
+    public static class BookResponse {
+        public String foo;
+    }
+
+    @ApiModel(value = "BookRequest", description = "desc")
+    @XmlRootElement(name = "book")
+    @JsonRootName("book")
+    public static class BookRequest {
+        public String bar;
+    }
+
+    public static class Error {
+        public String err;
+    }
+}


### PR DESCRIPTION
up to `1.5.23` release any defined `JsonRootName` annotation on a model takes precedence over a 
 defined `ApiModel.value` annotation on the same model, causing e.g. issues like the one described in #3286. This PR addresses this by reversing the logic in such cases.

**Note** this breaks default behaviour in such scenarios comparing to previous versions, as an expected effect, given that previous logic can be considered a bug, as swagger annotations must take precedence to provide full control of the resolved spec.

To maintain previous behavior for any reason, a custom model resolver can be provided:

```
class CustomSchemaNameResolverConverter extends ModelResolver {

        public CustomSchemaNameResolverConverter(ObjectMapper mapper) {
            super(mapper);
        }
        protected boolean prioritizeAnnotationInspectorSchemaName() {
          return true;
        }
    }
```

```
ModelConverters.getInstance().addConverter(new CustomSchemaNameResolverConverter(Json.mapper()));
```

