### PR TITLE
Relax Swagger Core 2.1.x OSGi constraints to allow usage of the Bean Validation API 1.1/2.0

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -35,6 +35,7 @@
                 <configuration>
                     <instructions>
                         <Automatic-Module-Name>io.swagger.v3.core</Automatic-Module-Name>
+                        <Import-Package>javax.validation.constraints;version="[1.1,3)",*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
### Background
Currently, Swagger Core depends on `javax.validation` API v1.1, strict. The OSGi manifest correctly includes the `javax.validation` API range as part of `Import-Package` instructions set: `javax.validation.constraints;version="[1.1,2)"`

### Problem
The `javax.validation` API v1.1 is superseded by v2.0 and is rarely used. The ongoing effort to migrate to the `Jakarta` artifacts (https://github.com/swagger-api/swagger-core/pull/3430) is a step in right direction, meantime the version range for OSGi deployments could be relaxed to include v2.0 as well: `javax.validation.constraints;version="[1.1,3)"`. 

```
 <Import-Package>javax.validation.constraints;version="[1.1,3)",*</Import-Package>
```

This is the only change in `MANIFEST.MF` (pretty minor) but it would actually relax the `javax.validation` version requirements and allow to use Swagger Core with Bean Validation 2.0 and/or with Jakarta artifacts inside OSGi container.

@frantuma @webron could you please take a look guys? It would also unblock Apache CXF 's team efforts to switch to Bean Validation 2.0.

Thank you!
