### PR TITLE
Include discriminator mapped schemas when filtering

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
@@ -291,6 +291,12 @@ public class SpecFilter {
             referencedDefinitions.add(schema.get$ref());
             return;
         }
+        if (schema.getDiscriminator() != null) {
+            for (Map.Entry<String, String> mapping: schema.getDiscriminator().getMapping().entrySet()) {
+                referencedDefinitions.add(mapping.getValue());
+            }
+            return;
+        }
 
         if (schema.getProperties() != null) {
             for (Object propName : schema.getProperties().keySet()) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/SpecFilterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/SpecFilterTest.java
@@ -255,6 +255,20 @@ public class SpecFilterTest {
         assertNotNull(filtered.getComponents().getSchemas().get("Category"));
         assertNotNull(filtered.getComponents().getSchemas().get("Pet"));
         assertNotNull(filtered.getComponents().getSchemas().get("Foo"));
+        assertNotNull(filtered.getComponents().getSchemas().get("allOfChild"));
+        assertNotNull(filtered.getComponents().getSchemas().get("anyOfChild"));
+        assertNotNull(filtered.getComponents().getSchemas().get("oneOfChild"));
+        assertNotNull(filtered.getComponents().getSchemas().get("allOfparentA"));
+        assertNotNull(filtered.getComponents().getSchemas().get("allOfparentB"));
+        assertNotNull(filtered.getComponents().getSchemas().get("anyOfparentA"));
+        assertNotNull(filtered.getComponents().getSchemas().get("anyOfparentB"));
+        assertNotNull(filtered.getComponents().getSchemas().get("oneOfparentA"));
+        assertNotNull(filtered.getComponents().getSchemas().get("oneOfparentB"));
+        assertNotNull(filtered.getComponents().getSchemas().get("oneOfNestedParentA"));
+        assertNotNull(filtered.getComponents().getSchemas().get("oneOfNestedParentB"));
+        assertNotNull(filtered.getComponents().getSchemas().get("discriminatorParent"));
+        assertNotNull(filtered.getComponents().getSchemas().get("discriminatorMatchedChildA"));
+        assertNotNull(filtered.getComponents().getSchemas().get("discriminatorMatchedChildB"));
     }
 
     @Test

--- a/modules/swagger-core/src/test/resources/specFiles/petstore-3.0-v2-ticket-3303.json
+++ b/modules/swagger-core/src/test/resources/specFiles/petstore-3.0-v2-ticket-3303.json
@@ -1,366 +1,550 @@
 {
-    "openapi": "3.0.1",
-    "tags": [
-        {
-            "name": "pet",
-            "description": "Everything about your Pets",
-            "externalDocs": {
-                "description": "Find out more",
-                "url": "http://swagger.io"
-            }
-        },
-        {
-            "name": "user",
-            "description": "Operations about user"
-        },
-        {
-            "name": "store",
-            "description": "Access to Petstore orders",
-            "externalDocs": {
-                "description": "Find out more",
-                "url": "http://swagger.io"
-            }
-        }
-    ],
-    "paths": {
-        "/pet/{petId}": {
-            "get": {
-                "summary": "Find pet by ID",
-                "description": "Returns a pet when 0 < ID <= 10.  ID > 10 or nonintegers will simulate API error conditions",
-                "operationId": "getPetById",
-                "parameters": [
-                    {
-                        "name": "petId",
-                        "in": "path",
-                        "description": "ID of pet that needs to be fetched",
-                        "required": true,
-                        "schema": {
-                            "type": "integer",
-                            "format": "int64"
-                        }
-                    },
-                    {
-                        "name": "userId",
-                        "in": "path",
-                        "description": "ID of user to fetch",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "includeSecretDetails",
-                        "in": "query",
-                        "description": "secret: it's a secret",
-                        "required": false,
-                        "type": "boolean"
-                    }
-                ],
-                "responses": {
-                    "400": {
-                        "description": "Invalid ID supplied"
-                    },
-                    "404": {
-                        "description": "Pet not found"
-                    },
-                    "default": {
-                        "description": "The pet",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "string"
-                                }
-                            },
-                            "application/xml": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        },
-                        "headers": {
-                            "X-Rate-Limit-Limit": {
-                                "description": "The number of allowed requests in the current period",
-                                "schema": {
-                                    "$ref": "#/components/schemas/PetHeader"
-                                }
-                            },
-                            "X-Rate-Limit-Remaining": {
-                                "description": "The number of remaining requests in the current period",
-                                "schema": {
-                                    "type": "integer"
-                                }
-                            },
-                            "X-Rate-Limit-Reset": {
-                                "description": "The number of seconds left in the current period",
-                                "schema": {
-                                    "type": "integer"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/pet": {
-            "put": {
-                "tags": [
-                    "pet"
-                ],
-                "summary": "Update an existing pet",
-                "operationId": "updatePet",
-                "requestBody": {
-                    "description": "Pet object that needs to be added to the store",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Category"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "400": {
-                        "description": "Invalid ID supplied"
-                    },
-                    "404": {
-                        "description": "Pet not found"
-                    },
-                    "405": {
-                        "description": "Validation exception"
-                    }
-                }
-            },
-            "post": {
-                "summary": "Add a new pet to the store",
-                "operationId": "addPet",
-                "requestBody": {
-                    "description": "Pet object that needs to be added to the store",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Pet"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "405": {
-                        "description": "Invalid input"
-                    }
-                }
-            }
-        },
-        "/pet/findByStatus": {
-            "get": {
-                "summary": "Finds Pets by status",
-                "description": "Multiple status values can be provided with comma separated strings",
-                "operationId": "findPetsByStatus",
-                "parameters": [
-                    {
-                        "name": "status",
-                        "in": "query",
-                        "description": "Status values that need to be considered for filter",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "skip",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32"
-                        }
-                    },
-                    {
-                        "name": "limit",
-                        "in": "query",
-                        "schema": {
-                            "type": "integer",
-                            "format": "int32"
-                        }
-                    }
-                ],
-                "responses": {
-                    "400": {
-                        "description": "Invalid status value"
-                    },
-                    "default": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/pet/findByTags": {
-            "get": {
-                "summary": "Finds Pets by tags",
-                "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
-                "operationId": "findPetsByTags",
-                "parameters": [
-                    {
-                        "name": "tags",
-                        "in": "query",
-                        "description": "Tags to filter by",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "400": {
-                        "description": "Invalid tag value"
-                    },
-                    "default": {
-                        "description": "Pets matching criteria",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Pet"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+  "openapi": "3.0.1",
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
     },
-    "components": {
-        "schemas": {
-            "Category": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "xml": {
-                    "name": "Category"
-                }
-            },
-            "PetHeader": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "xml": {
-                    "name": "PetHeader"
-                }
-            },
-            "Tag": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "foo": {
-                        "$ref": "#/components/schemas/Foo"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "xml": {
-                    "name": "Tag"
-                }
-            },
-            "Foo": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "xml": {
-                    "name": "Foo"
-                }
-            },
-            "Bar": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "name": {
-                        "type": "string"
-                    }
-                },
-                "xml": {
-                    "name": "Bar"
-                }
-            },
-            "Pet": {
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "integer",
-                        "format": "int64"
-                    },
-                    "category": {
-                        "$ref": "#/components/schemas/Category"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "photoUrls": {
-                        "type": "array",
-                        "xml": {
-                            "wrapped": true
-                        },
-                        "items": {
-                            "type": "string",
-                            "xml": {
-                                "name": "photoUrl"
-                            }
-                        }
-                    },
-                    "tags": {
-                        "type": "array",
-                        "xml": {
-                            "wrapped": true
-                        },
-                        "items": {
-                            "$ref": "#/components/schemas/Tag",
-                            "xml": {
-                                "name": "tag"
-                            }
-                        }
-                    },
-                    "status": {
-                        "type": "string",
-                        "description": "pet status in the store",
-                        "enum": [
-                            "available,pending,sold"
-                        ]
-                    }
-                },
-                "xml": {
-                    "name": "Pet"
-                }
-            }
-        }
+    {
+      "name": "user",
+      "description": "Operations about user"
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
     }
+  ],
+  "paths": {
+    "/pet/{petId}": {
+      "get": {
+        "summary": "Find pet by ID",
+        "description": "Returns a pet when 0 < ID <= 10.  ID > 10 or nonintegers will simulate API error conditions",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "ID of user to fetch",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "includeSecretDetails",
+            "in": "query",
+            "description": "secret: it's a secret",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "default": {
+            "description": "The pet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            },
+            "headers": {
+              "X-Rate-Limit-Limit": {
+                "description": "The number of allowed requests in the current period",
+                "schema": {
+                  "$ref": "#/components/schemas/PetHeader"
+                }
+              },
+              "X-Rate-Limit-Remaining": {
+                "description": "The number of remaining requests in the current period",
+                "schema": {
+                  "type": "integer"
+                }
+              },
+              "X-Rate-Limit-Reset": {
+                "description": "The number of seconds left in the current period",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pet": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "operationId": "updatePet",
+        "requestBody": {
+          "description": "Pet object that needs to be added to the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Category"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet object that needs to be added to the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        }
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid status value"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid tag value"
+          },
+          "default": {
+            "description": "Pets matching criteria",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/polymorphic": {
+      "get": {
+        "summary": "polymorphic Objects response",
+        "responses": {
+          "400": {
+            "description": "Invalid status value"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/polymorphicRoot"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Category"
+        }
+      },
+      "PetHeader": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "PetHeader"
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "foo": {
+            "$ref": "#/components/schemas/Foo"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Tag"
+        }
+      },
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Foo"
+        }
+      },
+      "Bar": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Bar"
+        }
+      },
+      "allOfparentA": {
+        "type": "object",
+        "properties": {
+          "parentAStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "allOfparentB": {
+        "type": "object",
+        "properties": {
+          "parentAStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "anyOfparentA": {
+        "type": "object",
+        "properties": {
+          "parentCStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "anyOfparentB": {
+        "type": "object",
+        "properties": {
+          "parentCStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "oneOfparentA": {
+        "type": "object",
+        "properties": {
+          "parentBStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "oneOfparentB": {
+        "type": "object",
+        "properties": {
+          "parentBStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "oneOfNestedParentA": {
+        "type": "object",
+        "properties": {
+          "parentBStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "oneOfNestedParentB": {
+        "type": "object",
+        "properties": {
+          "parentBStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "discriminatorMatchedChildA": {
+        "type": "object",
+        "properties": {
+          "parentBStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "discriminatorMatchedChildB": {
+        "type": "object",
+        "properties": {
+          "parentBStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "discriminatorParent": {
+        "type": "object",
+        "properties": {
+          "parentBStuff": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "discriminator": {
+          "propertyName": "discriminatorKey",
+          "mapping": {
+            "A": "#/components/schemas/discriminatorMatchedChildA",
+            "B": "#/components/schemas/discriminatorMatchedChildB"
+          }
+        }
+      },
+      "allOfChild": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/allOfparentA"
+          },
+          {
+            "$ref": "#/components/schemas/allOfparentB"
+          }
+        ]
+      },
+      "anyOfChild": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/anyOfparentA"
+          },
+          {
+            "$ref": "#/components/schemas/anyOfparentB"
+          }
+        ]
+      },
+      "oneOfChild": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/oneOfparentA"
+          },
+          {
+            "$ref": "#/components/schemas/oneOfparentB"
+          },
+          {
+            "$ref": "#/components/schemas/oneOfChildNested"
+          }
+        ]
+      },
+      "oneOfChildNested": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/oneOfNestedParentB"
+          },
+          {
+            "$ref": "#/components/schemas/oneOfNestedParentA"
+          }
+        ]
+      },
+      "polymorphicRoot": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/oneOfChild"
+          },
+          {
+            "$ref": "#/components/schemas/allOfChild"
+          },
+          {
+            "$ref": "#/components/schemas/anyOfChild"
+          },
+          {
+            "$ref": "#/components/schemas/discriminatorParent"
+          }
+        ]
+      },
+      "Pet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "name": {
+            "type": "string"
+          },
+          "photoUrls": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "type": "string",
+              "xml": {
+                "name": "photoUrl"
+              }
+            }
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag",
+              "xml": {
+                "name": "tag"
+              }
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available,pending,sold"
+            ]
+          }
+        },
+        "xml": {
+          "name": "Pet"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
This takes care of #3345 and adds more tests for ensuring that compositional schemas are filtered correctly.