### PR TITLE
feature: listing registered converters

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/converter/ModelConverters.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/converter/ModelConverters.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -40,6 +41,10 @@ public class ModelConverters {
 
     public void removeConverter(ModelConverter converter) {
         converters.remove(converter);
+    }
+
+    public List<ModelConverter> getConverters() {
+        return Collections.unmodifiableList(converters);
     }
 
     public void addPackageToSkip(String pkg) {


### PR DESCRIPTION
Sometimes, it's useful to be able to list registered converters to know if we need to add some converter. For example, we needed that for the springdoc-openapi project to allow tests running in parallel (avoiding them to all add the same converters when different spring contexts are present).