### PR TITLE
refs #3697 - fix @Hidden and @Schema.hidden resolving

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -37,6 +37,7 @@ import io.swagger.v3.core.util.ObjectMapperFactory;
 import io.swagger.v3.core.util.OptionalUtils;
 import io.swagger.v3.core.util.PrimitiveType;
 import io.swagger.v3.core.util.ReflectionUtils;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.media.ArraySchema;
@@ -568,7 +569,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
             PropertyMetadata md = propDef.getMetadata();
 
-            if (member != null && !ignore(member, xmlAccessorTypeAnnotation, propName, propertiesToIgnore)) {
+            if (member != null && !ignore(member, xmlAccessorTypeAnnotation, propName, propertiesToIgnore, propDef)) {
 
                 List<Annotation> annotationList = new ArrayList<>();
                 AnnotationMap annotationMap = member.getAllAnnotations();
@@ -966,12 +967,42 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     }
 
     protected boolean ignore(final Annotated member, final XmlAccessorType xmlAccessorTypeAnnotation, final String propName, final Set<String> propertiesToIgnore) {
+        return ignore (member, xmlAccessorTypeAnnotation, propName, propertiesToIgnore, null);
+    }
+
+    protected boolean hasHiddenAnnotation(Annotated annotated) {
+        return annotated.hasAnnotation(Hidden.class) || (
+                annotated.hasAnnotation(io.swagger.v3.oas.annotations.media.Schema.class) &&
+                annotated.getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class).hidden()
+        );
+    }
+
+    protected boolean ignore(final Annotated member, final XmlAccessorType xmlAccessorTypeAnnotation, final String propName, final Set<String> propertiesToIgnore, BeanPropertyDefinition propDef) {
         if (propertiesToIgnore.contains(propName)) {
             return true;
         }
         if (member.hasAnnotation(JsonIgnore.class)) {
             return true;
         }
+        if (hasHiddenAnnotation(member)) {
+            return true;
+        }
+
+        if (propDef != null) {
+            if (propDef.hasGetter() && hasHiddenAnnotation(propDef.getGetter())) {
+                return true;
+            }
+            if (propDef.hasSetter() && hasHiddenAnnotation(propDef.getSetter())) {
+                return true;
+            }
+            if (propDef.hasConstructorParameter() && hasHiddenAnnotation(propDef.getConstructorParameter())) {
+                return true;
+            }
+            if (propDef.hasField() && hasHiddenAnnotation(propDef.getField())) {
+                return true;
+            }
+        }
+
         if (xmlAccessorTypeAnnotation == null) {
             return false;
         }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/SwaggerAnnotationIntrospector.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/SwaggerAnnotationIntrospector.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import io.swagger.v3.core.util.AnnotationsUtils;
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -23,16 +22,6 @@ public class SwaggerAnnotationIntrospector extends AnnotationIntrospector {
     @Override
     public Version version() {
         return PackageVersion.VERSION;
-    }
-
-    @Override
-    public boolean hasIgnoreMarker(AnnotatedMember m) {
-        Schema ann = m.getAnnotation(Schema.class);
-        if (ann != null && ann.hidden()) {
-            return true;
-        }
-        Hidden hidden = m.getAnnotation(Hidden.class);
-        return hidden != null;
     }
 
     @Override

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3697Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3697Test.java
@@ -1,0 +1,31 @@
+package io.swagger.v3.core.resolving;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.core.resolving.resources.TestObject3697;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.Test;
+
+public class Ticket3697Test extends SwaggerTestBase {
+
+    @Test
+    public void testHiddenJsonCreator() throws Exception {
+
+        final ModelResolver modelResolver = new ModelResolver(mapper());
+
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        Schema model = context
+                .resolve(new AnnotatedType(TestObject3697.class));
+
+        SerializationMatchers.assertEqualsToYaml(context.getDefinedModels(), "TestObject3697:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    id:\n" +
+                "      type: integer\n" +
+                "      format: int64");
+    }
+
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/resources/TestObject3697.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/resources/TestObject3697.java
@@ -1,0 +1,30 @@
+package io.swagger.v3.core.resolving.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TestObject3697 {
+    @JsonProperty("id")
+    private final Long id;
+
+    @io.swagger.v3.oas.annotations.media.Schema(hidden = true)
+    @JsonProperty("hidden")
+    private final String hidden;
+
+
+    @JsonCreator
+    public TestObject3697(@JsonProperty("id") Long id,
+                          @io.swagger.v3.oas.annotations.media.Schema(hidden = true)
+                                              @JsonProperty("hidden") String hidden) {
+        this.id = id;
+        this.hidden = hidden;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getHidden() {
+        return hidden;
+    }
+}


### PR DESCRIPTION
This implements better support for `@Hidden` and `@Schema.hidden` resolving in POJOs properties, allowing to mark any accessor (field, getter, setter or constructor) with `@Hidden` not to include the property in the resulting spec. This differs from previous behaviour where all accessors needed to be marked, and as in #3697 in some cases this wasn't sufficient. 

Also fixes #3560