### PR TITLE
Take `@Deprecated` into account for operations

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -954,7 +954,10 @@ public class Reader implements OpenApiReader {
         }
 
         if (apiOperation != null) {
-            setOperationObjectFromApiOperationAnnotation(operation, apiOperation, methodProduces, classProduces, methodConsumes, classConsumes, jsonViewAnnotation);
+            boolean classOrMethodDeprecated = method.getDeclaringClass().isAnnotationPresent(Deprecated.class) || method.isAnnotationPresent(Deprecated.class);
+            setOperationObjectFromApiOperationAnnotation(
+                    operation, apiOperation, methodProduces, classProduces, methodConsumes,
+                    classConsumes, jsonViewAnnotation, classOrMethodDeprecated);
         }
 
         // apiResponses
@@ -1105,7 +1108,8 @@ public class Reader implements OpenApiReader {
                     classProduces,
                     methodConsumes,
                     classConsumes,
-                    jsonViewAnnotation);
+                    jsonViewAnnotation,
+                    false);
             setPathItemOperation(pathItemObject, callbackOperation.method(), callbackNewOperation);
         }
 
@@ -1154,7 +1158,8 @@ public class Reader implements OpenApiReader {
             Produces classProduces,
             Consumes methodConsumes,
             Consumes classConsumes,
-            JsonView jsonViewAnnotation) {
+            JsonView jsonViewAnnotation,
+            boolean classOrMethodDeprecated) {
         if (StringUtils.isNotBlank(apiOperation.summary())) {
             operation.setSummary(apiOperation.summary());
         }
@@ -1164,7 +1169,9 @@ public class Reader implements OpenApiReader {
         if (StringUtils.isNotBlank(apiOperation.operationId())) {
             operation.setOperationId(getOperationId(apiOperation.operationId()));
         }
-        if (apiOperation.deprecated()) {
+        if (classOrMethodDeprecated) {
+            operation.setDeprecated(true);
+        } else if (apiOperation.deprecated()) {
             operation.setDeprecated(apiOperation.deprecated());
         }
 

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/AnnotatedOperationMethodTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/operations/AnnotatedOperationMethodTest.java
@@ -412,6 +412,7 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                 "                $ref: '#/components/schemas/Pet'\n" +
                 "        \"400\":\n" +
                 "          description: Invalid tag value\n" +
+                "      deprecated: true\n" +
                 "  /pet/findByCategory/{category}:\n" +
                 "    get:\n" +
                 "      summary: Finds Pets by category\n" +
@@ -1180,6 +1181,80 @@ public class AnnotatedOperationMethodTest extends AbstractAnnotationTest {
                         @SecurityRequirement(
                                 name = "api_key",
                                 scopes = {}),})
+        @GET
+        @Path("/path")
+        public void simpleGet() {
+        }
+    }
+
+    @Test
+    public void testSimpleDeprecatedGetOperation() {
+        String openApiYAML = readIntoYaml(SimpleDeprecatedGetOperationTest.class);
+        int start = openApiYAML.indexOf("get:");
+        int end = openApiYAML.length() - 1;
+
+        String expectedYAML = "get:\n" +
+                "      summary: Deprecated get operation\n" +
+                "      description: Defines a deprecated get operation with no inputs and a complex\n" +
+                "      operationId: getWithNoParameters\n" +
+                "      responses:\n" +
+                "        \"200\":\n" +
+                "          description: voila!\n" +
+                "      deprecated: true";
+        String extractedYAML = openApiYAML.substring(start, end);
+
+        assertEquals(extractedYAML, expectedYAML);
+    }
+
+    static class SimpleDeprecatedGetOperationTest {
+        @Operation(
+                summary = "Deprecated get operation",
+                description = "Defines a deprecated get operation with no inputs and a complex",
+                operationId = "getWithNoParameters",
+                responses = {
+                        @ApiResponse(
+                                responseCode = "200",
+                                description = "voila!")
+                }
+        )
+        @GET
+        @Path("/path")
+        @Deprecated
+        public void deprecatedGet() {
+        }
+    }
+
+    @Test
+    public void testSimpleGetOperationInDeprecatedClass() {
+        String openApiYAML = readIntoYaml(DeprecatedSimpleGetOperationTest.class);
+        int start = openApiYAML.indexOf("get:");
+        int end = openApiYAML.length() - 1;
+
+        String expectedYAML = "get:\n" +
+                "      summary: Simple get operation in deprecated class\n" +
+                "      description: Defines a simple get operation in a deprecated class with no inputs\n" +
+                "      operationId: getWithNoParameters\n" +
+                "      responses:\n" +
+                "        \"200\":\n" +
+                "          description: voila!\n" +
+                "      deprecated: true";
+        String extractedYAML = openApiYAML.substring(start, end);
+
+        assertEquals(extractedYAML, expectedYAML);
+    }
+
+    @Deprecated
+    static class DeprecatedSimpleGetOperationTest {
+        @Operation(
+                summary = "Simple get operation in deprecated class",
+                description = "Defines a simple get operation in a deprecated class with no inputs",
+                operationId = "getWithNoParameters",
+                responses = {
+                        @ApiResponse(
+                                responseCode = "200",
+                                description = "voila!")
+                }
+        )
         @GET
         @Path("/path")
         public void simpleGet() {

--- a/modules/swagger-jaxrs2/src/test/resources/petstore/FullPetResource.yaml
+++ b/modules/swagger-jaxrs2/src/test/resources/petstore/FullPetResource.yaml
@@ -212,6 +212,7 @@ paths:
                 $ref: '#/components/schemas/Pet'
         "400":
           description: Invalid tag value
+      deprecated: true
   /complexcallback:
     get:
       summary: Simple get operation


### PR DESCRIPTION
Mark operations as deprecated which have been declared on a deprecated method or class using the `java.lang.Deprecated` annotation.

Fixes #3500