### PR TITLE
fix: Support enums with unbounded wildcards

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -947,28 +947,32 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         Class<Enum<?>> enumClass = (Class<Enum<?>>) propClass;
 
         Enum<?>[] enumConstants = enumClass.getEnumConstants();
-        String[] enumValues = _intr.findEnumValues(propClass, enumConstants, new String[enumConstants.length]);
+        if (enumConstants != null) {
+            String[] enumValues = _intr.findEnumValues(propClass, enumConstants,
+                new String[enumConstants.length]);
 
-        for (Enum<?> en : enumConstants) {
-            String n;
+            for (Enum<?> en : enumConstants) {
+                String n;
 
-            String enumValue = enumValues[en.ordinal()];
-            String s = jsonValueMethod.flatMap(m -> ReflectionUtils.safeInvoke(m, en)).map(Object::toString).orElse(null);
+                String enumValue = enumValues[en.ordinal()];
+                String s = jsonValueMethod.flatMap(m -> ReflectionUtils.safeInvoke(m, en))
+                    .map(Object::toString).orElse(null);
 
-            if (s != null) {
-                n = s;
-            } else if (enumValue != null) {
-                n = enumValue;
-            } else if (useIndex) {
-                n = String.valueOf(en.ordinal());
-            } else if (useToString) {
-                n = en.toString();
-            } else {
-                n = _intr.findEnumValue(en);
-            }
-            if (property instanceof StringSchema) {
-                StringSchema sp = (StringSchema) property;
-                sp.addEnumItem(n);
+                if (s != null) {
+                    n = s;
+                } else if (enumValue != null) {
+                    n = enumValue;
+                } else if (useIndex) {
+                    n = String.valueOf(en.ordinal());
+                } else if (useToString) {
+                    n = en.toString();
+                } else {
+                    n = _intr.findEnumValue(en);
+                }
+                if (property instanceof StringSchema) {
+                    StringSchema sp = (StringSchema) property;
+                    sp.addEnumItem(n);
+                }
             }
         }
     }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/EnumTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/EnumTest.java
@@ -15,13 +15,12 @@ import java.util.Collection;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class EnumTest extends SwaggerTestBase {
 
     @Test
-    public void testEnum() throws Exception {
+    public void testEnum() {
         final ModelResolver modelResolver = new ModelResolver(mapper());
         final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
 
@@ -41,11 +40,37 @@ public class EnumTest extends SwaggerTestBase {
         final StringSchema strProperty = (StringSchema) property;
         assertNotNull(strProperty.getEnum());
         final Collection<String> values =
-                new ArrayList<String>(Collections2.transform(Arrays.asList(Currency.values()), Functions.toStringFunction()));
+                new ArrayList<>(Collections2.transform(Arrays.asList(Currency.values()), Functions.toStringFunction()));
         assertEquals(strProperty.getEnum(), values);
+    }
+
+    @Test
+    public void testEnumGenerics() {
+        final ModelResolver modelResolver = new ModelResolver(mapper());
+        final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        final Schema model = context.resolve((new AnnotatedType().type(Contract.class)));
+        assertNotNull(model);
+        assertEquals(model.getName(), "Contract");
+        assertTrue(model.getProperties().containsKey("type"));
+        assertNotNull(model.getProperties().get("type"));
     }
 
     public enum Currency {
         USA, CANADA
+    }
+
+    public static class Contract {
+
+        private Enum<?> type;
+
+        public Enum<?> getType() {
+            return type;
+        }
+
+        public Contract setType(Enum<?> type) {
+            this.type = type;
+            return this;
+        }
     }
 }


### PR DESCRIPTION
This is a fix for enums with unbounded wildcards. We get a NullPointerException otherwise because `enumConstants` is `null`.