### PR TITLE
Backport from master to 1.5 for support to override enum values

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -14,7 +14,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.constraints.DecimalMax;

--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -1,6 +1,7 @@
 package io.swagger.jackson;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -13,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.constraints.DecimalMax;
@@ -30,7 +32,6 @@ import javax.xml.bind.annotation.XmlElementRefs;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSchema;
 
-import io.swagger.models.refs.RefFormat;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +43,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.annotation.ObjectIdGenerator;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
@@ -76,6 +78,7 @@ import io.swagger.models.properties.PropertyBuilder;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.models.properties.StringProperty;
 import io.swagger.models.properties.UUIDProperty;
+import io.swagger.models.refs.RefFormat;
 import io.swagger.util.AllowableValues;
 import io.swagger.util.AllowableValuesUtils;
 import io.swagger.util.BaseReaderUtils;
@@ -207,11 +210,38 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         final boolean useIndex = _mapper.isEnabled(SerializationFeature.WRITE_ENUMS_USING_INDEX);
         final boolean useToString = _mapper.isEnabled(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
 
+        Method jsonValueMethod = null;
+        Method[] methodList = propClass.getMethods();
+        for (Method m : methodList) {
+        	if (m.isAnnotationPresent(JsonValue.class) 
+        			&& m.getAnnotation(JsonValue.class).value()) {
+        		jsonValueMethod = m;
+        		break;
+        	}
+        }
+        
         @SuppressWarnings("unchecked")
         Class<Enum<?>> enumClass = (Class<Enum<?>>) propClass;
-        for (Enum<?> en : enumClass.getEnumConstants()) {
+        
+        Enum<?>[] enumConstants = enumClass.getEnumConstants();
+        String[] enumValues = _intr.findEnumValues(propClass, enumConstants, new String[enumConstants.length]);
+
+        for (Enum<?> en : enumConstants) {        
+            String s = null; 
+            String enumValue = enumValues[en.ordinal()];
+            if (jsonValueMethod != null) {
+            	Object invokeResult = ReflectionUtils.safeInvoke(jsonValueMethod, en);
+            	if (invokeResult != null) {
+            		s = invokeResult.toString();
+            	}
+            }
+
             String n;
-            if (useIndex) {
+            if (s != null) {
+                n = s;
+            } else if (enumValue != null) {
+                n = enumValue;
+            } else if (useIndex) {            
                 n = String.valueOf(en.ordinal());
             } else if (useToString) {
                 n = en.toString();

--- a/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;

--- a/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/util/ReflectionUtils.java
@@ -3,6 +3,7 @@ package io.swagger.util;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
@@ -11,14 +12,16 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.google.common.collect.Sets;
 
 public class ReflectionUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ReflectionUtils.class);
@@ -289,5 +292,14 @@ public class ReflectionUtils {
     public static boolean isVoid(Type type) {
         final Class<?> cls = TypeFactory.defaultInstance().constructType(type).getRawClass();
         return Void.class.isAssignableFrom(cls) || Void.TYPE.isAssignableFrom(cls);
+    }
+
+    public static Object safeInvoke(Method method, Object obj, Object... args) {
+        try {
+            return method.invoke(obj, args);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            return null;
+        }
+
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/EnumPropertyTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/EnumPropertyTest.java
@@ -3,19 +3,22 @@ package io.swagger;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Map;
+
+import javax.xml.validation.Schema;
+
+import org.testng.annotations.Test;
+
 import io.swagger.converter.ModelConverters;
 import io.swagger.matchers.SerializationMatchers;
 import io.swagger.models.Model;
 import io.swagger.models.ModelWithEnumField;
 import io.swagger.models.ModelWithEnumField2707;
 import io.swagger.models.ModelWithEnumProperty;
+import io.swagger.models.ModelWithJacksonEnumField;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.StringProperty;
-
-import org.testng.annotations.Test;
-
-import java.util.Arrays;
-import java.util.Map;
 
 public class EnumPropertyTest {
     @Test(description = "it should read a model with an enum property")
@@ -72,4 +75,25 @@ public class EnumPropertyTest {
         final StringProperty stringProperty = (StringProperty)enumProperty;
         assertEquals(stringProperty.getEnum(), Arrays.asList("PRIVATE", "PUBLIC", "SYSTEM", "INVITE_ONLY"));
     }
+    
+    @Test(description = "it should extract enum values from fields using JsonProperty and JsonValue")
+    public void testExtractJacksonEnumFields() {
+        final Map<String, Model> models = ModelConverters.getInstance().read(ModelWithJacksonEnumField.class);
+        final Model model = models.get("ModelWithJacksonEnumField");
+
+        final Property firstEnumProperty = (Property) model.getProperties().get("firstEnumValue");
+        assertTrue(firstEnumProperty instanceof StringProperty);
+        final StringProperty stringProperty = (StringProperty) firstEnumProperty;
+        assertEquals(stringProperty.getEnum(), Arrays.asList("p1", "p2", "SYSTEM", "INVITE_ONLY"));
+
+        final Property secondEnumProperty = (Property) model.getProperties().get("secondEnumValue");
+        assertTrue(secondEnumProperty instanceof StringProperty);
+        final StringProperty secondStringProperty = (StringProperty) secondEnumProperty;
+        assertEquals(secondStringProperty.getEnum(), Arrays.asList("one", "two", "three"));
+
+        final Property thirdEnumProperty = (Property) model.getProperties().get("thirdEnumValue");
+        assertTrue(thirdEnumProperty instanceof StringProperty);
+        final StringProperty thirdStringProperty = (StringProperty) thirdEnumProperty;
+        assertEquals(thirdStringProperty.getEnum(), Arrays.asList("2", "4", "6"));
+    }    
 }

--- a/modules/swagger-core/src/test/java/io/swagger/models/JacksonNumberValueEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/models/JacksonNumberValueEnum.java
@@ -1,0 +1,19 @@
+package io.swagger.models;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum JacksonNumberValueEnum {
+    FIRST(2),
+    SECOND(4),
+    THIRD(6);
+
+    private final int value;
+
+    JacksonNumberValueEnum(int value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public Number getValue() {
+        return value;
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/models/JacksonPropertyEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/models/JacksonPropertyEnum.java
@@ -1,0 +1,9 @@
+package io.swagger.models;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum JacksonPropertyEnum {
+    @JsonProperty("p1") PRIVATE,
+    @JsonProperty("p2") PUBLIC,
+    SYSTEM,
+    INVITE_ONLY
+}

--- a/modules/swagger-core/src/test/java/io/swagger/models/JacksonValueEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/models/JacksonValueEnum.java
@@ -1,0 +1,19 @@
+package io.swagger.models;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum JacksonValueEnum {
+    FIRST("one"),
+    SECOND("two"),
+    THIRD("three");
+
+    private final String value;
+
+    JacksonValueEnum(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/models/ModelWithJacksonEnumField.java
+++ b/modules/swagger-core/src/test/java/io/swagger/models/ModelWithJacksonEnumField.java
@@ -1,0 +1,7 @@
+package io.swagger.models;
+
+public class ModelWithJacksonEnumField {
+    public JacksonPropertyEnum firstEnumValue;
+    public JacksonValueEnum secondEnumValue;
+    public JacksonNumberValueEnum thirdEnumValue;
+}


### PR DESCRIPTION
This PR adds the feature from #3553 to the 1.5 branch. It allows to override enum values with the Jackson-specific annotations @JsonProperty or @JsonValue.

Since the 1.5 branch uses source target setting for Java 7, the `stream` API and `Optional` are not available. The code from the master branch was adapted to work without these. Except from that, the changes from the #3553 PR have all been ported into this PR, including the corresponding tests.

Closes #3616 