### PR TITLE
Issue 4041 schema json object defaultValue

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -1516,10 +1516,15 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         return null;
     }
 
-    protected String resolveDefaultValue(Annotated a, Annotation[] annotations, io.swagger.v3.oas.annotations.media.Schema schema) {
+    protected Object resolveDefaultValue(Annotated a, Annotation[] annotations, io.swagger.v3.oas.annotations.media.Schema schema) {
         if (schema != null) {
             if (!schema.defaultValue().isEmpty()) {
-                return schema.defaultValue();
+                try {
+                    ObjectMapper mapper = ObjectMapperFactory.buildStrictGenericObjectMapper();
+                    return mapper.readTree(schema.defaultValue());
+                } catch (IOException e) {
+                    return schema.defaultValue();
+                }
             }
         }
         if (a == null) {
@@ -2001,8 +2006,8 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         if (StringUtils.isNotBlank(format) && StringUtils.isBlank(schema.getFormat())) {
             schema.format(format);
         }
-        String defaultValue = resolveDefaultValue(a, annotations, schemaAnnotation);
-        if (StringUtils.isNotBlank(defaultValue)) {
+        Object defaultValue = resolveDefaultValue(a, annotations, schemaAnnotation);
+        if (defaultValue != null) {
             schema.setDefault(defaultValue);
         }
         Object example = resolveExample(a, annotations, schemaAnnotation);

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/PojoTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/PojoTest.java
@@ -482,6 +482,65 @@ public class PojoTest {
 
     }
 
+    /**
+     * Test schema with json object defaultValue and example.
+     */
+    @Test(description = "Shows how to provide model examples as json")
+    public void testModelPropertyExampleDefaultJson() {
+
+        String json = "{\"ExampleJsonExtended\": {" +
+                            "\"type\":\"object\"," +
+                            "\"properties\":{" +
+                                "\"id\":{" +
+                                    "\"type\":\"integer\"," +
+                                    "\"format\":\"int32\"" +
+                                "}," +
+                                "\"idType\":{" +
+                                    "\"type\":\"string\"" +
+                                "}," +
+                                "\"isActive\":{" +
+                                    "\"type\":\"boolean\"" +
+                                "}" +
+                            "}," +
+                            "\"example\":{" +
+                                "\"id\":19877734," +
+                                "\"idType\":\"employee code\"," +
+                                "\"isActive\":false" +
+                            "}," +
+                            "\"default\":{" +
+                                "\"id\":19877734," +
+                                "\"idType\":\"employee code\"," +
+                                "\"isActive\":false" +
+                            "}" +
+                        "}," +
+                        "\"modelWithPropertyExampleDefaultJson\":{" +
+                            "\"type\":\"object\"," +
+                            "\"properties\":{" +
+                                "\"exampleJsonExtended\":{" +
+                                    "\"$ref\":\"#/components/schemas/ExampleJsonExtended\"" +
+                                "}" +
+                            "}" +
+                        "}" +
+                    "}";
+        SerializationMatchers.assertEqualsToJson(readAll(modelWithPropertyExampleDefaultJson.class), json);
+    }
+
+    static class modelWithPropertyExampleDefaultJson {
+        final String SAMPLE = "{\"id\": 19877734, \"idType\":\"employee code\", \"isActive\":false}";
+        ExampleJsonExtended tester = new ExampleJsonExtended();
+
+        @Schema( example = SAMPLE, defaultValue = SAMPLE)
+        private ExampleJsonExtended exampleJsonExtended;
+
+        public ExampleJsonExtended getExampleJsonExtended() {
+            return exampleJsonExtended;
+        }
+
+        public void setExampleJsonExtended(ExampleJsonExtended exampleJsonExtended) {
+            this.exampleJsonExtended = exampleJsonExtended;
+        }
+    }
+
     @Test(description = "Shows how to provide model examples as json")
     public void testModelPropertyStringExampleJson() {
 
@@ -520,6 +579,37 @@ public class PojoTest {
 
         public void setId(String id) {
             this.id = id;
+        }
+
+    }
+
+    static class ExampleJsonExtended {
+        private int id;
+        private String idType;
+        private boolean isActive;
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+
+        public String getIdType() {
+            return idType;
+        }
+
+        public void setIdType(String idType) {
+            this.idType = idType;
+        }
+
+        public boolean getIsActive() {
+            return isActive;
+        }
+
+        public void setIsActive(boolean isActive) {
+            this.isActive = isActive;
         }
 
     }


### PR DESCRIPTION
fixes #4041

changes the default value for schema to serialize to object if this is possible, otherwise returns string

Note: this issue title is asking about the swagger-maven-plugin. The issue is not in this module, it is in swagger-core.  The issue can be re-created using the swaggger-maven-plugin, but that is to say, the swagger-maven-plugin is just one specific way to invoke the model resolution in swagger-core where this issue happens.   