### PR TITLE
Add support for java.lang.Deprecated on classes and fields

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -173,6 +173,12 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             beanDesc = recurBeanDesc;
         }
 
+        final Boolean deprecated;
+        if (beanDesc.getClassAnnotations().has(Deprecated.class)) {
+            deprecated = beanDesc.getClassAnnotations().has(io.swagger.v3.oas.annotations.media.Schema.class) ? null : true;
+        } else {
+            deprecated = null;
+        }
 
         String name = annotatedType.getName();
         if (StringUtils.isBlank(name)) {
@@ -190,12 +196,13 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         // if we have a ref we don't consider anything else
         if (resolvedSchemaAnnotation != null &&
                 StringUtils.isNotEmpty(resolvedSchemaAnnotation.ref())) {
+            Schema schema = new Schema().$ref(resolvedSchemaAnnotation.ref()).name(name).deprecated(deprecated);
             if (resolvedArrayAnnotation == null) {
-                return new Schema().$ref(resolvedSchemaAnnotation.ref()).name(name);
+                return schema;
             } else {
-                ArraySchema schema = new ArraySchema();
-                resolveArraySchema(annotatedType, schema, resolvedArrayAnnotation);
-                return schema.items(new Schema().$ref(resolvedSchemaAnnotation.ref()).name(name));
+                ArraySchema arraySchema = new ArraySchema();
+                resolveArraySchema(annotatedType, arraySchema, resolvedArrayAnnotation);
+                return arraySchema.items(schema);
             }
         }
 
@@ -288,7 +295,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         if (model == null) {
             PrimitiveType primitiveType = PrimitiveType.fromType(type);
             if (primitiveType != null) {
-                model = PrimitiveType.fromType(type).createProperty();
+                model = primitiveType.createProperty();
                 isPrimitive = true;
             }
         }
@@ -318,7 +325,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         }
 
         if ("Object".equals(name)) {
-            return new Schema();
+            return new Schema().deprecated(deprecated);
         }
 
         if (isPrimitive) {
@@ -341,12 +348,12 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 // Store off the ref and add the enum as a top-level model
                 context.defineModel(name, model, annotatedType, null);
                 // Return the model as a ref only property
-                model = new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + name);
+                model = new Schema().$ref(Components.COMPONENTS_SCHEMAS_REF + name).deprecated(deprecated);
             }
             return model;
         }
 
-        /**
+        /*
          * --Preventing parent/child hierarchy creation loops - Comment 1--
          * Creating a parent model will result in the creation of child models. Creating a child model will result in
          * the creation of a parent model, as per the second If statement following this comment.
@@ -361,6 +368,9 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         Schema resolvedModel = context.resolve(annotatedType);
         if (resolvedModel != null) {
             if (name != null && name.equals(resolvedModel.getName())) {
+                if (resolvedModel.getDeprecated() == null) {
+                    resolvedModel.setDeprecated(deprecated);
+                }
                 return resolvedModel;
             }
         }
@@ -377,7 +387,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                     .jsonViewAnnotation(annotatedType.getJsonViewAnnotation())
                     .propertyName(annotatedType.getPropertyName())
                     .skipOverride(true);
-            return context.resolve(aType);
+            Schema schema = context.resolve(aType);
+            if (schema.getDeprecated() == null) {
+                schema.setDeprecated(deprecated);
+            }
+            return schema;
         }
 
         List<Class<?>> composedSchemaReferencedClasses = getComposedSchemaReferencedClasses(type.getRawClass(), annotatedType.getCtxAnnotations(), resolvedSchemaAnnotation);
@@ -488,16 +502,21 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         } else if (isComposedSchema) {
             model = new ComposedSchema()
                     .type("object")
-                    .name(name);
+                    .name(name)
+                    .deprecated(deprecated);
         } else {
             AnnotatedType aType = OptionalUtils.unwrapOptional(annotatedType);
             if (aType != null) {
                 model = context.resolve(aType);
+                if (model.getDeprecated() == null) {
+                    model.setDeprecated(deprecated);
+                }
                 return model;
             } else {
                 model = new Schema()
                         .type("object")
-                        .name(name);
+                        .name(name)
+                        .deprecated(deprecated);
             }
         }
 
@@ -646,7 +665,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                         handleUnwrapped(props, context.resolve(t), uw.prefix(), uw.suffix());
                         return null;
                     } else {
-                        return new Schema();
+                        return new Schema().deprecated(deprecated);
                         //t.jsonUnwrappedHandler(null);
                         //return context.resolve(t);
                     }
@@ -710,7 +729,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             model.setProperties(modelProps);
         }
 
-        /**
+        /*
          * --Preventing parent/child hierarchy creation loops - Comment 2--
          * Creating a parent model will result in the creation of child models, as per the first If statement following
          * this comment. Creating a child model will result in the creation of a parent model, as per the second If
@@ -729,10 +748,10 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             context.defineModel(name, model, annotatedType, null);
         }
 
-        /**
+        /*
          * This must be done after model.setProperties so that the model's set
          * of properties is available to filter from any subtypes
-         **/
+         */
         if (!resolveSubtypes(model, beanDesc, context)) {
             model.setDiscriminator(null);
         }
@@ -865,6 +884,10 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         }
 
         resolveDiscriminatorProperty(type, context, model);
+
+        if (model.getDeprecated() == null) {
+            model.setDeprecated(deprecated);
+        }
 
         return model;
     }
