### PR TITLE
fix #3414 - fix enumsAsRef global property behavior

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -91,6 +91,10 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     public static final String SET_PROPERTY_OF_ENUMS_AS_REF = "enums-as-ref";
 
     public static boolean composedModelPropertiesAsSibling = System.getProperty(SET_PROPERTY_OF_COMPOSED_MODEL_AS_SIBLING) != null ? true : false;
+
+    /**
+     * Allows all enums to be resolved as a reference to a scheme added to the components section.
+     */
     public static boolean enumsAsRef = System.getProperty(SET_PROPERTY_OF_ENUMS_AS_REF) != null ? true : false;
 
     public ModelResolver(ObjectMapper mapper) {
@@ -322,10 +326,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 schema.setItems(model);
                 return schema;
             }
-            if (type.isEnumType() &&
-                    (resolvedSchemaAnnotation != null && resolvedSchemaAnnotation.enumAsRef()) ||
-                    ModelResolver.enumsAsRef
-            ) {
+            if (type.isEnumType() && shouldResolveEnumAsRef(resolvedSchemaAnnotation)) {
                 // Store off the ref and add the enum as a top-level model
                 context.defineModel(name, model, annotatedType, null);
                 // Return the model as a ref only property
@@ -866,6 +867,10 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         resolveDiscriminatorProperty(type, context, model);
 
         return model;
+    }
+
+    private boolean shouldResolveEnumAsRef(io.swagger.v3.oas.annotations.media.Schema resolvedSchemaAnnotation) {
+        return (resolvedSchemaAnnotation != null && resolvedSchemaAnnotation.enumAsRef()) || ModelResolver.enumsAsRef;
     }
 
     private Schema clone(Schema property) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
@@ -6,6 +6,7 @@ import io.swagger.v3.core.converter.ModelConverterContextImpl;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.core.oas.models.Model1979;
 import io.swagger.v3.core.oas.models.ModelWithEnumField;
 import io.swagger.v3.core.oas.models.ModelWithEnumProperty;
 import io.swagger.v3.core.oas.models.ModelWithEnumRefProperty;
@@ -137,6 +138,21 @@ public class EnumPropertyTest {
                 "  - PUBLIC\n" +
                 "  - SYSTEM\n" +
                 "  - INVITE_ONLY\n";
+        SerializationMatchers.assertEqualsToYaml(models, yaml);
+        ModelResolver.enumsAsRef = false;
+    }
+
+    @Test(description = "it should not affect non-enum models when the enumsAsRef property is enabled globally")
+    public void testEnumRefPropertyGlobalNotAffectingNonEnums() {
+        ModelResolver.enumsAsRef = true;
+        Schema schema = context.resolve(new AnnotatedType(Model1979.class));
+        final Map<String, Schema> models = context.getDefinedModels();
+        final String yaml = "Model1979:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    id:\n" +
+                "      type: string\n" +
+                "      nullable: true";
         SerializationMatchers.assertEqualsToYaml(models, yaml);
         ModelResolver.enumsAsRef = false;
     }


### PR DESCRIPTION
- Fixes if-statement in ModelResolver to not treat non-enum models as enums when enumsAsRef is globally enabled
- Adds a comment explaining the purpose of the enumsAsRef global property in ModelResolver