### PR TITLE
Fix build on Windows OS

### DIFF
--- a/modules/swagger-project-jakarta/modules/swagger-maven-plugin-jakarta/src/main/java/io/swagger/v3/plugin/maven/jakarta/JakartaTransformer.java
+++ b/modules/swagger-project-jakarta/modules/swagger-maven-plugin-jakarta/src/main/java/io/swagger/v3/plugin/maven/jakarta/JakartaTransformer.java
@@ -8,6 +8,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URI;
@@ -131,61 +132,55 @@ public class JakartaTransformer {
      * Extracts Jar into temp directory
      *
      */
-    private static void extract(String inPath, String outPath) throws Exception {
+	private static void extract(String inPath, String outPath) throws Exception {
 
-        Path target = Paths.get(outPath);
-        Path source = Paths.get(inPath);
+		Path target = Paths.get(outPath);
+		Path source = Paths.get(inPath);
 
-        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(source.toFile()))) {
+		try (ZipInputStream zis = new ZipInputStream(new FileInputStream(source.toFile()))) {
+			ZipEntry zipEntry = zis.getNextEntry();
 
-            // list files in zip
-            ZipEntry zipEntry = zis.getNextEntry();
+			while (zipEntry != null) {
+				Path path = target.resolve(zipEntry.getName()).normalize();
 
-            while (zipEntry != null) {
+				if (!path.startsWith(target + File.separator)) {
+					throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
+				}
 
-                boolean isDirectory = false;
+				if (zipEntry.isDirectory()) {
+					if (!Files.isDirectory(path)) {
+						Files.createDirectories(path);
+					}
+				} else {
+					// fix for Windows-created archives
+					Path parent = path.getParent();
+					if (!Files.isDirectory(parent)) {
+						Files.createDirectories(parent);
+					}
 
-                if (zipEntry.getName().endsWith(File.separator)) {
-                    isDirectory = true;
-                }
-
-                Path targetDirResolved = target.resolve(zipEntry.getName());
-
-                Path normalizePath = targetDirResolved.normalize();
-                if (!normalizePath.startsWith(target)) {
-                    throw new IOException("Bad zip entry: " + zipEntry.getName());
-                }
-
-                Path newPath = normalizePath;
-
-                if (isDirectory) {
-                    Files.createDirectories(newPath);
-                } else {
-                    if (newPath.getParent() != null) {
-                        if (Files.notExists(newPath.getParent())) {
-                            Files.createDirectories(newPath.getParent());
-                        }
-                    }
-                    Files.copy(zis, newPath, StandardCopyOption.REPLACE_EXISTING);
-                }
-
-                zipEntry = zis.getNextEntry();
-
-            }
-            zis.closeEntry();
-
-        }
-    }
+					// write file content
+					try (OutputStream os = Files.newOutputStream(path)) {
+						byte[] buffer = new byte[1024];
+						int len;
+						while ((len = zis.read(buffer)) > 0) {
+							os.write(buffer, 0, len);
+						}
+					}
+				}
+				zipEntry = zis.getNextEntry();
+			}
+			zis.closeEntry();
+		}
+	}
 
     /**
      *
      * Compress temp directory back into Jar after transformed
      *
      */
-
     public static void jar(Path sourcePath, String outJarPath) throws IOException {
 
-        URI uri = URI.create("jar:file:" + outJarPath);
+        URI uri = URI.create("jar:" + Paths.get(outJarPath).normalize().toUri());
 
         Files.walkFileTree(sourcePath, new SimpleFileVisitor<Path>() {
             @Override

--- a/modules/swagger-project-jakarta/modules/swagger-maven-plugin-jakarta/src/main/java/io/swagger/v3/plugin/maven/jakarta/JakartaTransformer.java
+++ b/modules/swagger-project-jakarta/modules/swagger-maven-plugin-jakarta/src/main/java/io/swagger/v3/plugin/maven/jakarta/JakartaTransformer.java
@@ -132,46 +132,46 @@ public class JakartaTransformer {
      * Extracts Jar into temp directory
      *
      */
-	private static void extract(String inPath, String outPath) throws Exception {
+    private static void extract(String inPath, String outPath) throws Exception {
 
-		Path target = Paths.get(outPath);
-		Path source = Paths.get(inPath);
+        Path target = Paths.get(outPath);
+        Path source = Paths.get(inPath);
 
-		try (ZipInputStream zis = new ZipInputStream(new FileInputStream(source.toFile()))) {
-			ZipEntry zipEntry = zis.getNextEntry();
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(source.toFile()))) {
+            ZipEntry zipEntry = zis.getNextEntry();
 
-			while (zipEntry != null) {
-				Path path = target.resolve(zipEntry.getName()).normalize();
+            while (zipEntry != null) {
+                Path path = target.resolve(zipEntry.getName()).normalize();
 
-				if (!path.startsWith(target + File.separator)) {
-					throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
-				}
+                if (!path.startsWith(target + File.separator)) {
+                    throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
+                }
 
-				if (zipEntry.isDirectory()) {
-					if (!Files.isDirectory(path)) {
-						Files.createDirectories(path);
-					}
-				} else {
-					// fix for Windows-created archives
-					Path parent = path.getParent();
-					if (!Files.isDirectory(parent)) {
-						Files.createDirectories(parent);
-					}
+                if (zipEntry.isDirectory()) {
+                    if (!Files.isDirectory(path)) {
+                        Files.createDirectories(path);
+                    }
+                } else {
+                    // fix for Windows-created archives
+                    Path parent = path.getParent();
+                    if (!Files.isDirectory(parent)) {
+                        Files.createDirectories(parent);
+                    }
 
-					// write file content
-					try (OutputStream os = Files.newOutputStream(path)) {
-						byte[] buffer = new byte[1024];
-						int len;
-						while ((len = zis.read(buffer)) > 0) {
-							os.write(buffer, 0, len);
-						}
-					}
-				}
-				zipEntry = zis.getNextEntry();
-			}
-			zis.closeEntry();
-		}
-	}
+                    // write file content
+                    try (OutputStream os = Files.newOutputStream(path)) {
+                        byte[] buffer = new byte[1024];
+                        int len;
+                        while ((len = zis.read(buffer)) > 0) {
+                            os.write(buffer, 0, len);
+                        }
+                    }
+                }
+                zipEntry = zis.getNextEntry();
+            }
+            zis.closeEntry();
+        }
+    }
 
     /**
      *


### PR DESCRIPTION
@frantuma Validating the SNAPSHOT builds for refs #3836 on my end
- Files.copy(...) failed with DirectoryNotEmptyException (see [docs](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#copy%28java.nio.file.Path,%20java.nio.file.Path,%20java.nio.file.CopyOption...%29))
- URI.create(...) failed due to backwards slashes in outJarPath