### PR TITLE
TEC-11227 Extend the Operation annotation

### DIFF
--- a/modules/swagger-annotations/pom.xml
+++ b/modules/swagger-annotations/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.swagger.core.v3</groupId>
         <artifactId>swagger-project</artifactId>
-        <version>2.1.7-SNAPSHOT</version>
+        <version>2.1.7-EBX-1</version>
         <relativePath>../..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Operation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Operation.java
@@ -62,6 +62,13 @@ import static java.lang.annotation.ElementType.METHOD;
 @Inherited
 public @interface Operation {
     /**
+     * The path of the operation.
+     *
+     * @return the path of the operation
+     */
+    String path();
+    
+    /**
      * The HTTP method for this operation.
      *
      * @return the HTTP method of this operation

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Operation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Operation.java
@@ -18,6 +18,7 @@ package io.swagger.v3.oas.annotations;
 
 import io.swagger.v3.oas.annotations.extensions.Extension;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.ratelimits.RateLimit;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.servers.Server;
@@ -164,4 +165,11 @@ public @interface Operation {
      * @return whether or not to ignore JsonView annotations
      */
     boolean ignoreJsonView() default false;
+    
+    /**
+     * The list of rate limits applied to this operation
+     *
+     * @return the list of rate limits for this operation
+     */
+    RateLimit[] rateLimits() default {};
 }

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/ratelimits/RateLimit.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/ratelimits/RateLimit.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2017 SmartBear Software
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.swagger.v3.oas.annotations.ratelimits;
+
+/**
+ * The annotation may be used to define a custom rate limit
+ */
+public @interface RateLimit {
+  
+  /**
+   * The name of the rate limit
+   *
+   * @return the name of the rate limit
+   */
+  String name();
+  
+  /**
+   * The maximum number of times the operation can be called within the interval secs. The
+   * default of -1 means there is no rate limit on the operation
+   *
+   * @return the rate limit
+   */
+  int callLimit() default -1;
+  
+  /**
+   * The maximum total number of seconds the operation can be processed. The default of -1 means
+   * there is no rate limit on the operation
+   *
+   * @return the rate limit seconds
+   */
+  int intervalLimitSecs() default -1;
+  
+  /**
+   * The interval seconds for the entire rate limit on the operation
+   *
+   * @return the interval seconds
+   */
+  int intervalSecs() default -1;
+  
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>pom</packaging>
     <name>swagger-project</name>
     <description>swagger-project</description>
-    <version>2.1.7-SNAPSHOT</version>
+    <version>2.1.7-EBX-1</version>
     <url>https://github.com/swagger-api/swagger-core</url>
     <scm>
         <connection>scm:git:git@github.com:swagger-api/swagger-core.git</connection>


### PR DESCRIPTION
- Create the path and rate limit annotation within the operation annotation as they don't exist
- The path should have been generated as part of javax when creating the documentation from code but we're using Vert.x instead.
- Rate limit annotation is not within the OpenAPI spec
- Bump the pom ready for uploading to Archiva