### PR TITLE
Fix omitted char in javadoc

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/tags/Tags.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/tags/Tags.java
@@ -37,7 +37,7 @@ public @interface Tags {
     /**
      * An array of Tag annotation objects which hold metadata for the API
      *
-     * @return rray of Tags
+     * @return array of Tags
      */
     Tag[] value() default {};
 


### PR DESCRIPTION
add a missing 'a' so that everything looks perfect now :)