### PR TITLE
Contact Model has no Vendor Extensions

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/models/Contact.java
+++ b/modules/swagger-models/src/main/java/io/swagger/models/Contact.java
@@ -1,9 +1,16 @@
 package io.swagger.models;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 public class Contact {
     private String name;
     private String url;
     private String email;
+    private Map<String, Object> vendorExtensions = new LinkedHashMap<String, Object>();
 
     public Contact name(String name) {
         this.setName(name);
@@ -44,6 +51,22 @@ public class Contact {
         this.email = email;
     }
 
+    @JsonAnyGetter
+    public Map<String, Object> getVendorExtensions() {
+        return vendorExtensions;
+    }
+
+    @JsonAnySetter
+    public void setVendorExtension(String name, Object value) {
+        if (name.startsWith("x-")) {
+            vendorExtensions.put(name, value);
+        }
+    }
+
+    public void setVendorExtensions(Map<String, Object> vendorExtensions) {
+        this.vendorExtensions = vendorExtensions;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -51,6 +74,7 @@ public class Contact {
         result = prime * result + ((email == null) ? 0 : email.hashCode());
         result = prime * result + ((name == null) ? 0 : name.hashCode());
         result = prime * result + ((url == null) ? 0 : url.hashCode());
+        result = prime * result + ((vendorExtensions == null) ? 0 : vendorExtensions.hashCode());
         return result;
     }
 
@@ -85,6 +109,13 @@ public class Contact {
                 return false;
             }
         } else if (!url.equals(other.url)) {
+            return false;
+        }
+        if (vendorExtensions == null) {
+            if (other.vendorExtensions != null) {
+                return false;
+            }
+        } else if (!vendorExtensions.equals(other.vendorExtensions)) {
             return false;
         }
         return true;


### PR DESCRIPTION
This issue was reported on https://github.com/swagger-api/swagger-parser/issues/1204.
and reading the spec for 2.0 swagger version, https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#contact-object has the vendor extension as valid.

That's the reason for the PR, to add vendor extension for contact object in core, and fix the issue in parser to be able to deserialize it validly.

pre-requisite for Parser issue #1204