### PR TITLE
Encoding form parameters via RequestBody on Method Level

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -709,7 +709,7 @@ public class Reader implements OpenApiReader {
                     isRequestBodyEmpty = false;
                 }
 
-                if (requestBodyParameter.getSchema() != null ) {
+                if (requestBodyParameter.getSchema() != null) {
                     Content content = processContent(null, requestBodyParameter.getSchema(), methodConsumes, classConsumes);
                     requestBody.setContent(content);
                     isRequestBodyEmpty = false;
@@ -718,9 +718,11 @@ public class Reader implements OpenApiReader {
                     //requestBody.setExtensions(extensions);
                     operation.setRequestBody(requestBody);
                 }
-            } else if( requestBodyParameter.getSchema() != null ) {
+            } else if (requestBodyParameter.getSchema() != null) {
+                // This allows us to use RequestBody on the method for encoding attributes
+                // it does make it so the
                 boolean formParams = false;
-                if( methodConsumes != null ) {
+                if(methodConsumes != null) {
                     for (String methodConsume : methodConsumes.value()) {
                         if ("application/x-www-form-urlencoded".equalsIgnoreCase(methodConsume)) {
                             formParams = true;
@@ -728,7 +730,7 @@ public class Reader implements OpenApiReader {
                         }
                     }
                 }
-                if ( !formParams && classConsumes != null ) {
+                if (!formParams && classConsumes != null) {
                     for (String classConsume : classConsumes.value()) {
                         if ("application/x-www-form-urlencoded".equalsIgnoreCase(classConsume)) {
                             formParams = true;
@@ -737,7 +739,7 @@ public class Reader implements OpenApiReader {
                     }
                 }
                 Content content = operation.getRequestBody().getContent();
-                if( formParams ) {
+                if(formParams) {
                     content.get("application/x-www-form-urlencoded").schema(requestBodyParameter.getSchema());
                 }
             }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -709,7 +709,7 @@ public class Reader implements OpenApiReader {
                     isRequestBodyEmpty = false;
                 }
 
-                if (requestBodyParameter.getSchema() != null) {
+                if (requestBodyParameter.getSchema() != null ) {
                     Content content = processContent(null, requestBodyParameter.getSchema(), methodConsumes, classConsumes);
                     requestBody.setContent(content);
                     isRequestBodyEmpty = false;
@@ -717,6 +717,28 @@ public class Reader implements OpenApiReader {
                 if (!isRequestBodyEmpty) {
                     //requestBody.setExtensions(extensions);
                     operation.setRequestBody(requestBody);
+                }
+            } else if( requestBodyParameter.getSchema() != null ) {
+                boolean formParams = false;
+                if( methodConsumes != null ) {
+                    for (String methodConsume : methodConsumes.value()) {
+                        if ("application/x-www-form-urlencoded".equalsIgnoreCase(methodConsume)) {
+                            formParams = true;
+                            break;
+                        }
+                    }
+                }
+                if ( !formParams && classConsumes != null ) {
+                    for (String classConsume : classConsumes.value()) {
+                        if ("application/x-www-form-urlencoded".equalsIgnoreCase(classConsume)) {
+                            formParams = true;
+                            break;
+                        }
+                    }
+                }
+                Content content = operation.getRequestBody().getContent();
+                if( formParams ) {
+                    content.get("application/x-www-form-urlencoded").schema(requestBodyParameter.getSchema());
                 }
             }
         }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -720,7 +720,8 @@ public class Reader implements OpenApiReader {
                 }
             } else if (requestBodyParameter.getSchema() != null) {
                 // This allows us to use RequestBody on the method for encoding attributes
-                // it does make it so the
+                // The particular methodology employed here means that all attributes
+                // outside of the schema for application/x-www-form-urlencoded are carried over.
                 boolean formParams = false;
                 if(methodConsumes != null) {
                     for (String methodConsume : methodConsumes.value()) {
@@ -738,8 +739,8 @@ public class Reader implements OpenApiReader {
                         }
                     }
                 }
-                Content content = operation.getRequestBody().getContent();
                 if(formParams) {
+                    Content content = operation.getRequestBody().getContent();
                     content.get("application/x-www-form-urlencoded").schema(requestBodyParameter.getSchema());
                 }
             }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/requests/RequestBodyTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/requests/RequestBodyTest.java
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
-import org.jboss.arquillian.test.spi.annotation.TestScoped;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.Consumes;
@@ -538,29 +537,45 @@ public class RequestBodyTest extends AbstractAnnotationTest {
                 "                id:\n" +
                 "                  type: array\n" +
                 "                  items:\n" +
-                "                    type: string\n"+
-                "                name:\n" +
-                "                  type: array\n" +
-                "                  items:\n" +
-                "                    type: string\n"+
-                "                gender:\n" +
-                "                  type: array\n" +
-                "                  items:\n" +
                 "                    type: string\n" +
-                "                pet:\n" +
+                "                name:\n" +
                 "                  type: array\n" +
                 "                  items:\n" +
                 "                    type: string\n" +
                 "            encoding:\n" +
                 "              id:\n" +
                 "                style: form\n" +
-                "                explode: true\n"+
+                "                explode: true\n" +
                 "              name:\n" +
                 "                style: form\n" +
-                "                explode: true\n"+
-                "              pet:\n" +
-                "                style: spaceDelimited\n" +
-                "              gender:\n" +
+                "                explode: true\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            application/json: {}\n" +
+                "  /things/sriracha:\n" +
+                "    post:\n" +
+                "      operationId: srirachaThing\n" +
+                "      requestBody:\n" +
+                "        content:\n" +
+                "          application/x-www-form-urlencoded:\n" +
+                "            schema:\n" +
+                "              type: object\n" +
+                "              properties:\n" +
+                "                id:\n" +
+                "                  type: array\n" +
+                "                  items:\n" +
+                "                    type: string\n"+
+                "                name:\n" +
+                "                  type: array\n" +
+                "                  items:\n" +
+                "                    type: string\n" +
+                "            encoding:\n" +
+                "              id:\n" +
+                "                style: form\n" +
+                "                explode: true\n" +
+                "              name:\n" +
                 "                style: form\n" +
                 "                explode: true\n" +
                 "      responses:\n" +
@@ -568,6 +583,7 @@ public class RequestBodyTest extends AbstractAnnotationTest {
                 "          description: default response\n" +
                 "          content:\n" +
                 "            application/json: {}";
+        ;
         compareAsYaml(UrlEncodedResourceWithEncodings.class, expectedYAML);
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/requests/RequestBodyTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/requests/RequestBodyTest.java
@@ -5,6 +5,7 @@ import io.swagger.v3.jaxrs2.annotations.AbstractAnnotationTest;
 import io.swagger.v3.jaxrs2.it.resources.MultiPartFileResource;
 import io.swagger.v3.jaxrs2.it.resources.OctetStreamResource;
 import io.swagger.v3.jaxrs2.it.resources.UrlEncodedResource;
+import io.swagger.v3.jaxrs2.it.resources.UrlEncodedResourceWithEncodings;
 import io.swagger.v3.jaxrs2.resources.model.Pet;
 import io.swagger.v3.jaxrs2.resources.model.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
+import org.jboss.arquillian.test.spi.annotation.TestScoped;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.Consumes;
@@ -520,4 +522,52 @@ public class RequestBodyTest extends AbstractAnnotationTest {
         compareAsYaml(MultiPartFileResource.class, expectedYAML);
     }
 
+    @Test
+    public void testUrlEncodedWithEncoding() throws IOException {
+        String expectedYAML = "openapi: 3.0.1\n" +
+                "paths:\n" +
+                "  /things/search:\n" +
+                "    post:\n" +
+                "      operationId: searchForThings\n" +
+                "      requestBody:\n" +
+                "        content:\n" +
+                "          application/x-www-form-urlencoded:\n" +
+                "            schema:\n" +
+                "              type: object\n" +
+                "              properties:\n" +
+                "                id:\n" +
+                "                  type: array\n" +
+                "                  items:\n" +
+                "                    type: string\n"+
+                "                name:\n" +
+                "                  type: array\n" +
+                "                  items:\n" +
+                "                    type: string\n"+
+                "                gender:\n" +
+                "                  type: array\n" +
+                "                  items:\n" +
+                "                    type: string\n" +
+                "                pet:\n" +
+                "                  type: array\n" +
+                "                  items:\n" +
+                "                    type: string\n" +
+                "            encoding:\n" +
+                "              id:\n" +
+                "                style: form\n" +
+                "                explode: true\n"+
+                "              name:\n" +
+                "                style: form\n" +
+                "                explode: true\n"+
+                "              pet:\n" +
+                "                style: spaceDelimited\n" +
+                "              gender:\n" +
+                "                style: form\n" +
+                "                explode: true\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            application/json: {}";
+        compareAsYaml(UrlEncodedResourceWithEncodings.class, expectedYAML);
+    }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/OpenApiResourceIT.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/OpenApiResourceIT.java
@@ -174,6 +174,71 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
             "                }\n" +
             "            }\n" +
             "        },\n" +
+            "        \"/things/search\": {\n" +
+            "            \"post\": {\n" +
+            "                \"operationId\": \"searchForThings\",\n" +
+            "                \"requestBody\": {\n"+
+            "                    \"content\": {\n"+
+            "                        \"application/x-www-form-urlencoded\": {\n"+
+            "                            \"schema\":{\n"+
+            "                                \"type\":\"object\",\n" +
+            "                                \"properties\": {\n" +
+            "                                    \"id\":{\n"+
+            "                                        \"type\":\"array\",\n" +
+            "                                        \"items\":{\n" +
+            "                                            \"type\":\"string\"\n" +
+            "                                        }\n" +
+            "                                    },\n" +
+            "                                    \"name\":{\n" +
+            "                                        \"type\":\"array\",\n" +
+            "                                        \"items\":{\n" +
+            "                                            \"type\":\"string\"\n" +
+            "                                        }\n" +
+            "                                    },\n" +
+            "                                    \"gender\":{\n" +
+            "                                        \"type\":\"array\",\n" +
+            "                                        \"items\":{\n" +
+            "                                            \"type\":\"string\"\n" +
+            "                                        }\n" +
+            "                                    },\n" +
+            "                                    \"pet\":{\n" +
+            "                                        \"type\":\"array\",\n" +
+            "                                        \"items\":{\n" +
+            "                                            \"type\":\"string\"\n" +
+            "                                        }\n"+
+            "                                    }\n" +
+            "                                }\n" +
+            "                            },\n" +
+            "                            \"encoding\":{\n" +
+            "                                \"id\":{\n" +
+            "                                    \"style\":\"form\",\n" +
+            "                                    \"explode\":true" +
+            "                                },\n" +
+            "                                \"name\":{\n" +
+            "                                    \"style\":\"form\",\n" +
+            "                                    \"explode\":true\n" +
+            "                                },\n" +
+            "                                \"gender\":{\n" +
+            "                                    \"style\":\"form\",\n" +
+            "                                    \"explode\":true\n" +
+            "                                },\n" +
+            "                                \"pet\":{\n" +
+            "                                    \"style\":\"spaceDelimited\"\n" +
+            "                                }\n" +
+            "                            }\n" +
+            "                        }\n" +
+            "                    }\n" +
+            "                },\n" +
+            "                \"responses\":{\n" +
+            "                    \"default\":{\n" +
+            "                        \"description\":\"default response\",\n" +
+            "                        \"content\":{\n" +
+            "                            \"application/json\":{}\n" +
+            "                        }\n" +
+            "                    }\n" +
+            "                }\n" +
+            "            }\n" +
+            "        },\n" +
             "        \"/users/add\": {\n" +
             "            \"post\": {\n" +
             "                \"operationId\": \"addUser\",\n" +
@@ -450,6 +515,48 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
             "          description: default response\n" +
             "          content:\n" +
             "            application/json: {}\n" +
+            "  /things/search:\n" +
+            "    post:\n" +
+            "      operationId: searchForThings\n" +
+            "      requestBody:\n" +
+            "        content:\n" +
+            "          application/x-www-form-urlencoded:\n" +
+            "            schema:\n" +
+            "              type: object\n" +
+            "              properties:\n" +
+            "                gender:\n" +
+            "                  type: array\n" +
+            "                  items:\n" +
+            "                    type: string\n" +
+            "                id:\n" +
+            "                  type: array\n" +
+            "                  items:\n" +
+            "                    type: string\n" +
+            "                name:\n" +
+            "                  type: array\n" +
+            "                  items:\n" +
+            "                    type: string\n" +
+            "                pet:\n" +
+            "                  type: array\n" +
+            "                  items:\n" +
+            "                    type: string\n" +
+            "            encoding:\n" +
+            "              gender:\n" +
+            "                style: form\n" +
+            "                explode: true\n" +
+            "              id:\n" +
+            "                style: form\n" +
+            "                explode: true\n" +
+            "              name:\n" +
+            "                style: form\n" +
+            "                explode: true\n" +
+            "              pet:\n" +
+            "                style: spaceDelimited\n" +
+            "      responses:\n" +
+            "        default:\n" +
+            "          description: default response\n" +
+            "          content:\n" +
+            "            application/json: {}\n" +
             "  /users/add:\n" +
             "    post:\n" +
             "      operationId: addUser\n" +
@@ -591,6 +698,10 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
                 .contentType(ContentType.JSON)
                 .extract()
                 .response().body().asString();
+
+        System.err.print("actualBody is: " + actualBody + "\n");
+        String json = formatJson(actualBody);
+        System.err.print("formatted actualBody is: " + json + "\n");
 
         compareAsJson(formatJson(actualBody), EXPECTED_JSON);
     }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/OpenApiResourceIT.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/OpenApiResourceIT.java
@@ -194,18 +194,6 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
             "                                        \"items\":{\n" +
             "                                            \"type\":\"string\"\n" +
             "                                        }\n" +
-            "                                    },\n" +
-            "                                    \"gender\":{\n" +
-            "                                        \"type\":\"array\",\n" +
-            "                                        \"items\":{\n" +
-            "                                            \"type\":\"string\"\n" +
-            "                                        }\n" +
-            "                                    },\n" +
-            "                                    \"pet\":{\n" +
-            "                                        \"type\":\"array\",\n" +
-            "                                        \"items\":{\n" +
-            "                                            \"type\":\"string\"\n" +
-            "                                        }\n"+
             "                                    }\n" +
             "                                }\n" +
             "                            },\n" +
@@ -217,13 +205,52 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
             "                                \"name\":{\n" +
             "                                    \"style\":\"form\",\n" +
             "                                    \"explode\":true\n" +
+            "                                }\n" +
+            "                            }\n" +
+            "                        }\n" +
+            "                    }\n" +
+            "                },\n" +
+            "                \"responses\":{\n" +
+            "                    \"default\":{\n" +
+            "                        \"description\":\"default response\",\n" +
+            "                        \"content\":{\n" +
+            "                            \"application/json\":{}\n" +
+            "                        }\n" +
+            "                    }\n" +
+            "                }\n" +
+            "            }\n" +
+            "        },\n" +
+            "        \"/things/sriracha\": {\n" +
+            "            \"post\": {\n" +
+            "                \"operationId\": \"srirachaThing\",\n" +
+            "                \"requestBody\": {\n"+
+            "                    \"content\": {\n"+
+            "                        \"application/x-www-form-urlencoded\": {\n"+
+            "                            \"schema\":{\n"+
+            "                                \"type\":\"object\",\n" +
+            "                                \"properties\": {\n" +
+            "                                    \"id\":{\n"+
+            "                                        \"type\":\"array\",\n" +
+            "                                        \"items\":{\n" +
+            "                                            \"type\":\"string\"\n" +
+            "                                        }\n" +
+            "                                    },\n" +
+            "                                    \"name\":{\n" +
+            "                                        \"type\":\"array\",\n" +
+            "                                        \"items\":{\n" +
+            "                                            \"type\":\"string\"\n" +
+            "                                        }\n" +
+            "                                    }\n" +
+            "                                }\n" +
+            "                            },\n" +
+            "                            \"encoding\":{\n" +
+            "                                \"id\":{\n" +
+            "                                    \"style\":\"form\",\n" +
+            "                                    \"explode\":true" +
             "                                },\n" +
-            "                                \"gender\":{\n" +
+            "                                \"name\":{\n" +
             "                                    \"style\":\"form\",\n" +
             "                                    \"explode\":true\n" +
-            "                                },\n" +
-            "                                \"pet\":{\n" +
-            "                                    \"style\":\"spaceDelimited\"\n" +
             "                                }\n" +
             "                            }\n" +
             "                        }\n" +
@@ -524,10 +551,6 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
             "            schema:\n" +
             "              type: object\n" +
             "              properties:\n" +
-            "                gender:\n" +
-            "                  type: array\n" +
-            "                  items:\n" +
-            "                    type: string\n" +
             "                id:\n" +
             "                  type: array\n" +
             "                  items:\n" +
@@ -536,22 +559,42 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
             "                  type: array\n" +
             "                  items:\n" +
             "                    type: string\n" +
-            "                pet:\n" +
-            "                  type: array\n" +
-            "                  items:\n" +
-            "                    type: string\n" +
             "            encoding:\n" +
-            "              gender:\n" +
-            "                style: form\n" +
-            "                explode: true\n" +
             "              id:\n" +
             "                style: form\n" +
             "                explode: true\n" +
             "              name:\n" +
             "                style: form\n" +
             "                explode: true\n" +
-            "              pet:\n" +
-            "                style: spaceDelimited\n" +
+            "      responses:\n" +
+            "        default:\n" +
+            "          description: default response\n" +
+            "          content:\n" +
+            "            application/json: {}\n" +
+            "  /things/sriracha:\n" +
+            "    post:\n" +
+            "      operationId: srirachaThing\n" +
+            "      requestBody:\n" +
+            "        content:\n" +
+            "          application/x-www-form-urlencoded:\n" +
+            "            schema:\n" +
+            "              type: object\n" +
+            "              properties:\n" +
+            "                id:\n" +
+            "                  type: array\n" +
+            "                  items:\n" +
+            "                    type: string\n" +
+            "                name:\n" +
+            "                  type: array\n" +
+            "                  items:\n" +
+            "                    type: string\n" +
+            "            encoding:\n" +
+            "              id:\n" +
+            "                style: form\n" +
+            "                explode: true\n" +
+            "              name:\n" +
+            "                style: form\n" +
+            "                explode: true\n" +
             "      responses:\n" +
             "        default:\n" +
             "          description: default response\n" +
@@ -698,10 +741,6 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
                 .contentType(ContentType.JSON)
                 .extract()
                 .response().body().asString();
-
-        System.err.print("actualBody is: " + actualBody + "\n");
-        String json = formatJson(actualBody);
-        System.err.print("formatted actualBody is: " + json + "\n");
 
         compareAsJson(formatJson(actualBody), EXPECTED_JSON);
     }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/resources/UrlEncodedResourceWithEncodings.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/resources/UrlEncodedResourceWithEncodings.java
@@ -1,0 +1,54 @@
+package io.swagger.v3.jaxrs2.it.resources;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterStyle;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Encoding;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static io.swagger.v3.oas.annotations.enums.Explode.FALSE;
+import static io.swagger.v3.oas.annotations.enums.Explode.TRUE;
+
+@Path("/things")
+@Produces("application/json")
+public class UrlEncodedResourceWithEncodings {
+
+    @POST
+    @Path( "/search" )
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @RequestBody( content = @Content( encoding = { @Encoding( name = "id", style = "FORM", explode = true ),
+            @Encoding( name = "name", style = "FORM", explode = true ),
+            @Encoding( name = "gender", style = "FORM", explode = true ),
+            @Encoding( name = "pet", style = "SPACE_DELIMITED" ) } ) )
+    public Response searchForThings( @BeanParam CompositeFormBody body ) {
+        return Response.status(200).entity("Searching for something").build();
+    }
+
+    public static class CompositeFormBody {
+        @Parameter( name = "id", style = ParameterStyle.FORM, explode = TRUE )
+        @FormParam( "id" )
+        public List<String> ids;
+
+        @Parameter( name = "name", style = ParameterStyle.FORM, explode = FALSE )
+        @FormParam( "name" )
+        public List<String> names;
+
+        @FormParam( "gender" )
+        @Parameter( name = "gender" )
+        public List<String> genders;
+
+        @FormParam( "pet" )
+        @Parameter( name = "pet", style = ParameterStyle.SPACEDELIMITED )
+        public List<String> pets;
+    }
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/resources/UrlEncodedResourceWithEncodings.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/resources/UrlEncodedResourceWithEncodings.java
@@ -10,6 +10,7 @@ import javax.ws.rs.BeanParam;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -24,31 +25,30 @@ import static io.swagger.v3.oas.annotations.enums.Explode.TRUE;
 public class UrlEncodedResourceWithEncodings {
 
     @POST
-    @Path( "/search" )
+    @Path("/search")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-    @RequestBody( content = @Content( encoding = { @Encoding( name = "id", style = "FORM", explode = true ),
-            @Encoding( name = "name", style = "FORM", explode = true ),
-            @Encoding( name = "gender", style = "FORM", explode = true ),
-            @Encoding( name = "pet", style = "SPACE_DELIMITED" ) } ) )
+    @RequestBody(content = @Content(encoding = {@Encoding(name = "id", style = "FORM", explode = true),
+            @Encoding(name = "name", style = "FORM", explode = true)}) )
     public Response searchForThings( @BeanParam CompositeFormBody body ) {
         return Response.status(200).entity("Searching for something").build();
     }
 
+    @POST
+    @Path("/sriracha")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @RequestBody(content = @Content(encoding = {@Encoding(name = "id", style = "FORM", explode = true),
+             @Encoding(name = "name", style = "FORM", explode = true )}))
+    public Response srirachaThing(@FormParam( "id" ) List<String> ids, @FormParam( "name" ) List<String> names) {
+        return Response.status(200).entity("Sriracha!").build();
+    }
+
     public static class CompositeFormBody {
-        @Parameter( name = "id", style = ParameterStyle.FORM, explode = TRUE )
-        @FormParam( "id" )
+        @Parameter(name = "id", style = ParameterStyle.FORM, explode = TRUE)
+        @FormParam("id")
         public List<String> ids;
 
-        @Parameter( name = "name", style = ParameterStyle.FORM, explode = FALSE )
-        @FormParam( "name" )
+        @Parameter(name = "name", style = ParameterStyle.FORM, explode = FALSE)
+        @FormParam("name")
         public List<String> names;
-
-        @FormParam( "gender" )
-        @Parameter( name = "gender" )
-        public List<String> genders;
-
-        @FormParam( "pet" )
-        @Parameter( name = "pet", style = ParameterStyle.SPACEDELIMITED )
-        public List<String> pets;
     }
 }


### PR DESCRIPTION
Maybe addresses part of #3282
Definitely addresses #3643

Allow setting encoding for form parameters via the `@RequestBody` annotation on method level. It could be more natural for users to allow using `@Parameter` on each `@FormParam`, but this way introduced a lot less complication to the code, esp in handling the params correctly both wrapped into and unwrapped from an `@BeanParam`.

I've also added a couple tests to make sure it is read properly.