### PR TITLE
refs #2845 - resolve  @JsonIgnoreProperties as property annotation (partial support)

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.introspect.AnnotationMap;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.util.Annotations;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
@@ -515,11 +516,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         final XmlAccessorType xmlAccessorTypeAnnotation = beanDesc.getClassAnnotations().get(XmlAccessorType.class);
 
         // see if @JsonIgnoreProperties exist
-        Set<String> propertiesToIgnore = new HashSet<>();
-        JsonIgnoreProperties ignoreProperties = beanDesc.getClassAnnotations().get(JsonIgnoreProperties.class);
-        if (ignoreProperties != null) {
-            propertiesToIgnore.addAll(Arrays.asList(ignoreProperties.value()));
-        }
+        Set<String> propertiesToIgnore = resolveIgnoredProperties(beanDesc.getClassAnnotations(), annotatedType.getCtxAnnotations());
 
         List<Schema> props = new ArrayList<>();
         Map<String, Schema> modelProps = new LinkedHashMap<>();
@@ -1797,6 +1794,31 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             return xml;
         }
         return null;
+    }
+
+    protected Set<String> resolveIgnoredProperties(Annotations a, Annotation[] annotations) {
+
+        Set<String> propertiesToIgnore = new HashSet<>();
+        JsonIgnoreProperties ignoreProperties = a.get(JsonIgnoreProperties.class);
+        if (ignoreProperties != null) {
+            propertiesToIgnore.addAll(Arrays.asList(ignoreProperties.value()));
+        }
+        propertiesToIgnore.addAll(resolveIgnoredProperties(annotations));
+        return propertiesToIgnore;
+    }
+
+    protected Set<String> resolveIgnoredProperties(Annotation[] annotations) {
+
+        Set<String> propertiesToIgnore = new HashSet<>();
+        if (annotations != null) {
+            for (Annotation annotation : annotations) {
+                if (annotation instanceof JsonIgnoreProperties) {
+                    propertiesToIgnore.addAll(Arrays.asList(((JsonIgnoreProperties) annotation).value()));
+                    break;
+                }
+            }
+        }
+        return propertiesToIgnore;
     }
 
     protected Integer resolveMinItems(AnnotatedType a, io.swagger.v3.oas.annotations.media.ArraySchema arraySchema) {


### PR DESCRIPTION
This partially addresses #2845 and #3442; please see [this comment in test](https://github.com/swagger-api/swagger-core/blob/master/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/JsonPropertyTest.java#L147) about further work needed to add full support