### PR TITLE
Enabling fully qualified java class names 

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/TypeNameResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/TypeNameResolver.java
@@ -20,14 +20,15 @@ import java.util.Set;
 public class TypeNameResolver {
     public final static TypeNameResolver std = new TypeNameResolver();
     private boolean useFqn=false;
-
-    public void setUseFqn(boolean useFqn) {
-		this.useFqn = useFqn;
-	}
-
-	protected TypeNameResolver() {
+    
+    protected TypeNameResolver() {
     }
 
+    public void setUseFqn(boolean useFqn) {
+        this.useFqn = useFqn;
+    }
+
+	
     public String nameForType(JavaType type, Options... options) {
         return nameForType(type, options.length == 0 ? Collections.<Options>emptySet() :
                 EnumSet.copyOf(Arrays.asList(options)));
@@ -56,9 +57,9 @@ public class TypeNameResolver {
         return modelName == null ? getNameOfClass(cls) : modelName;
     }
 
-	private String getNameOfClass(Class<?> cls) {
-		return useFqn?cls.getName():cls.getSimpleName();
-	}
+    protected String getNameOfClass(Class<?> cls) {
+        return useFqn?cls.getName():cls.getSimpleName();
+    }
 
     protected String nameForGenericType(JavaType type, Set<Options> options) {
         final StringBuilder generic = new StringBuilder(nameForClass(type, options));

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/TypeNameResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/TypeNameResolver.java
@@ -19,8 +19,13 @@ import java.util.Set;
  */
 public class TypeNameResolver {
     public final static TypeNameResolver std = new TypeNameResolver();
+    private boolean useFqn=false;
 
-    protected TypeNameResolver() {
+    public void setUseFqn(boolean useFqn) {
+		this.useFqn = useFqn;
+	}
+
+	protected TypeNameResolver() {
     }
 
     public String nameForType(JavaType type, Options... options) {
@@ -42,14 +47,18 @@ public class TypeNameResolver {
 
     protected String nameForClass(Class<?> cls, Set<Options> options) {
         if (options.contains(Options.SKIP_API_MODEL)) {
-            return cls.getSimpleName();
+            return getNameOfClass(cls);
         }
 
         io.swagger.v3.oas.annotations.media.Schema mp = AnnotationsUtils.getSchemaDeclaredAnnotation(cls);
 
         final String modelName = mp == null ? null : StringUtils.trimToNull(mp.name());
-        return modelName == null ? cls.getSimpleName() : modelName;
+        return modelName == null ? getNameOfClass(cls) : modelName;
     }
+
+	private String getNameOfClass(Class<?> cls) {
+		return useFqn?cls.getName():cls.getSimpleName();
+	}
 
     protected String nameForGenericType(JavaType type, Set<Options> options) {
         final StringBuilder generic = new StringBuilder(nameForClass(type, options));


### PR DESCRIPTION
This change will enable  fully qualified java class names to be
displayed in api-docs and swagger-ui.
By default original behaviour will continue.
When needed fqns can be enabled by invoking
TypeNameResolver.std.setUseFqn(true);