### PR TITLE
Update to Jackson 2.11.0

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/JsonDeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/JsonDeserializationTest.java
@@ -265,8 +265,10 @@ public class JsonDeserializationTest {
         final OpenAPI swagger = Yaml.mapper().readValue(jsonString, OpenAPI.class);
         assertNotNull(swagger);
         Map<String, Schema> props = swagger.getComponents().getSchemas().get("MyModel").getProperties();
-        assertTrue(Yaml.pretty().writeValueAsString(props.get("date")).contains("example: 2019-08-05"));
-        assertTrue(Yaml.pretty().writeValueAsString(props.get("dateTime")).contains("example: 2019-08-05T12:34:56Z"));
+        final String dateYaml = Yaml.mapper().writeValueAsString(props.get("date"));
+        assertEquals(Yaml.mapper().readTree(dateYaml).path("example").asText(), "2019-08-05");
+        final String dateTimeYaml = Yaml.mapper().writeValueAsString(props.get("dateTime"));
+        assertEquals(Yaml.mapper().readTree(dateTimeYaml).path("example").asText(), "2019-08-05T12:34:56Z");
 
     }
 

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/AbstractAnnotationTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/AbstractAnnotationTest.java
@@ -48,11 +48,11 @@ public abstract class AbstractAnnotationTest {
     }
 
     public void compareAsYaml(final String actualYaml, final String expectedYaml) throws IOException {
-        SerializationMatchers.assertEqualsToYaml(Yaml.mapper().readValue(actualYaml, OpenAPI.class), expectedYaml);
+        SerializationMatchers.assertEqualsToYaml(Yaml.mapper().readValue(actualYaml, JsonNode.class), expectedYaml);
     }
 
     public void compareAsJson(final String actualJson, final String expectedJson) throws IOException {
-        SerializationMatchers.assertEqualsToJson(Yaml.mapper().readValue(actualJson, OpenAPI.class), expectedJson);
+        SerializationMatchers.assertEqualsToJson(Yaml.mapper().readValue(actualJson, JsonNode.class), expectedJson);
     }
 
     protected String getOpenAPIAsString(final String file) throws IOException {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/callbacks/CallbackTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/callbacks/CallbackTest.java
@@ -17,11 +17,13 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 
+import java.io.IOException;
+
 import static org.testng.Assert.assertEquals;
 
 public class CallbackTest extends AbstractAnnotationTest {
     @Test
-    public void testSimpleCallback() {
+    public void testSimpleCallback() throws IOException {
         String openApiYAML = readIntoYaml(SimpleCallback.class);
         int start = openApiYAML.indexOf("/test:");
         int end = openApiYAML.length() - 1;
@@ -85,7 +87,7 @@ public class CallbackTest extends AbstractAnnotationTest {
                 "      properties:\n" +
                 "        subscriptionId:\n" +
                 "          type: string";
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     static class SimpleCallback {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/examples/ExamplesTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/examples/ExamplesTest.java
@@ -17,6 +17,8 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 
+import java.io.IOException;
+
 import static org.testng.Assert.assertEquals;
 
 public class ExamplesTest extends AbstractAnnotationTest {
@@ -342,7 +344,7 @@ public class ExamplesTest extends AbstractAnnotationTest {
 
 
     @Test
-    public void testFullExample() {
+    public void testFullExample() throws IOException {
         String openApiYAML = readIntoYaml(ExamplesTest.SimpleOperations.class);
         int start = openApiYAML.indexOf("/test:");
         int end = openApiYAML.length() - 1;
@@ -437,7 +439,7 @@ public class ExamplesTest extends AbstractAnnotationTest {
                 "          format: int32\n" +
                 "      xml:\n" +
                 "        name: User";
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     static class SimpleOperations {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/info/InfoTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/info/InfoTest.java
@@ -7,11 +7,13 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+
 import static org.testng.Assert.assertEquals;
 
 public class InfoTest extends AbstractAnnotationTest {
     @Test
-    public void testSimpleInfoGet() {
+    public void testSimpleInfoGet() throws IOException {
         String openApiYAML = readIntoYaml(InfoTest.ClassWithInfoAnnotation.class);
         int start = openApiYAML.indexOf("info:");
         int end = openApiYAML.length() - 1;
@@ -29,7 +31,7 @@ public class InfoTest extends AbstractAnnotationTest {
                 "  version: \"0.0\"";
         String extractedYAML = openApiYAML.substring(start, end);
 
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     @OpenAPIDefinition(info = @Info(

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/AnnotatedOperationMethodTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/AnnotatedOperationMethodTest.java
@@ -98,7 +98,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
     }
 
     @Test
-    public void testGetOperationWithResponsePayloadAndAlternateCodes() {
+    public void testGetOperationWithResponsePayloadAndAlternateCodes() throws IOException {
         String openApiYAML = readIntoYaml(GetOperationWithResponsePayloadAndAlternateCodes.class);
         int start = openApiYAML.indexOf("get:");
         int end = openApiYAML.indexOf("components:");
@@ -128,7 +128,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                 "                  externalValue: example of external value\n" +
                 "      deprecated: true\n";
 
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     static class GetOperationWithResponsePayloadAndAlternateCodes {
@@ -177,7 +177,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
     }
 
     @Test(description = "reads an operation with response examples defined")
-    public void testOperationWithResponseExamples() {
+    public void testOperationWithResponseExamples() throws IOException {
         String openApiYAML = readIntoYaml(GetOperationWithResponseExamples.class);
         int start = openApiYAML.indexOf("get:");
         int end = openApiYAML.indexOf("components:");
@@ -199,11 +199,11 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                 "                  description: basic\n" +
                 "                  value: '{id: 19877734}'\n" +
                 "      deprecated: true\n";
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     @Test(description = "reads an operation with response examples defined")
-    public void testOperationWithParameterExample() {
+    public void testOperationWithParameterExample() throws IOException {
         String openApiYAML = readIntoYaml(GetOperationWithParameterExample.class);
         int start = openApiYAML.indexOf("get:");
         int end = openApiYAML.indexOf("components:");
@@ -231,7 +231,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                 "                  description: basic\n" +
                 "                  value: '{id: 19877734}'\n" +
                 "      deprecated: true\n";
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     static class GetOperationWithResponseExamples {
@@ -1055,7 +1055,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
     }
 
     @Test
-    public void testSimpleGetOperationWithSecurity() {
+    public void testSimpleGetOperationWithSecurity() throws IOException {
 
         String openApiYAML = readIntoYaml(SimpleGetOperationWithSecurity.class);
         int start = openApiYAML.indexOf("get:");
@@ -1073,7 +1073,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                 "        - write:pets";
         String extractedYAML = openApiYAML.substring(start, end);
 
-        assertEquals(expectedYAML, extractedYAML);
+        compareAsYaml(expectedYAML, extractedYAML);
     }
 
     static class SimpleGetOperationWithSecurity {
@@ -1096,7 +1096,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
     }
 
     @Test
-    public void testSimpleGetOperationWithMultipleSecurity() {
+    public void testSimpleGetOperationWithMultipleSecurity() throws IOException {
 
         String openApiYAML = readIntoYaml(SimpleGetOperationWithMultipleSecurityScopes.class);
         int start = openApiYAML.indexOf("get:");
@@ -1115,7 +1115,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                 "        - read:pets";
         String extractedYAML = openApiYAML.substring(start, end);
 
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     static class SimpleGetOperationWithMultipleSecurityScopes {
@@ -1138,7 +1138,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
     }
 
     @Test
-    public void testSimpleGetOperationWithMultipleSecurityAnnotations() {
+    public void testSimpleGetOperationWithMultipleSecurityAnnotations() throws IOException {
 
         String openApiYAML = readIntoYaml(SimpleGetOperationWithMultipleSecurityAnnotations.class);
         int start = openApiYAML.indexOf("get:");
@@ -1160,7 +1160,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                 "      - api_key: []";
         String extractedYAML = openApiYAML.substring(start, end);
 
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     static class SimpleGetOperationWithMultipleSecurityAnnotations {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/MergedOperationTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/MergedOperationTest.java
@@ -12,6 +12,8 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 
+import java.io.IOException;
+
 import static org.testng.Assert.assertEquals;
 
 public class MergedOperationTest extends AbstractAnnotationTest {
@@ -34,10 +36,10 @@ public class MergedOperationTest extends AbstractAnnotationTest {
     }
 
     @Test(description = "shows how a method with parameters and no special annotations is processed")
-    public void testAnnotatedParameters() {
+    public void testAnnotatedParameters() throws IOException {
         String yaml = readIntoYaml(MethodWithParameters.class);
 
-        assertEquals(yaml,
+        compareAsYaml(yaml,
                 "openapi: 3.0.1\n" +
                         "paths:\n" +
                         "  /findAll:\n" +
@@ -80,7 +82,7 @@ public class MergedOperationTest extends AbstractAnnotationTest {
     }
 
     @Test(description = "shows how annotations can decorate an operation")
-    public void testPartiallyAnnotatedMethod() {
+    public void testPartiallyAnnotatedMethod() throws IOException {
         String yaml = readIntoYaml(MethodWithPartialAnnotation.class);
         String expectedYaml = "openapi: 3.0.1\n" +
                 "paths:\n" +
@@ -114,7 +116,7 @@ public class MergedOperationTest extends AbstractAnnotationTest {
                 "    SimpleResponse:\n" +
                 "      type: object\n";
 
-        assertEquals(yaml, expectedYaml);
+        compareAsYaml(yaml, expectedYaml);
     }
 
     static class MethodWithPartialAnnotation {
@@ -134,7 +136,7 @@ public class MergedOperationTest extends AbstractAnnotationTest {
     }
 
     @Test(description = "shows how a request body is passed")
-    public void testRequestBody() {
+    public void testRequestBody() throws IOException {
         String yaml = readIntoYaml(MethodWithRequestBody.class);
         String expectedYaml = "openapi: 3.0.1\n" +
                 "paths:\n" +
@@ -155,7 +157,7 @@ public class MergedOperationTest extends AbstractAnnotationTest {
                 "    InputValue:\n" +
                 "      type: object\n";
 
-        assertEquals(yaml, expectedYaml);
+        compareAsYaml(yaml, expectedYaml);
     }
 
     static class MethodWithRequestBody {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/parameters/ParametersTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/parameters/ParametersTest.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -41,7 +42,7 @@ public class ParametersTest extends AbstractAnnotationTest {
     }
 
     @Test
-    public void testParameters() {
+    public void testParameters() throws IOException {
         String openApiYAML = readIntoYaml(ParametersTest.SimpleOperations.class);
         int start = openApiYAML.indexOf("/test:");
         int end = openApiYAML.length() - 1;
@@ -129,11 +130,11 @@ public class ParametersTest extends AbstractAnnotationTest {
                 "      properties:\n" +
                 "        subscriptionId:\n" +
                 "          type: string";
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     @Test
-    public void testArraySchemaParameters() {
+    public void testArraySchemaParameters() throws IOException {
         String openApiYAML = readIntoYaml(ParametersTest.ArraySchemaOperations.class);
         int start = openApiYAML.indexOf("/test:");
         int end = openApiYAML.length() - 1;
@@ -169,11 +170,11 @@ public class ParametersTest extends AbstractAnnotationTest {
                 "      properties:\n" +
                 "        subscriptionId:\n" +
                 "          type: string";
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     @Test
-    public void testRepeatableParameters() {
+    public void testRepeatableParameters() throws IOException {
         String openApiYAML = readIntoYaml(ParametersTest.RepeatableParametersOperations.class);
         int start = openApiYAML.indexOf("/test:");
         int end = openApiYAML.length() - 1;
@@ -261,7 +262,7 @@ public class ParametersTest extends AbstractAnnotationTest {
                 "      properties:\n" +
                 "        subscriptionId:\n" +
                 "          type: string";
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
     }
 
     @Test(description = "JsonUnwrapped, JsonIgnore, JsonValue should be honoured")

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/pathItems/OperationsWithLinksTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/pathItems/OperationsWithLinksTest.java
@@ -292,7 +292,7 @@ public class OperationsWithLinksTest extends AbstractAnnotationTest {
     }
 
     @Test(description = "Shows creating simple links")
-    public void createOperationWithLinkReferences() {
+    public void createOperationWithLinkReferences() throws IOException {
         String openApiYAML = readIntoYaml(ClassWithOperationAndLinkReferences.class);
         int start = openApiYAML.indexOf("/users:");
         int end = openApiYAML.length() - 1;
@@ -327,7 +327,7 @@ public class OperationsWithLinksTest extends AbstractAnnotationTest {
                 "        username:\n" +
                 "          type: string";
         String extractedYAML = openApiYAML.substring(start, end);
-        assertEquals(extractedYAML, expectedYaml);
+        compareAsYaml(extractedYAML, expectedYaml);
     }
 
     static class ClassWithOperationAndLinkReferences {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/security/SecurityTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/security/SecurityTest.java
@@ -19,7 +19,7 @@ import static org.testng.Assert.assertEquals;
 
 public class SecurityTest extends AbstractAnnotationTest {
     @Test
-    public void testSecuritySheme() {
+    public void testSecuritySheme() throws IOException {
         String openApiYAML = readIntoYaml(SecurityTest.OAuth2SchemeOnClass.class);
         int start = openApiYAML.indexOf("components:");
         String extractedYAML = openApiYAML.substring(start, openApiYAML.length() - 1);
@@ -33,7 +33,7 @@ public class SecurityTest extends AbstractAnnotationTest {
                 "          authorizationUrl: http://url.com/auth\n" +
                 "          scopes:\n" +
                 "            write:pets: modify pets in your account";
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
 
     }
 
@@ -90,7 +90,7 @@ public class SecurityTest extends AbstractAnnotationTest {
     }
 
     @Test
-    public void testMultipleSecurityShemes() {
+    public void testMultipleSecurityShemes() throws IOException {
         String openApiYAML = readIntoYaml(SecurityTest.MultipleSchemesOnClass.class);
         int start = openApiYAML.indexOf("components:");
         String extractedYAML = openApiYAML.substring(start, openApiYAML.length() - 1);
@@ -108,12 +108,12 @@ public class SecurityTest extends AbstractAnnotationTest {
                 "          authorizationUrl: http://url.com/auth\n" +
                 "          scopes:\n" +
                 "            write:pets: modify pets in your account";
-        assertEquals(extractedYAML, expectedYAML);
+        compareAsYaml(extractedYAML, expectedYAML);
 
     }
 
     @Test
-    public void testTicket2767() {
+    public void testTicket2767() throws IOException {
         String openApiYAML = readIntoYaml(SecurityTest.Ticket2767.class);
         String expectedYAML = "openapi: 3.0.1\n" +
                 "info:\n" +
@@ -126,12 +126,12 @@ public class SecurityTest extends AbstractAnnotationTest {
                 "    basicAuth:\n" +
                 "      type: http\n" +
                 "      scheme: basic\n";
-        assertEquals(openApiYAML, expectedYAML);
+        compareAsYaml(openApiYAML, expectedYAML);
 
     }
 
     @Test
-    public void testTicket2767_2() {
+    public void testTicket2767_2() throws IOException {
         String openApiYAML = readIntoYaml(SecurityTest.Ticket2767_2.class);
         String expectedYAML = "openapi: 3.0.1\n" +
                 "info:\n" +
@@ -144,7 +144,7 @@ public class SecurityTest extends AbstractAnnotationTest {
                 "    api_key:\n" +
                 "      type: apiKey\n" +
                 "      name: API_KEY\n";
-        assertEquals(openApiYAML, expectedYAML);
+        compareAsYaml(openApiYAML, expectedYAML);
 
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
         <felix-version>4.2.1</felix-version>
         <servlet-api-version>4.0.3</servlet-api-version>
         <jersey2-version>2.26</jersey2-version>
-        <jackson-version>2.10.1</jackson-version>
+        <jackson-version>2.11.0</jackson-version>
         <logback-version>1.2.3</logback-version>
         <classgraph-version>4.8.65</classgraph-version>
         <guava-version>27.0.1-jre</guava-version>


### PR DESCRIPTION
* Update to Jackson 2.11.0
* Make tests independent of YAML formatting (whitespace, single/double quotes)

Refs #3554
Closes #3531