### PR TITLE
Fix unstable ordering of urls in gradle resolve task

### DIFF
--- a/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/tasks/ResolveTask.java
+++ b/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/tasks/ResolveTask.java
@@ -1,5 +1,6 @@
 package io.swagger.v3.plugins.gradle.tasks;
 
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -315,30 +316,30 @@ public class ResolveTask extends DefaultTask {
         }
         LOGGER.info( "Resolving OpenAPI specification.." );
 
-        Set<URL> urls = StreamSupport.stream(getClasspath().spliterator(), false).map(f -> {
+        Stream<URL> classpathStream = StreamSupport.stream(getClasspath().spliterator(), false).map(f -> {
             try {
                 return f.toURI().toURL();
-            }
-            catch (MalformedURLException e) {
+            } catch (MalformedURLException e) {
                 throw new GradleException(
-                        String.format("Could not create classpath for annotations task %s.", getName()), e);
+                    String.format("Could not create classpath for annotations task %s.", getName()), e);
             }
-        }).collect(Collectors.toSet());
+        });
 
-        Set<URL> buildUrls = StreamSupport.stream(getBuildClasspath().spliterator(), false).map(f -> {
+        Stream<URL> buildClasspathStream = StreamSupport.stream(getBuildClasspath().spliterator(), false).map(f -> {
             try {
                 return f.toURI().toURL();
-            }
-            catch (MalformedURLException e) {
+            } catch (MalformedURLException e) {
                 throw new GradleException(
-                        String.format("Could not create classpath for annotations task %s.", getName()), e);
+                    String.format("Could not create classpath for annotations task %s.", getName()), e);
             }
-        }).collect(Collectors.toSet());
+        });
 
-        urls.addAll(buildUrls);
+        URL[] urls = Stream.concat(classpathStream, buildClasspathStream)
+            .distinct()
+            .toArray(URL[]::new);
 
         //ClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]), Thread.currentThread().getContextClassLoader());
-        ClassLoader classLoader = new URLClassLoader(urls.toArray(new URL[urls.size()]));
+        ClassLoader classLoader = new URLClassLoader(urls);
 
         try {
             Class swaggerLoaderClass = classLoader.loadClass("io.swagger.v3.jaxrs2.integration.SwaggerLoader");


### PR DESCRIPTION
The use of a set to filter dublicated jars in the resolve task, resulted
in an unstable ordering of the urls. This caused the resolve task to
fail on some machines and not on other, caused by the url paths.

Fixes #3876