### PR TITLE
Allows replacing of the schema serializer

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ObjectMapperFactory.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ObjectMapperFactory.java
@@ -61,6 +61,8 @@ import java.util.Map;
 
 public class ObjectMapperFactory {
 
+    private static SchemaSerializerFactory schemaSerializerFactory;
+
     protected static ObjectMapper createJson() {
         return create(null);
     }
@@ -88,7 +90,7 @@ public class ObjectMapperFactory {
                     public JsonSerializer<?> modifySerializer(
                             SerializationConfig config, BeanDescription desc, JsonSerializer<?> serializer) {
                         if (Schema.class.isAssignableFrom(desc.getBeanClass())) {
-                            return new SchemaSerializer((JsonSerializer<Object>) serializer);
+                            return schemaSerializerFactory==null?new SchemaSerializer((JsonSerializer<Object>) serializer):schemaSerializerFactory.create(serializer);
                         }
                         return serializer;
                     }
@@ -161,6 +163,10 @@ public class ObjectMapperFactory {
         }
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return mapper;
+    }
+    
+    public static void setSchemaSerializerFactory(SchemaSerializerFactory schemaSerializerFactory) {
+        ObjectMapperFactory.schemaSerializerFactory = schemaSerializerFactory;
     }
 
 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/SchemaSerializerFactory.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/SchemaSerializerFactory.java
@@ -1,0 +1,11 @@
+package io.swagger.v3.core.util;
+
+import com.fasterxml.jackson.databind.JsonSerializer;
+
+import io.swagger.v3.core.jackson.SchemaSerializer;
+
+public interface SchemaSerializerFactory {
+
+   SchemaSerializer create(JsonSerializer<?> serializer);
+
+}


### PR DESCRIPTION
Hi @frantuma, @webron  and @HugoMario,

Please refer this issue https://github.com/swagger-api/swagger-core/issues/3312
I think I have a fix for this over here -https://github.com/teq-niq/sample/tree/swagger-core-issue3312-better (branch: “swagger-core-issue3312-better” of https://github.com/teq-niq/sample.git). 
Please have a look at https://github.com/teq-niq/sample/blob/swagger-core-issue3312-better/src/main/java/sample/config/OpenApiConfig.java and the method resolvedSchemaEnforcer()  and the comments on it. Hope that is otherwise useful.
This may not necessarily be the best fix for that problem but it seems to work. (My PR is not about this. Please bear with me and read this through)
While I do refer to issue 3312 and this code in my demo sample, my PR is not about that.
My PR here is  limited to only providing extensibility to SchemaSerializer so that it can be replaced by any class that extends it by developers who want to do so. I do also demonstrate this PR’s concept in that same demo code of mine.
In case there is a better approach to meet the objective of this PR pls suggest. I think it’s a very simple solution to my goal of extending and replacing SchemaSerializer .
Otherwise I hope  you liked this fix and will please approve it. 
I am also copying @bnasslahsen of springdoc project here.
Thank you.
Raghu