### PR TITLE
#4103 Support for Jackson reference types

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/jackson/ModelResolver.java
@@ -170,7 +170,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             if (propType.isEnumType()) {
                 property = new StringProperty();
                 _addEnumProps(propType.getRawClass(), (StringProperty) property);
-            } else if (_isOptionalType(propType)) {
+            } else if (_isReferenceType(propType)) {
                 property = context.resolveProperty(propType.containedType(0), null);
             } else {
                 // complex type
@@ -191,9 +191,9 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         return property;
     }
 
-    private boolean _isOptionalType(JavaType propType) {
+    private boolean _isReferenceType(JavaType propType) {
         return Arrays.asList("com.google.common.base.Optional", "java.util.Optional")
-                .contains(propType.getRawClass().getCanonicalName());
+                .contains(propType.getRawClass().getCanonicalName()) || propType.isReferenceType();
     }
 
     @Override

--- a/modules/swagger-core/src/test/java/io/swagger/jackson/ModelResolverTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/jackson/ModelResolverTest.java
@@ -1,16 +1,25 @@
 package io.swagger.jackson;
 
+import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.swagger.converter.ModelConverterContextImpl;
 import io.swagger.models.Link;
 import io.swagger.models.Model;
 import io.swagger.models.ModelImpl;
 import io.swagger.models.Xml;
+import io.swagger.models.properties.DecimalProperty;
+import io.swagger.models.properties.Property;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import javax.xml.bind.annotation.XmlRootElement;
+
+import java.lang.annotation.Annotation;
+import java.math.BigDecimal;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.testng.Assert.*;
 
@@ -50,5 +59,40 @@ public class ModelResolverTest extends SwaggerTestBase {
     @XmlRootElement(name = "TypeWithOutNamespace")
     public static class TypeWithoutNamespace {
     }
+
+    @Test
+    public void testResolvePropertyWithAtomicReference() {
+        final ObjectMapper mapper = mapper();
+        final ModelResolver modelResolver = new ModelResolver(mapper);
+
+        final JavaType javaType = TypeFactory.defaultInstance().constructType(TypeWithAtomicReferenceMember.class);
+        final BeanDescription beanDescription = mapper.getSerializationConfig().introspect(javaType);
+
+        JavaType atomicReferenceBigDecimalType = null;
+        for (final BeanPropertyDefinition propDef : beanDescription.findProperties()) {
+            if ("member".equals(propDef.getName())) {
+                atomicReferenceBigDecimalType = propDef.getPrimaryType();
+            }
+        }
+        assertNotNull(atomicReferenceBigDecimalType, "Failed to read atomic reference field 'member'");
+
+        final Property actualProperty = modelResolver.resolveProperty(atomicReferenceBigDecimalType,
+                new ModelConverterContextImpl(modelResolver), new Annotation[0], null);
+        assertEquals(actualProperty.getType(), DecimalProperty.TYPE, "Got wrong type for AtomicReference member");
+    }
+
+    @SuppressWarnings("unused")
+    private static final class TypeWithAtomicReferenceMember {
+        AtomicReference<BigDecimal> member;
+
+        public AtomicReference<BigDecimal> getMember() {
+            return member;
+        }
+
+        public void setMember(AtomicReference<BigDecimal> member) {
+            this.member = member;
+        }
+    }
+
 
 }


### PR DESCRIPTION
In addition to the hard coded `Optional` reference types the type information from jackson is used to unwrap additional reference types (e.g. `AtomicReference`)

Fixes #4103 for 1.5 branch (swagger 1.6.X)