### PR TITLE
Fixed example of date formatted string

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/properties/MapPropertyDeserializerTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/properties/MapPropertyDeserializerTest.java
@@ -228,4 +228,30 @@ public class MapPropertyDeserializerTest {
         assertTrue(example instanceof String);
         assertEquals(example, "ok");
     }
+
+    @Test(description = "date example format should be yyyy-MM-dd")
+    public void testDateFormatStringExample() throws Exception {
+        Operation operation = Yaml.mapper().readValue(
+                "      responses:\n" +
+                        "        \"200\":\n" +
+                        "          content:\n" +
+                        "            '*/*':\n" +
+                        "              description: OK\n" +
+                        "              schema:\n" +
+                        "                type: object\n" +
+                        "                properties:\n" +
+                        "                  date:\n" +
+                        "                    type: string\n" +
+                        "                    format: date\n" +
+                        "                    example: 2020-03-03\n",
+                        Operation.class);
+
+        ApiResponse response = operation.getResponses().get("200");
+        assertNotNull(response);
+        Schema schema = (Schema)response.getContent().get("*/*").getSchema().getProperties().get("date");
+        Object example = schema.getExample();
+        assertNotNull(example);
+        assertTrue(example instanceof String);
+        assertEquals(example, "2020-03-03");
+    }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/properties/MapPropertyDeserializerTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/properties/MapPropertyDeserializerTest.java
@@ -16,6 +16,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import java.time.OffsetDateTime;
+
 public class MapPropertyDeserializerTest {
     private static final String json = "{\n" +
             "  \"tags\": [\n" +
@@ -253,5 +255,31 @@ public class MapPropertyDeserializerTest {
         assertNotNull(example);
         assertTrue(example instanceof String);
         assertEquals(example, "2020-03-03");
+    }
+
+    @Test(description = "date-time example format should be such as 2021-11-13T20:20:39Z, 2021-11-13T20:20:39+09:00")
+    public void testDateTimeFormatStringExample() throws Exception {
+        Operation operation = Yaml.mapper().readValue(
+                "      responses:\n" +
+                        "        \"200\":\n" +
+                        "          content:\n" +
+                        "            '*/*':\n" +
+                        "              description: OK\n" +
+                        "              schema:\n" +
+                        "                type: object\n" +
+                        "                properties:\n" +
+                        "                  date:\n" +
+                        "                    type: string\n" +
+                        "                    format: date-time\n" +
+                        "                    example: 2021-11-13T20:20:39+09:00\n",
+                        Operation.class);
+
+        ApiResponse response = operation.getResponses().get("200");
+        assertNotNull(response);
+        Schema schema = (Schema)response.getContent().get("*/*").getSchema().getProperties().get("date");
+        Object example = schema.getExample();
+        assertNotNull(example);
+        assertTrue(example instanceof OffsetDateTime);
+        assertEquals(example.toString(), "2021-11-13T20:20:39+09:00");
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/properties/MapPropertyDeserializerTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/properties/MapPropertyDeserializerTest.java
@@ -257,6 +257,31 @@ public class MapPropertyDeserializerTest {
         assertEquals(example, "2020-03-03");
     }
 
+    @Test(description = "date example format should be yyyy-MM-dd")
+    public void testDateFormatStringNoExample() throws Exception {
+        Operation operation = Yaml.mapper().readValue(
+                "      responses:\n" +
+                        "        \"200\":\n" +
+                        "          content:\n" +
+                        "            '*/*':\n" +
+                        "              description: OK\n" +
+                        "              schema:\n" +
+                        "                type: object\n" +
+                        "                properties:\n" +
+                        "                  date:\n" +
+                        "                    type: string\n" +
+                        "                    format: date",
+                        Operation.class);
+
+        ApiResponse response = operation.getResponses().get("200");
+        assertNotNull(response);
+        Schema schema = (Schema)response.getContent().get("*/*").getSchema().getProperties().get("date");
+        Object example = schema.getExample();
+        assertNotNull(example);
+        assertTrue(example instanceof String);
+        assertEquals(example, "");
+    }
+
     @Test(description = "date-time example format should be such as 2021-11-13T20:20:39Z, 2021-11-13T20:20:39+09:00")
     public void testDateTimeFormatStringExample() throws Exception {
         Operation operation = Yaml.mapper().readValue(

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateSchema.java
@@ -94,8 +94,11 @@ public class DateSchema extends Schema<Date> {
 
     @Override
     public Object getExample() {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        return sdf.format(this.example);
+        if (this.example != null) {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+            return sdf.format(this.example);
+        }
+        return "";
     }
 }
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/DateSchema.java
@@ -91,5 +91,11 @@ public class DateSchema extends Schema<Date> {
         sb.append("}");
         return sb.toString();
     }
+
+    @Override
+    public Object getExample() {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        return sdf.format(this.example);
+    }
 }
 


### PR DESCRIPTION
# Summary

When format of the string is `date` and example is set to '2021-11-10', expected example string is '2021-11-10'.
Current implementation returns "Wed Nov 10 09:00:00 JST 2021". I afraid this is not example input corresponding to the definition.
