### PR TITLE
Refs #3153 - Provide option to disable JAXB processing

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
@@ -23,6 +23,8 @@ public abstract class AbstractModelConverter implements ModelConverter {
     protected final ObjectMapper _mapper;
     protected final AnnotationIntrospector _intr;
     protected final TypeNameResolver _typeNameResolver;
+    final boolean _jAXBEnabled;
+
     /**
      * Minor optimization: no need to keep on resolving same types over and over
      * again.
@@ -33,12 +35,21 @@ public abstract class AbstractModelConverter implements ModelConverter {
         this (mapper, TypeNameResolver.std);
     }
 
+    protected AbstractModelConverter(ObjectMapper mapper, boolean enableJAXB) {
+        this (mapper, TypeNameResolver.std, enableJAXB);
+    }
+
     protected AbstractModelConverter(ObjectMapper mapper, TypeNameResolver typeNameResolver) {
+        this (mapper, typeNameResolver, true);
+    }
+
+    protected AbstractModelConverter(ObjectMapper mapper, TypeNameResolver typeNameResolver, boolean enableJAXB) {
+        _jAXBEnabled = enableJAXB;
         mapper.registerModule(
                 new SimpleModule("swagger", Version.unknownVersion()) {
                     @Override
                     public void setupModule(SetupContext context) {
-                        context.insertAnnotationIntrospector(new SwaggerAnnotationIntrospector());
+                        context.insertAnnotationIntrospector(new SwaggerAnnotationIntrospector(_jAXBEnabled));
                     }
                 });
         _mapper = mapper;

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
@@ -23,7 +23,6 @@ public abstract class AbstractModelConverter implements ModelConverter {
     protected final ObjectMapper _mapper;
     protected final AnnotationIntrospector _intr;
     protected final TypeNameResolver _typeNameResolver;
-    final boolean _jAXBEnabled;
 
     /**
      * Minor optimization: no need to keep on resolving same types over and over
@@ -35,26 +34,30 @@ public abstract class AbstractModelConverter implements ModelConverter {
         this (mapper, TypeNameResolver.std);
     }
 
-    protected AbstractModelConverter(ObjectMapper mapper, boolean enableJAXB) {
-        this (mapper, TypeNameResolver.std, enableJAXB);
-    }
-
     protected AbstractModelConverter(ObjectMapper mapper, TypeNameResolver typeNameResolver) {
-        this (mapper, typeNameResolver, true);
-    }
-
-    protected AbstractModelConverter(ObjectMapper mapper, TypeNameResolver typeNameResolver, boolean enableJAXB) {
-        _jAXBEnabled = enableJAXB;
         mapper.registerModule(
                 new SimpleModule("swagger", Version.unknownVersion()) {
                     @Override
                     public void setupModule(SetupContext context) {
-                        context.insertAnnotationIntrospector(new SwaggerAnnotationIntrospector(_jAXBEnabled));
+                        context.insertAnnotationIntrospector(new SwaggerAnnotationIntrospector());
                     }
                 });
         _mapper = mapper;
         _typeNameResolver = typeNameResolver;
         _intr = mapper.getSerializationConfig().getAnnotationIntrospector();
+    }
+
+    protected AbstractModelConverter(ObjectMapper mapper, TypeNameResolver typeNameResolver, AnnotationIntrospector annotationIntrospector) {
+        mapper.registerModule(
+                new SimpleModule("swagger", Version.unknownVersion()) {
+                    @Override
+                    public void setupModule(SetupContext context) {
+                        context.insertAnnotationIntrospector(annotationIntrospector);
+                    }
+                });
+        _mapper = mapper;
+        _typeNameResolver = typeNameResolver;
+        _intr = annotationIntrospector;
     }
 
     @Override

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
@@ -35,16 +35,7 @@ public abstract class AbstractModelConverter implements ModelConverter {
     }
 
     protected AbstractModelConverter(ObjectMapper mapper, TypeNameResolver typeNameResolver) {
-        mapper.registerModule(
-                new SimpleModule("swagger", Version.unknownVersion()) {
-                    @Override
-                    public void setupModule(SetupContext context) {
-                        context.insertAnnotationIntrospector(new SwaggerAnnotationIntrospector());
-                    }
-                });
-        _mapper = mapper;
-        _typeNameResolver = typeNameResolver;
-        _intr = mapper.getSerializationConfig().getAnnotationIntrospector();
+        this (mapper, typeNameResolver, new SwaggerAnnotationIntrospector());
     }
 
     protected AbstractModelConverter(ObjectMapper mapper, TypeNameResolver typeNameResolver, AnnotationIntrospector annotationIntrospector) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -90,12 +90,10 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     private final boolean _jAXBEnabled;
 
     public ModelResolver(ObjectMapper mapper) {
-        super(mapper);
-        _jAXBEnabled = true;
+        this(mapper, true);
     }
     public ModelResolver(ObjectMapper mapper, TypeNameResolver typeNameResolver) {
-        super(mapper, typeNameResolver);
-        _jAXBEnabled = true;
+        this(mapper, typeNameResolver, true);
     }
     public ModelResolver(ObjectMapper mapper, boolean enableJAXB) {
         this(mapper, TypeNameResolver.std, enableJAXB);

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -19,12 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyMetadata;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.introspect.Annotated;
-import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
-import com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder;
+import com.fasterxml.jackson.databind.introspect.*;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.util.Annotations;
 import io.swagger.v3.core.converter.AnnotatedType;
@@ -92,17 +87,22 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
     public static boolean composedModelPropertiesAsSibling = System.getProperty(SET_PROPERTY_OF_COMPOSED_MODEL_AS_SIBLING) != null ? true : false;
 
+    private final boolean _jAXBEnabled;
+
     public ModelResolver(ObjectMapper mapper) {
         super(mapper);
-    }
-    public ModelResolver(ObjectMapper mapper, boolean enableJAXB) {
-        super(mapper, enableJAXB);
+        _jAXBEnabled = true;
     }
     public ModelResolver(ObjectMapper mapper, TypeNameResolver typeNameResolver) {
         super(mapper, typeNameResolver);
+        _jAXBEnabled = true;
+    }
+    public ModelResolver(ObjectMapper mapper, boolean enableJAXB) {
+        this(mapper, TypeNameResolver.std, enableJAXB);
     }
     public ModelResolver(ObjectMapper mapper, TypeNameResolver typeNameResolver, boolean enableJAXB) {
-        super(mapper, typeNameResolver, enableJAXB);
+        super(mapper, typeNameResolver, new SwaggerAnnotationIntrospector(enableJAXB));
+        _jAXBEnabled = enableJAXB;
     }
 
     public ObjectMapper objectMapper() {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/SwaggerAnnotationIntrospector.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/SwaggerAnnotationIntrospector.java
@@ -19,6 +19,16 @@ import java.util.List;
 
 public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
     private static final long serialVersionUID = 1L;
+    private final boolean _jAXBEnabled;
+
+    SwaggerAnnotationIntrospector() {
+        this(true);
+    }
+
+    SwaggerAnnotationIntrospector(boolean enableJAXB) {
+        super();
+        this._jAXBEnabled = enableJAXB;
+    }
 
     @Override
     public Version version() {
@@ -40,10 +50,12 @@ public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
 
     @Override
     public Boolean hasRequiredMarker(AnnotatedMember m) {
-        XmlElement elem = m.getAnnotation(XmlElement.class);
-        if (elem != null) {
-            if (elem.required()) {
-                return true;
+        if (_jAXBEnabled) {
+            XmlElement elem = m.getAnnotation(XmlElement.class);
+            if (elem != null) {
+                if (elem.required()) {
+                    return true;
+                }
             }
         }
         JsonProperty jsonProperty = m.getAnnotation(JsonProperty.class);


### PR DESCRIPTION
Resolves swagger-api/swagger-core#3153 .

This change is to provide an option in `ModelResolver` to disable JAXB XML annotation processing.
This will allow swagger-core to be used in Android applications, which does not/will not support JAXB.
Changes are intended to not require any changes to existing applications, nor change their behavior.

Summary of changes:
- `SwaggerAnnotationIntrospector` constructor overload to allow configuration of new boolean property to enable/disable JAXB processing.  Latter will default to true (enabled) if not specified.
- `AbstractModelResolver` constructor overload to allow instance of `AnnotationIntrospector` to be provided.
- `ModelResolver` constructor overload to allow configuration of new boolean property to enable/disable JAXB processing.  Latter will default to true (enabled) if not specified.
- `ModelResolver` constructor instantiates `SwaggerAnnotationIntrospector` and passes the latter to `super()`.
- `ModelResolver` and `SwaggerAnnotationIntrospector` code that uses JAXB classes are enclosed in `if` blocks checking `_jAXBEnabled` property.

Thank you for your time.