### PR TITLE
Re-ordering Stream APIs

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -770,9 +770,9 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             Class<?>[] oneOf = resolvedSchemaAnnotation.oneOf();
 
             List<Class<?>> allOfFiltered = Stream.of(allOf)
-                    .distinct()
                     .filter(c -> !this.shouldIgnoreClass(c))
                     .filter(c -> !(c.equals(Void.class)))
+                    .distinct()
                     .collect(Collectors.toList());
             allOfFiltered.forEach(c -> {
                 Schema allOfRef = context.resolve(new AnnotatedType().type(c).jsonViewAnnotation(annotatedType.getJsonViewAnnotation()));
@@ -788,9 +788,9 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             });
 
             List<Class<?>> anyOfFiltered = Stream.of(anyOf)
-                    .distinct()
                     .filter(c -> !this.shouldIgnoreClass(c))
                     .filter(c -> !(c.equals(Void.class)))
+                    .distinct()
                     .collect(Collectors.toList());
             anyOfFiltered.forEach(c -> {
                 Schema anyOfRef = context.resolve(new AnnotatedType().type(c).jsonViewAnnotation(annotatedType.getJsonViewAnnotation()));


### PR DESCRIPTION
We are conducting a research project on re-ordering Stream APIs for improving program execution speed.

Before and after re-ordering, we measured running time of tests which execute target Stream.
Command for running tests is : 
`time mvn -DfailIfNoTests=false -Dtest=CompositionTest test`

and the result is :
```
the order of Stream API      test running time
===============================================
distinct().filter()                9.728s
filter().distinct()                9.710s
```
