### PR TITLE
Fixes issue with multiple cookie values with same name when used by an filterClass. 

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/AbstractSpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/AbstractSpecFilter.java
@@ -16,42 +16,42 @@ import java.util.Optional;
 public abstract class AbstractSpecFilter implements OpenAPISpecFilter {
 
     @Override
-    public Optional<OpenAPI> filterOpenAPI(OpenAPI openAPI, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<OpenAPI> filterOpenAPI(OpenAPI openAPI, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         return Optional.of(openAPI);
     }
 
     @Override
-    public Optional<PathItem> filterPathItem(PathItem pathItem, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<PathItem> filterPathItem(PathItem pathItem, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         return Optional.of(pathItem);
     }
 
     @Override
-    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         return Optional.of(operation);
     }
 
     @Override
-    public Optional<Parameter> filterParameter(Parameter parameter, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Parameter> filterParameter(Parameter parameter, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         return Optional.of(parameter);
     }
 
     @Override
-    public Optional<RequestBody> filterRequestBody(RequestBody requestBody, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<RequestBody> filterRequestBody(RequestBody requestBody, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         return Optional.of(requestBody);
     }
 
     @Override
-    public Optional<ApiResponse> filterResponse(ApiResponse response, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<ApiResponse> filterResponse(ApiResponse response, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         return Optional.of(response);
     }
 
     @Override
-    public Optional<Schema> filterSchema(Schema schema, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Schema> filterSchema(Schema schema, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         return Optional.of(schema);
     }
 
     @Override
-    public Optional<Schema> filterSchemaProperty(Schema property, Schema schema, String propName, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Schema> filterSchemaProperty(Schema property, Schema schema, String propName, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         return Optional.of(property);
     }
 

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/OpenAPISpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/OpenAPISpecFilter.java
@@ -18,21 +18,21 @@ public interface OpenAPISpecFilter {
     Optional<OpenAPI> filterOpenAPI(
             OpenAPI openAPI,
             Map<String, List<String>> params,
-            Map<String, String> cookies,
+            Map<String, List<String>> cookies,
             Map<String, List<String>> headers);
 
     Optional<PathItem> filterPathItem(
             PathItem pathItem,
             ApiDescription api,
             Map<String, List<String>> params,
-            Map<String, String> cookies,
+            Map<String, List<String>> cookies,
             Map<String, List<String>> headers);
 
     Optional<Operation> filterOperation(
             Operation operation,
             ApiDescription api,
             Map<String, List<String>> params,
-            Map<String, String> cookies,
+            Map<String, List<String>> cookies,
             Map<String, List<String>> headers);
 
     Optional<Parameter> filterParameter(
@@ -40,7 +40,7 @@ public interface OpenAPISpecFilter {
             Operation operation,
             ApiDescription api,
             Map<String, List<String>> params,
-            Map<String, String> cookies,
+            Map<String, List<String>> cookies,
             Map<String, List<String>> headers);
 
     Optional<RequestBody> filterRequestBody(
@@ -48,7 +48,7 @@ public interface OpenAPISpecFilter {
             Operation operation,
             ApiDescription api,
             Map<String, List<String>> params,
-            Map<String, String> cookies,
+            Map<String, List<String>> cookies,
             Map<String, List<String>> headers);
 
     Optional<ApiResponse> filterResponse(
@@ -56,13 +56,13 @@ public interface OpenAPISpecFilter {
             Operation operation,
             ApiDescription api,
             Map<String, List<String>> params,
-            Map<String, String> cookies,
+            Map<String, List<String>> cookies,
             Map<String, List<String>> headers);
 
     Optional<Schema> filterSchema(
             Schema schema,
             Map<String, List<String>> params,
-            Map<String, String> cookies,
+            Map<String, List<String>> cookies,
             Map<String, List<String>> headers);
 
     Optional<Schema> filterSchemaProperty(
@@ -70,7 +70,7 @@ public interface OpenAPISpecFilter {
             Schema schema,
             String propName,
             Map<String, List<String>> params,
-            Map<String, String> cookies,
+            Map<String, List<String>> cookies,
             Map<String, List<String>> headers);
 
     boolean isRemovingUnreferencedDefinitions();

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 
 public class SpecFilter {
 
-    public OpenAPI filter(OpenAPI openAPI, OpenAPISpecFilter filter, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public OpenAPI filter(OpenAPI openAPI, OpenAPISpecFilter filter, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         OpenAPI filteredOpenAPI = filterOpenAPI(filter, openAPI, params, cookies, headers);
         if (filteredOpenAPI == null) {
             return filteredOpenAPI;
@@ -140,7 +140,7 @@ public class SpecFilter {
         return clone;
     }
 
-    protected OpenAPI filterOpenAPI(OpenAPISpecFilter filter, OpenAPI openAPI, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    protected OpenAPI filterOpenAPI(OpenAPISpecFilter filter, OpenAPI openAPI, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (openAPI != null) {
             Optional<OpenAPI> filteredOpenAPI = filter.filterOpenAPI(openAPI, params, cookies, headers);
             if (filteredOpenAPI.isPresent()) {
@@ -150,7 +150,7 @@ public class SpecFilter {
         return null;
     }
 
-    protected Operation filterOperation(OpenAPISpecFilter filter, Operation operation, String resourcePath, String key, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    protected Operation filterOperation(OpenAPISpecFilter filter, Operation operation, String resourcePath, String key, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (operation != null) {
             ApiDescription description = new ApiDescription(resourcePath, key);
             Optional<Operation> filteredOperation = filter.filterOperation(operation, description, params, cookies, headers);
@@ -206,7 +206,7 @@ public class SpecFilter {
         return null;
     }
 
-    protected PathItem filterPathItem(OpenAPISpecFilter filter, PathItem pathItem, String resourcePath, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    protected PathItem filterPathItem(OpenAPISpecFilter filter, PathItem pathItem, String resourcePath, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         ApiDescription description = new ApiDescription(resourcePath, null);
         Optional<PathItem> filteredPathItem = filter.filterPathItem(pathItem, description, params, cookies, headers);
         if (filteredPathItem.isPresent()) {
@@ -215,7 +215,7 @@ public class SpecFilter {
         return null;
     }
 
-    protected Parameter filterParameter(OpenAPISpecFilter filter, Operation operation, Parameter parameter, String resourcePath, String key, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    protected Parameter filterParameter(OpenAPISpecFilter filter, Operation operation, Parameter parameter, String resourcePath, String key, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (parameter != null) {
             ApiDescription description = new ApiDescription(resourcePath, key);
             Optional<Parameter> filteredParameter = filter.filterParameter(parameter, operation, description, params, cookies, headers);
@@ -227,7 +227,7 @@ public class SpecFilter {
 
     }
 
-    protected RequestBody filterRequestBody(OpenAPISpecFilter filter, Operation operation, RequestBody requestBody, String resourcePath, String key, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    protected RequestBody filterRequestBody(OpenAPISpecFilter filter, Operation operation, RequestBody requestBody, String resourcePath, String key, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (requestBody != null) {
             ApiDescription description = new ApiDescription(resourcePath, key);
             Optional<RequestBody> filteredRequestBody = filter.filterRequestBody(requestBody, operation, description, params, cookies, headers);
@@ -239,7 +239,7 @@ public class SpecFilter {
 
     }
 
-    protected ApiResponse filterResponse(OpenAPISpecFilter filter, Operation operation, ApiResponse response, String resourcePath, String key, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    protected ApiResponse filterResponse(OpenAPISpecFilter filter, Operation operation, ApiResponse response, String resourcePath, String key, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (response != null) {
             ApiDescription description = new ApiDescription(resourcePath, key);
             Optional<ApiResponse> filteredResponse = filter.filterResponse(response, operation, description, params, cookies, headers);
@@ -251,7 +251,7 @@ public class SpecFilter {
 
     }
 
-    protected Map<String, Schema> filterComponentsSchema(OpenAPISpecFilter filter, Map<String, Schema> schemasMap, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    protected Map<String, Schema> filterComponentsSchema(OpenAPISpecFilter filter, Map<String, Schema> schemasMap, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (schemasMap == null) {
             return null;
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/ChangeGetOperationsFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/ChangeGetOperationsFilter.java
@@ -17,7 +17,7 @@ public class ChangeGetOperationsFilter extends AbstractSpecFilter {
     private static final String CHANGED_OPERATION_DESCRIPTION = "Changing some attributes of the operation";
 
     @Override
-    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (GET.equals(api.getMethod())) {
             return Optional.of(operation.operationId(CHANGED_OPERATION_ID).description(CHANGED_OPERATION_DESCRIPTION));
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/InternalModelPropertiesRemoverFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/InternalModelPropertiesRemoverFilter.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  */
 public class InternalModelPropertiesRemoverFilter extends AbstractSpecFilter {
     @Override
-    public Optional<Schema> filterSchemaProperty(Schema property, Schema schema, String propName, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Schema> filterSchemaProperty(Schema property, Schema schema, String propName, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (StringUtils.isNotBlank(property.getName()) && property.getName().startsWith("_")) {
             if (headers != null && headers.containsKey("super-user")) {
                 return Optional.of(property);

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoCategoryRefSchemaFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoCategoryRefSchemaFilter.java
@@ -12,7 +12,7 @@ public class NoCategoryRefSchemaFilter extends AbstractSpecFilter {
     private static final String MODEL = "Category";
 
     @Override
-    public Optional<Schema> filterSchemaProperty(Schema property, Schema schema, String propName, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Schema> filterSchemaProperty(Schema property, Schema schema, String propName, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (schema == null || StringUtils.isBlank(schema.get$ref())) {
             return Optional.of(schema);
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoGetOperationsFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoGetOperationsFilter.java
@@ -15,7 +15,7 @@ public class NoGetOperationsFilter extends AbstractSpecFilter {
     private static final String GET = "GET";
 
     @Override
-    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (GET.equals(api.getMethod())) {
             return Optional.empty();
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoOpenAPIFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoOpenAPIFilter.java
@@ -15,7 +15,7 @@ public class NoOpenAPIFilter extends AbstractSpecFilter {
     public static final String VERSION = "3.0.1";
 
     @Override
-    public Optional<OpenAPI> filterOpenAPI(OpenAPI openAPI, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<OpenAPI> filterOpenAPI(OpenAPI openAPI, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (VERSION.equals(openAPI.getOpenapi())) {
             return Optional.empty();
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoParametersWithoutQueryInFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoParametersWithoutQueryInFilter.java
@@ -16,7 +16,7 @@ public class NoParametersWithoutQueryInFilter extends AbstractSpecFilter {
     private static final String QUERY_IN = "query";
 
     @Override
-    public Optional<Parameter> filterParameter(Parameter parameter, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Parameter> filterParameter(Parameter parameter, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (QUERY_IN.equals(parameter.getIn())) {
             return Optional.empty();
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoPathItemFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoPathItemFilter.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  **/
 public class NoPathItemFilter extends AbstractSpecFilter {
     @Override
-    public Optional<PathItem> filterPathItem(PathItem pathItem, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<PathItem> filterPathItem(PathItem pathItem, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (StringUtils.isBlank(pathItem.get$ref())) {
             return Optional.empty();
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoPetOperationsFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoPetOperationsFilter.java
@@ -16,7 +16,7 @@ public class NoPetOperationsFilter extends AbstractSpecFilter {
     public static final String PET_RESOURCE = "/pet";
 
     @Override
-    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (api.getPath().startsWith(PET_RESOURCE)) {
             return Optional.empty();
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoPetRefSchemaFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoPetRefSchemaFilter.java
@@ -12,7 +12,7 @@ public class NoPetRefSchemaFilter extends AbstractSpecFilter {
     private static final String MODEL = "Pet";
 
     @Override
-    public Optional<Schema> filterSchema(Schema schema, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Schema> filterSchema(Schema schema, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (schema == null || StringUtils.isBlank(schema.getXml().getName())) {
             return Optional.of(schema);
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoTagRefSchemaPropertyFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/NoTagRefSchemaPropertyFilter.java
@@ -12,7 +12,7 @@ public class NoTagRefSchemaPropertyFilter extends AbstractSpecFilter {
     private static final String MODEL = "Tag";
 
     @Override
-    public Optional<Schema> filterSchemaProperty(Schema property, Schema schema, String propName, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Schema> filterSchemaProperty(Schema property, Schema schema, String propName, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (property == null || StringUtils.isBlank(property.get$ref())) {
             return Optional.of(property);
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/RemoveInternalParamsFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/RemoveInternalParamsFilter.java
@@ -15,7 +15,7 @@ import java.util.Optional;
  **/
 public class RemoveInternalParamsFilter extends AbstractSpecFilter {
     @Override
-    public Optional<Parameter> filterParameter(Parameter parameter, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Parameter> filterParameter(Parameter parameter, Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (parameter.getDescription() != null && parameter.getDescription().startsWith("secret:")) {
             if (headers != null) {
                 if (headers.containsKey("super-user")) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/ReplaceGetOperationsFilter.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/resources/ReplaceGetOperationsFilter.java
@@ -17,7 +17,7 @@ public class ReplaceGetOperationsFilter extends AbstractSpecFilter {
     private static final String NEW_OPERATION_DESCRIPTION = "Replaced Operation";
 
     @Override
-    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+    public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
         if (GET.equals(api.getMethod())) {
             return Optional.of(new Operation().description(NEW_OPERATION_DESCRIPTION).
                     operationId(NEW_OPERATION_ID));

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/resources/BaseOpenApiResource.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/resources/BaseOpenApiResource.java
@@ -16,6 +16,7 @@ import javax.servlet.ServletConfig;
 import javax.ws.rs.core.Application;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -89,10 +90,10 @@ public abstract class BaseOpenApiResource {
         return output;
     }
 
-    private static Map<String, String> getCookies(HttpHeaders headers) {
-        Map<String, String> output = new HashMap<>();
+    private static Map<String, List<String>> getCookies(HttpHeaders headers) {
+        MultivaluedHashMap<String, String> output = new MultivaluedHashMap<>();
         if (headers != null) {
-            headers.getCookies().forEach((k, v) -> output.put(k, v.getValue()));
+            headers.getCookies().forEach((k, v) -> output.add(k, v.getValue()));
         }
         return output;
     }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ServletUtils.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ServletUtils.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.jaxrs2.util;
 
-import io.swagger.v3.jaxrs2.integration.OpenApiServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,7 +10,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -41,11 +39,11 @@ public class ServletUtils {
         return queryParameters;
     }
 
-    public static Map<String, String> getCookies(Cookie[] cookies) {
-        Map<String, String> mapOfCookies = new HashMap<>();
+    public static MultivaluedHashMap<String, String> getCookies(Cookie[] cookies) {
+        MultivaluedHashMap<String, String> mapOfCookies = new MultivaluedHashMap<>();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
-                mapOfCookies.put(cookie.getName(), cookie.getValue());
+                mapOfCookies.add(cookie.getName(), cookie.getValue());
             }
         }
         return mapOfCookies;

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -1302,7 +1302,7 @@ public class ReaderTest {
     class RefResponseFilter extends AbstractSpecFilter {
 
         @Override
-        public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers) {
+        public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params, Map<String, List<String>> cookies, Map<String, List<String>> headers) {
             if ("getWithPayloadResponse".equals(operation.getOperationId())) {
                 final ApiResponses apiResponses = (operation.getResponses() == null) ? new ApiResponses() : operation.getResponses();
                 apiResponses.addApiResponse("401", new ApiResponse().$ref("#/components/responses/invalidJWT"));
@@ -1472,7 +1472,7 @@ public class ReaderTest {
     class RefRequestBodyFilter extends AbstractSpecFilter {
         @Override
         public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params,
-                                                   Map<String, String> cookies, Map<String, List<String>> headers) {
+                                                   Map<String, List<String>> cookies, Map<String, List<String>> headers) {
             if ("sendPayload".equals(operation.getOperationId())) {
                 final RequestBody requestBody = new RequestBody();
                 requestBody.set$ref("#/components/requestBodies/User");
@@ -1583,7 +1583,7 @@ public class ReaderTest {
     class RefParameterFilter extends AbstractSpecFilter {
         @Override
         public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params,
-                                                   Map<String, String> cookies, Map<String, List<String>> headers) {
+                                                   Map<String, List<String>> cookies, Map<String, List<String>> headers) {
             if ("sendPayload".equals(operation.getOperationId())) {
                 final Parameter parameter = new Parameter();
                 parameter.set$ref("#/components/parameters/id");
@@ -1718,7 +1718,7 @@ public class ReaderTest {
     class RefExampleFilter extends AbstractSpecFilter {
         @Override
         public Optional<Operation> filterOperation(Operation operation, ApiDescription api, Map<String, List<String>> params,
-                                                   Map<String, String> cookies, Map<String, List<String>> headers) {
+                                                   Map<String, List<String>> cookies, Map<String, List<String>> headers) {
             if ("subscribe".equals(operation.getOperationId())) {
                 final Parameter parameter = new Parameter();
                 parameter.setExample(new Example().$ref("#/components/examples/Id"));

--- a/modules/swagger-maven-plugin/src/test/java/io/swagger/v3/plugin/maven/resources/MyFilter.java
+++ b/modules/swagger-maven-plugin/src/test/java/io/swagger/v3/plugin/maven/resources/MyFilter.java
@@ -18,7 +18,7 @@ public class MyFilter extends AbstractSpecFilter {
         public Optional<OpenAPI> filterOpenAPI(
                 OpenAPI openAPI,
                 Map<String, List<String>> params,
-                Map<String, String> cookies,
+                Map<String, List<String>> cookies,
                 Map<String, List<String>> headers) {
             openAPI.getInfo().setTitle("UPDATEDBYFILTER");
             return Optional.of(openAPI);
@@ -31,7 +31,7 @@ public class MyFilter extends AbstractSpecFilter {
                 Operation operation,
                 ApiDescription api,
                 Map<String, List<String>> params,
-                Map<String, String> cookies,
+                Map<String, List<String>> cookies,
                 Map<String, List<String>> headers) {
             // some processing
             return Optional.of(operation);


### PR DESCRIPTION
All methods in the OpenAPISpecFilter interface have a Map of cookies, but this map is only <String, String>. This PR refactors it into an Map<String, List<String>>, in the same way as params and headers are created. Because we can have cookies with the same name and multiple values.  This should fix #3582.