### PR TITLE
Enable caching of Gradle 'ResolveTask' - remove compatibility to Gradle versions prior to 3.2

### DIFF
--- a/modules/swagger-gradle-plugin/README.md
+++ b/modules/swagger-gradle-plugin/README.md
@@ -1,7 +1,9 @@
 # swagger-gradle-plugin
 
+**`swagger-gradle-plugin` supports gradle 3.2 and higher.**
+
 ## Installation
-### Gradle 2.1 and higher
+### Gradle 3.2 and higher
 
 ```
 plugins {
@@ -9,6 +11,10 @@ plugins {
 }
 ```
 ### Gradle 1.x and 2.0
+
+**NOTE**: Since version `2.0.10` gradle 1.x and 2.x up to 3.1 are not supported.
+
+with versions up to `2.0.9`:
 
 ```
 buildscript {
@@ -29,7 +35,7 @@ apply plugin: "io.swagger.core.v3.swagger-gradle-plugin"
 ### resolve
 
 * Resolves project openAPI specification and saves the result in JSON, YAML or both formats.
-All parameters except `outputFileName`, `outputFormat`, `classpath`, `skip`, `encoding` and `outputPath` correspond
+All parameters except `outputFileName`, `outputFormat`, `classpath`, `skip`, `encoding`, `outputDir` and `outputPath` correspond
 to `swagger` [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties) with same name.
 
 #### Example Usage
@@ -42,7 +48,7 @@ resolve {
     prettyPrint = 'TRUE'
     classpath = sourceSets.main.runtimeClasspath
     resourcePackages = ['io.test']
-    outputPath = 'test'
+    outputDir = file('test')
 }
 ```
 
@@ -50,7 +56,7 @@ resolve {
 Parameter | Description | Required | Default
 --------- | ----------- | --------- | -------
 `classpath`|classpath for resources to scan (swagger and deps already included in classpath)|true|
-`outputPath`|output path where file(s) are saved|true|
+`outputDir`|output path where file(s) are saved|true|
 `outputFileName`|file name (no extension)|false|`openapi`
 `outputFormat`|file format (`JSON`, `YAML`, `JSONANDYAML`|false|`JSON`
 `skip`|if `TRUE` skip execution|false|`FALSE`
@@ -67,6 +73,7 @@ Parameter | Description | Required | Default
 `objectMapperProcessorClass`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)|false|
 `modelConverterClasses`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)|false|
 `contextId`|see [Context](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#context)|false|
+`outputPath`|**DEPRECATED** output path where file(s) are saved|false|
 
 
 **Note** parameter `openApiFile` corresponds to [config](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties) openAPI. It points to a location of a file in YAML or JSON format representing the input spec that will be merged with the resolved spec. Typically used to add Info section, or any other meta data. 

--- a/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/tasks/ResolveTask.java
+++ b/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/tasks/ResolveTask.java
@@ -25,7 +25,6 @@ import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Map;


### PR DESCRIPTION
includes and replaces #3123 

**NOTE**:  since version `2.0.10` Gradle versions < 3.2 are not anymore supported