### PR TITLE
ref #3244 - keep existing ComposedSchema whenever it exists

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
@@ -20,13 +20,13 @@ import io.swagger.v3.oas.models.callbacks.Callback;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.headers.Header;
 import io.swagger.v3.oas.models.links.Link;
+import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -72,7 +72,16 @@ public class Components {
         if (this.schemas == null) {
             this.schemas = new LinkedHashMap<>();
         }
-        this.schemas.put(key, schemasItem);
+        Schema oldSchema = schemas.get(key);
+        if (null == oldSchema
+                || !(oldSchema instanceof ComposedSchema) && schemasItem instanceof ComposedSchema
+                || null == oldSchema.getDiscriminator() && null != schemasItem.getDiscriminator()
+                    && (!(oldSchema instanceof ComposedSchema) || schemasItem instanceof ComposedSchema)) {
+            // Only set the schema if it does not exist yet, we do not simplify it (replace a ComposedSchema with a normal Schema) or it is
+            // a working parent schema (having an appropriate discriminator). Do not replace an old composed schema having no discriminator
+            // with a non-composed schema having a discriminator.
+            this.schemas.put(key, schemasItem);
+        }
         return this;
     }
 


### PR DESCRIPTION
This PR

-  ignores schemas that overwrite an existing one whereas the existing one is a ComposedSchema and the new one is not
- allows to overwrite a ComposedSchema without a discriminator with a new ComposedSchema with a discriminator
- avoids re-resolution of an existing schema

All changes only avoid overwriting of composed schemas considering inheritance. They do not fix the cause for this behaviour! It would be much better to handle the composed schema before creating a replacement for it.