### PR TITLE
Test to show that required props are not working on RequestBody

### DIFF
--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -60,6 +60,7 @@ import io.swagger.v3.jaxrs2.resources.Ticket2806Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket2818Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket2848Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket3015Resource;
+import io.swagger.v3.jaxrs2.resources.TicketRequiredPropsResource;
 import io.swagger.v3.jaxrs2.resources.UserAnnotationResource;
 import io.swagger.v3.jaxrs2.resources.extensions.ExtensionsResource;
 import io.swagger.v3.jaxrs2.resources.extensions.OperationExtensionsResource;
@@ -110,6 +111,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import javax.ws.rs.core.MediaType;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -1191,6 +1193,23 @@ public class ReaderTest {
 
     }
 
+    @Test(description = "test required props from @RequestBody(@Content(@Schema)) annotation")
+    public void testRequiredProps() {
+        Reader reader = new Reader(new OpenAPI());
+        OpenAPI openAPI = reader.read(TicketRequiredPropsResource.class);
+        Paths paths = openAPI.getPaths();
+        assertEquals(paths.size(), 1);
+        PathItem pathItem = paths.get("/test/login");
+        assertNotNull(pathItem);
+        Operation operation = pathItem.getPut();
+        assertNotNull(operation);
+
+        io.swagger.v3.oas.models.media.MediaType type = operation.getRequestBody()
+                .getContent().get(MediaType.APPLICATION_FORM_URLENCODED);
+        assertNotNull(type.getSchema().getRequired());
+        assertEquals(type.getSchema().getRequired().size(), 2);
+    }
+
     @Test(description = "Responses with ref")
     public void testResponseWithRef() {
         Components components = new Components();
@@ -2060,7 +2079,7 @@ public class ReaderTest {
                 "          type: string\n";
         SerializationMatchers.assertEqualsToYaml(openAPI, yaml);
     }
-    
+
     @Test(description = "Filter class return type")
     public void testTicket3074() {
         Reader reader = new Reader(new OpenAPI());

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/TicketRequiredPropsResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/TicketRequiredPropsResource.java
@@ -1,0 +1,54 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.core.MediaType;
+
+@Path("test")
+public class TicketRequiredPropsResource {
+
+    @PUT
+    @Path("/login")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public void schemaImpl(
+            @BeanParam
+            @RequestBody(content = @Content(schema = @Schema(
+                    name = "login",
+                    requiredProperties = {"login", "password"}))) User user
+    ) {
+    }
+
+    public static class User {
+
+        @FormParam("login")
+        @Schema(required = true, name = "login")
+        private String login;
+
+        @FormParam("password")
+        @Schema(required = true, name = "password")
+        private String password;
+
+        public String getLogin() {
+            return login;
+        }
+
+        public void setLogin(String login) {
+            this.login = login;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+    }
+}


### PR DESCRIPTION
I'm trying to use required properties with RequestBody, but it seems that is not working as expected.

This test shows the two ways I'm trying to get it work:

- Using `requiredProperties` from `@Schema`
- And annotating the `User` class with `@Schema` and the `required` property set to true