### PR TITLE
Fix #3124 - Move enums to top level schema definitions

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
@@ -310,6 +310,13 @@ public @interface Schema {
     boolean hidden() default false;
 
     /**
+     * Allows enums to be represented as top level references.
+     *
+     * @return whether or not this schema is a top level enum reference
+     */
+    boolean enumAsRef() default false;
+
+    /**
      * An array of the sub types inheriting from this model.
      */
     Class<?>[] subTypes() default {};

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -263,7 +263,10 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         }
 
         if (model == null && type.isEnumType()) {
-            model = new StringSchema().$ref(name).name(name);
+            model = new StringSchema();
+            if (resolvedSchemaAnnotation != null && resolvedSchemaAnnotation.enumAsRef()) {
+                model = model.$ref(name).name(name);
+            }
             _addEnumProps(type.getRawClass(), model);
             isPrimitive = true;
         }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -264,9 +264,6 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
         if (model == null && type.isEnumType()) {
             model = new StringSchema();
-            if (resolvedSchemaAnnotation != null && resolvedSchemaAnnotation.enumAsRef()) {
-                model = model.$ref(name).name(name);
-            }
             _addEnumProps(type.getRawClass(), model);
             isPrimitive = true;
         }
@@ -321,6 +318,14 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 resolveArraySchema(annotatedType, schema, resolvedArrayAnnotation);
                 schema.setItems(model);
                 return schema;
+            }
+            if (type.isEnumType() &&
+                    resolvedSchemaAnnotation != null &&
+                    resolvedSchemaAnnotation.enumAsRef()) {
+                // Store off the ref and add the enum as a top-level model
+                context.defineModel(name, model, annotatedType, null);
+                // Return the model as a ref only property
+                model = new Schema().$ref(name);
             }
             return model;
         }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -263,7 +263,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         }
 
         if (model == null && type.isEnumType()) {
-            model = new StringSchema();
+            model = new StringSchema().$ref(name).name(name);
             _addEnumProps(type.getRawClass(), model);
             isPrimitive = true;
         }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -95,6 +95,7 @@ public abstract class AnnotationsUtils {
                 && schema.discriminatorMapping().length == 0
                 && schema.extensions().length == 0
                 && !schema.hidden()
+                && !schema.enumAsRef()
                 ) {
             return false;
         }
@@ -260,7 +261,9 @@ public abstract class AnnotationsUtils {
         if (thisSchema.hidden() != thatSchema.hidden()) {
             return false;
         }
-
+        if (thisSchema.enumAsRef() != thatSchema.enumAsRef()) {
+            return false;
+        }
         if (!thisSchema.implementation().equals(thatSchema.implementation())) {
             return false;
         }
@@ -1722,6 +1725,14 @@ public abstract class AnnotationsUtils {
                     return master.hidden();
                 }
                 return patch.hidden();
+            }
+
+            @Override
+            public boolean enumAsRef() {
+                if (master.enumAsRef() || !patch.enumAsRef()) {
+                    return master.enumAsRef();
+                }
+                return patch.enumAsRef();
             }
 
             @Override

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.matchers.SerializationMatchers;
 import io.swagger.v3.core.oas.models.ModelWithEnumField;
 import io.swagger.v3.core.oas.models.ModelWithEnumProperty;
+import io.swagger.v3.core.oas.models.ModelWithEnumRefProperty;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import org.testng.annotations.Test;
@@ -57,5 +58,33 @@ public class EnumPropertyTest {
 
         final StringSchema stringProperty = (StringSchema) enumProperty;
         assertEquals(stringProperty.getEnum(), Arrays.asList("PRIVATE", "PUBLIC", "SYSTEM", "INVITE_ONLY"));
+    }
+
+    @Test(description = "it should read a model with an enum property as a reference")
+    public void testEnumRefProperty() {
+        final Map<String, Schema> models = ModelConverters.getInstance().readAll(ModelWithEnumRefProperty.class);
+        final String json = "{" +
+                "   \"ModelWithEnumRefProperty\":{" +
+                "      \"type\":\"object\"," +
+                "      \"properties\":{" +
+                "         \"a\":{" +
+                "            \"$ref\":\"#/components/schemas/TestEnum\"" +
+                "         }," +
+                "         \"b\":{" +
+                "            \"$ref\":\"#/components/schemas/TestEnum\"" +
+                "         }" +
+                "      }" +
+                "   }," +
+                "   \"TestEnum\":{" +
+                "      \"type\":\"string\"," +
+                "      \"enum\":[" +
+                "         \"PRIVATE\"," +
+                "         \"PUBLIC\"," +
+                "         \"SYSTEM\"," +
+                "         \"INVITE_ONLY\"" +
+                "      ]" +
+                "   }" +
+                "}";
+        SerializationMatchers.assertEqualsToJson(models, json);
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithEnumRefProperty.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithEnumRefProperty.java
@@ -1,0 +1,26 @@
+package io.swagger.v3.core.oas.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ModelWithEnumRefProperty {
+    private TestEnum a;
+    private TestEnum b;
+
+    @Schema(enumAsRef = true)
+    public TestEnum getA() {
+        return a;
+    }
+
+    public void setA(TestEnum e) {
+        this.a = a;
+    }
+
+    @Schema(enumAsRef = true)
+    public TestEnum getB() {
+        return b;
+    }
+
+    public void setB(TestEnum b) {
+        this.b = b;
+    }
+}

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
@@ -72,7 +72,7 @@ public class Components {
         if (this.schemas == null) {
             this.schemas = new LinkedHashMap<>();
         }
-        this.schemas.put(key, schemasItem != null && schemasItem.getEnum() != null ? schemasItem.$ref(null) : schemasItem);
+        this.schemas.put(key, schemasItem);
         return this;
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
@@ -72,7 +72,7 @@ public class Components {
         if (this.schemas == null) {
             this.schemas = new LinkedHashMap<>();
         }
-        this.schemas.put(key, schemasItem);
+        this.schemas.put(key, schemasItem.getEnum() != null ? schemasItem.$ref(null) : schemasItem);
         return this;
     }
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
@@ -72,7 +72,7 @@ public class Components {
         if (this.schemas == null) {
             this.schemas = new LinkedHashMap<>();
         }
-        this.schemas.put(key, schemasItem.getEnum() != null ? schemasItem.$ref(null) : schemasItem);
+        this.schemas.put(key, schemasItem != null && schemasItem.getEnum() != null ? schemasItem.$ref(null) : schemasItem);
         return this;
     }
 


### PR DESCRIPTION
This fixes #3124 by moving enums to top level schema properties, original inspiration from #2996.

@frantuma I know the tests are likely going to break because this changes how enums work.  I was hoping to get your feedback on how to make this configurable, like #2996 originally proposed.  Should it be an annotation on the class or a configuration property of the OpenAPI?