### PR TITLE
Relax Swagger Core 1.6.x OSGi constraints to allow usage of the Bean Validation API 1.1/2.0

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -44,6 +44,7 @@
                             io.swagger.model,
                             io.swagger.util
                         </Export-Package>
+                        <Import-Package>javax.validation.constraints;version="[1.1,3)",*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/modules/swagger-hibernate-validations/pom.xml
+++ b/modules/swagger-hibernate-validations/pom.xml
@@ -45,6 +45,7 @@
                             io.swagger.config,
                             io.swagger.models
                         </Export-Package>
+                        <Import-Package>javax.validation.constraints;version="[1.1,3)",*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
### Background
Currently, Swagger Core depends on `javax.validation` API v1.1, strict. The OSGi manifest correctly includes the `javax.validation` API range as part of `Import-Package` instructions set: `javax.validation.constraints;version="[1.1,2)"`

### Problem
The `javax.validation` API v1.1 is superseded by v2.0 and is rarely used. The version range for OSGi deployments could be relaxed to include v2.0 as well: `javax.validation.constraints;version="[1.1,3)"`. 

```
 <Import-Package>javax.validation.constraints;version="[1.1,3)",*</Import-Package>
```

This is the only change in `MANIFEST.MF` (pretty minor) but it would actually relax the `javax.validation` version requirements and allow to use Swagger Core with Bean Validation 2.0 and/or with Jakarta artifacts inside OSGi container.

@frantuma this is backport of the https://github.com/swagger-api/swagger-core/pull/3445 to 1.6.x release branch. The latest Swagger Core 2.1.2 works like a charm.

Thank you!