### PR TITLE
refs #3643, refs #3282, resolve @Parameter for form params

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -32,6 +32,7 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.callbacks.Callback;
 import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.Encoding;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
@@ -500,7 +501,8 @@ public class Reader implements OpenApiReader {
                                         operationParameters,
                                         paramAnnotations[i],
                                         type,
-                                        jsonViewAnnotationForRequestBody);
+                                        jsonViewAnnotationForRequestBody,
+                                        null);
                             }
                         }
                     } else {
@@ -529,15 +531,32 @@ public class Reader implements OpenApiReader {
                                         operationParameters,
                                         paramAnnotations[i],
                                         type,
-                                        jsonViewAnnotationForRequestBody);
+                                        jsonViewAnnotationForRequestBody,
+                                        null);
                             }
                         }
                     }
                     // if we have form parameters, need to merge them into single schema and use as request body..
                     if (!formParameters.isEmpty()) {
                         Schema mergedSchema = new ObjectSchema();
+                        Map<String, Encoding> encoding = new LinkedHashMap<>();
                         for (Parameter formParam: formParameters) {
+                            if (formParam.getExplode() != null || (formParam.getStyle() != null) && Encoding.StyleEnum.fromString(formParam.getStyle().toString()) != null) {
+                                Encoding e = new Encoding();
+                                if (formParam.getExplode() != null) {
+                                    e.explode(formParam.getExplode());
+                                }
+                                if (formParam.getStyle() != null  && Encoding.StyleEnum.fromString(formParam.getStyle().toString()) != null) {
+                                    e.style(Encoding.StyleEnum.fromString(formParam.getStyle().toString()));
+                                }
+                                encoding.put(formParam.getName(), e);
+                            }
                             mergedSchema.addProperties(formParam.getName(), formParam.getSchema());
+                            if (formParam.getSchema() != null &&
+                                    StringUtils.isNotBlank(formParam.getDescription()) &&
+                                    StringUtils.isBlank(formParam.getSchema().getDescription())) {
+                                formParam.getSchema().description(formParam.getDescription());
+                            }
                             if (null != formParam.getRequired() && formParam.getRequired()) {
                                 mergedSchema.addRequiredItem(formParam.getName());
                             }
@@ -551,7 +570,8 @@ public class Reader implements OpenApiReader {
                                 operationParameters,
                                 new Annotation[0],
                                 null,
-                                jsonViewAnnotationForRequestBody);
+                                jsonViewAnnotationForRequestBody,
+                                encoding);
 
                     }
                     if (!operationParameters.isEmpty()) {
@@ -659,7 +679,8 @@ public class Reader implements OpenApiReader {
                                       Consumes methodConsumes, Consumes classConsumes,
                                       List<Parameter> operationParameters,
                                       Annotation[] paramAnnotations, Type type,
-                                      JsonView jsonViewAnnotation) {
+                                      JsonView jsonViewAnnotation,
+                                      Map<String, Encoding> encoding) {
 
         io.swagger.v3.oas.annotations.parameters.RequestBody requestBodyAnnotation = getRequestBody(Arrays.asList(paramAnnotations));
         if (requestBodyAnnotation != null) {
@@ -717,6 +738,18 @@ public class Reader implements OpenApiReader {
                 if (!isRequestBodyEmpty) {
                     //requestBody.setExtensions(extensions);
                     operation.setRequestBody(requestBody);
+                }
+            }
+        }
+        if (operation.getRequestBody() != null &&
+                operation.getRequestBody().getContent() != null &&
+                encoding != null && !encoding.isEmpty()) {
+            Content content = operation.getRequestBody().getContent();
+            for (String mediaKey: content.keySet()) {
+                if (mediaKey.equals(javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED) ||
+                        mediaKey.equals(javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA)) {
+                    MediaType m = content.get(mediaKey);
+                    m.encoding(encoding);
                 }
             }
         }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -63,6 +63,7 @@ import io.swagger.v3.jaxrs2.resources.Ticket2848Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket3015Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket3587Resource;
 import io.swagger.v3.jaxrs2.resources.UploadResource;
+import io.swagger.v3.jaxrs2.resources.UrlEncodedResourceWithEncodings;
 import io.swagger.v3.jaxrs2.resources.UserAnnotationResource;
 import io.swagger.v3.jaxrs2.resources.extensions.ExtensionsResource;
 import io.swagger.v3.jaxrs2.resources.extensions.OperationExtensionsResource;
@@ -2343,6 +2344,76 @@ public class ReaderTest {
                 "        id:\n" +
                 "          type: integer\n" +
                 "          format: int32";
+        SerializationMatchers.assertEqualsToYaml(openAPI, yaml);
+    }
+
+    @Test
+    public void testRequestBodyEncoding() {
+        Reader reader = new Reader(new OpenAPI());
+
+        OpenAPI openAPI = reader.read(UrlEncodedResourceWithEncodings.class);
+        String yaml = "openapi: 3.0.1\n" +
+                "paths:\n" +
+                "  /things/search:\n" +
+                "    post:\n" +
+                "      operationId: searchForThings\n" +
+                "      requestBody:\n" +
+                "        content:\n" +
+                "          application/x-www-form-urlencoded:\n" +
+                "            schema:\n" +
+                "              type: object\n" +
+                "              properties:\n" +
+                "                id:\n" +
+                "                  type: array\n" +
+                "                  description: id param\n" +
+                "                  items:\n" +
+                "                    type: string\n" +
+                "                name:\n" +
+                "                  type: array\n" +
+                "                  items:\n" +
+                "                    type: string\n" +
+                "            encoding:\n" +
+                "              id:\n" +
+                "                style: form\n" +
+                "                explode: true\n" +
+                "              name:\n" +
+                "                style: form\n" +
+                "                explode: false\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            application/json: {}\n" +
+                "  /things/sriracha:\n" +
+                "    post:\n" +
+                "      operationId: srirachaThing\n" +
+                "      requestBody:\n" +
+                "        content:\n" +
+                "          application/x-www-form-urlencoded:\n" +
+                "            schema:\n" +
+                "              type: object\n" +
+                "              properties:\n" +
+                "                id:\n" +
+                "                  type: array\n" +
+                "                  description: id param\n" +
+                "                  items:\n" +
+                "                    type: string\n" +
+                "                name:\n" +
+                "                  type: array\n" +
+                "                  items:\n" +
+                "                    type: string\n" +
+                "            encoding:\n" +
+                "              id:\n" +
+                "                style: form\n" +
+                "                explode: true\n" +
+                "              name:\n" +
+                "                style: form\n" +
+                "                explode: false\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            application/json: {}\n";
         SerializationMatchers.assertEqualsToYaml(openAPI, yaml);
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/UrlEncodedResourceWithEncodings.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/UrlEncodedResourceWithEncodings.java
@@ -1,0 +1,48 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterStyle;
+
+import javax.ws.rs.BeanParam;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+import static io.swagger.v3.oas.annotations.enums.Explode.FALSE;
+import static io.swagger.v3.oas.annotations.enums.Explode.TRUE;
+
+@Path("/things")
+@Produces("application/json")
+public class UrlEncodedResourceWithEncodings {
+
+    @POST
+    @Path("/search")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response searchForThings( @BeanParam CompositeFormBody body ) {
+        return Response.status(200).entity("Searching for something").build();
+    }
+
+    @POST
+    @Path("/sriracha")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    public Response srirachaThing(
+            @Parameter(name = "id", style = ParameterStyle.FORM, explode = TRUE, description = "id param") @FormParam( "id" ) List<String> ids,
+            @Parameter(name = "name", style = ParameterStyle.FORM, explode = FALSE) @FormParam( "name" ) List<String> names) {
+        return Response.status(200).entity("Sriracha!").build();
+    }
+
+    public static class CompositeFormBody {
+        @Parameter(name = "id", style = ParameterStyle.FORM, explode = TRUE, description = "id param")
+        @FormParam("id")
+        public List<String> ids;
+
+        @Parameter(name = "name", style = ParameterStyle.FORM, explode = FALSE)
+        @FormParam("name")
+        public List<String> names;
+    }
+}

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Encoding.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Encoding.java
@@ -51,6 +51,15 @@ public class Encoding {
         public String toString() {
             return String.valueOf(value);
         }
+
+        public static StyleEnum fromString(String value) {
+            for (StyleEnum e : values()) {
+                if (e.value.equals(value)) {
+                    return e;
+                }
+            }
+            return null;
+        }
     }
 
     public Encoding() {


### PR DESCRIPTION
related to #3643, #3282 and [this question](https://community.smartbear.com/t5/Swagger-Open-Source-Tools/Specifying-Encoding-For-Form-Data-Parameters/m-p/206091#M1362)

replaces #3644, adds @Parameter support for `form` parameters, allowing to specify encoding and description, e.g.

```java
@Parameter(name = "id", style = ParameterStyle.FORM, explode = TRUE, description = "id param") @FormParam( "id" ) List<String> ids
```

see also related test