### PR TITLE
refs #3341 - add description to @ExampleObject annotation

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ExampleObject.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ExampleObject.java
@@ -77,4 +77,12 @@ public @interface ExampleObject {
      **/
     String ref() default "";
 
+    /**
+     * A description of the purpose or context of the example
+     *
+     * @since 2.0.11
+     * @return a description of the example
+     **/
+    String description() default "";
+
 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -335,6 +335,11 @@ public abstract class AnnotationsUtils {
             exampleObject.setSummary(example.summary());
         }
 
+        if (StringUtils.isNotBlank(example.description())) {
+            isEmpty = false;
+            exampleObject.setDescription(example.description());
+        }
+
         if (StringUtils.isNotBlank(example.externalValue())) {
             isEmpty = false;
             exampleObject.setExternalValue(example.externalValue());

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/examples/ExamplesTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/examples/ExamplesTest.java
@@ -158,6 +158,7 @@ public class ExamplesTest extends AbstractAnnotationTest {
                                 examples = {
                                         @ExampleObject(
                                                 name = "Default Request",
+                                                description = "Subscription Example Description",
                                                 value = "{\"subscriptionId\" : \"1\", \"subscriptionItem\" : {\"subscriptionItemId\" : \"2\"}}",
                                                 summary = "Subscription  Example")
                                 }

--- a/modules/swagger-jaxrs2/src/test/resources/examples/ParameterExample.yaml
+++ b/modules/swagger-jaxrs2/src/test/resources/examples/ParameterExample.yaml
@@ -31,7 +31,7 @@ paths:
             examples:
               Default Request:
                 summary: Subscription  Example
-                description: Default Request
+                description: Subscription Example Description
                 value:
                   subscriptionId: "1"
                   subscriptionItem:


### PR DESCRIPTION
introduces `@ExampleObject.description` annotation member, and resolves it when present, instead of populating `description` with the value of `@ExampleObject.name`