@@ -1727,6 +1750,13 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     protected Boolean resolveDeprecated(Annotated a, Annotation[] annotations, io.swagger.v3.oas.annotations.media.Schema schema) {
         if (schema != null && schema.deprecated()) {
             return schema.deprecated();
+        }
+        if (annotations != null) {
+            for (Annotation annotation : annotations) {
+                if (Deprecated.class.equals(annotation.annotationType())) {
+                    return true;
+                }
+            }
         }
         return null;
     }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/ModelConverterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/ModelConverterTest.java
@@ -7,6 +7,9 @@ import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.matchers.SerializationMatchers;
 import io.swagger.v3.core.oas.models.Cat;
 import io.swagger.v3.core.oas.models.ClientOptInput;
+import io.swagger.v3.core.oas.models.DeprecatedModel;
+import io.swagger.v3.core.oas.models.DeprecatedSchemaModel;
+import io.swagger.v3.core.oas.models.DeprecatedWithoutDeprecatedSchemaModel;
 import io.swagger.v3.core.oas.models.Employee;
 import io.swagger.v3.core.oas.models.EmptyModel;
 import io.swagger.v3.core.oas.models.JacksonReadonlyModel;
@@ -15,6 +18,7 @@ import io.swagger.v3.core.oas.models.Model1155;
 import io.swagger.v3.core.oas.models.ModelPropertyName;
 import io.swagger.v3.core.oas.models.ModelWithAltPropertyName;
 import io.swagger.v3.core.oas.models.ModelWithApiModel;
+import io.swagger.v3.core.oas.models.ModelWithDeprecation;
 import io.swagger.v3.core.oas.models.ModelWithEnumArray;
 import io.swagger.v3.core.oas.models.ModelWithFormattedStrings;
 import io.swagger.v3.core.oas.models.ModelWithNumbers;
@@ -410,5 +414,49 @@ public class ModelConverterTest {
     abstract class AnnotatedBaseClass {
         @JsonProperty
         public abstract String field();
+    }
+
+    @Test(description = "it should honor the @Deprecated annotation on fields and getters")
+    public void honorApiModelWithDeprecatedFields() {
+        final Map<String, Schema> schemas = readAll(ModelWithDeprecation.class);
+        assertEquals(schemas.size(), 1);
+        Schema schema = schemas.values().iterator().next();
+        Map<String, Schema> properties = schema.getProperties();
+        assertEquals(properties.size(), 4);
+        assertNull(properties.get("fullName").getDeprecated());
+        assertNotNull(properties.get("lastName").getDeprecated());
+        assertTrue(properties.get("lastName").getDeprecated());
+        assertNotNull(properties.get("firstName").getDeprecated());
+        assertTrue(properties.get("firstName").getDeprecated());
+        assertNotNull(properties.get("middleName").getDeprecated());
+        assertTrue(properties.get("middleName").getDeprecated());
+    }
+
+    @Test(description = "it should honor the @Deprecated annotation on model classes")
+    public void honorApiModelWithDeprecatedAnnotation() {
+        @SuppressWarnings("deprecation")
+        final Map<String, Schema> schemas = readAll(DeprecatedModel.class);
+        assertEquals(schemas.size(), 1);
+        Schema schema = schemas.values().iterator().next();
+        assertNotNull(schema.getDeprecated());
+        assertTrue(schema.getDeprecated());
+    }
+
+    @Test(description = "it should honor the @Schema annotation on model classes")
+    public void honorApiModelWithSchemaDeprecatedAnnotation() {
+        final Map<String, Schema> schemas = readAll(DeprecatedSchemaModel.class);
+        assertEquals(schemas.size(), 1);
+        Schema schema = schemas.values().iterator().next();
+        assertNotNull(schema.getDeprecated());
+        assertTrue(schema.getDeprecated());
+    }
+
+    @Test(description = "it should prioritize the @Schema annotation on model classes before @Deprecated")
+    public void honorDeprecatedApiModelWithoutSchemaDeprecatedAnnotation() {
+        @SuppressWarnings("deprecation")
+        final Map<String, Schema> schemas = readAll(DeprecatedWithoutDeprecatedSchemaModel.class);
+        assertEquals(schemas.size(), 1);
+        Schema schema = schemas.values().iterator().next();
+        assertNull(schema.getDeprecated());
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/DeprecatedModel.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/DeprecatedModel.java
@@ -1,0 +1,5 @@
+package io.swagger.v3.core.oas.models;
+
+@Deprecated
+public class DeprecatedModel {
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/DeprecatedSchemaModel.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/DeprecatedSchemaModel.java
@@ -1,0 +1,7 @@
+package io.swagger.v3.core.oas.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(deprecated = true)
+public class DeprecatedSchemaModel {
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/DeprecatedWithoutDeprecatedSchemaModel.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/DeprecatedWithoutDeprecatedSchemaModel.java
@@ -1,0 +1,8 @@
+package io.swagger.v3.core.oas.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Deprecated
+@Schema(deprecated = false)
+public class DeprecatedWithoutDeprecatedSchemaModel {
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithDeprecation.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithDeprecation.java
@@ -1,0 +1,18 @@
+package io.swagger.v3.core.oas.models;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ModelWithDeprecation {
+    public String fullName;
+    @Deprecated
+    public String lastName;
+    private String firstName;
+    @Schema(deprecated = true)
+    public String middleName;
+
+    @Deprecated
+    public String getFirstName() {
+        return firstName;
+    }
+}


### PR DESCRIPTION
The `@Deprecated` annotation hasn't been taken into account for setting the `deprecated` attribute of schemas.

This change set adds support for the `@Deprecated` annotation, for example a class with this annotation will result in a schema with the attribute `deprecated = true`.

Refs #2506 (possibly)