### PR TITLE
Json deserialization process should not remove extension for Security Scheme

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/SecuritySchemeDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/SecuritySchemeDeserializer.java
@@ -11,6 +11,8 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
 
 public class SecuritySchemeDeserializer extends JsonDeserializer<SecurityScheme> {
 
@@ -61,6 +63,15 @@ public class SecuritySchemeDeserializer extends JsonDeserializer<SecurityScheme>
             } else if ("mutualTLS".equals(type)) {
                 result
                         .type(SecurityScheme.Type.MUTUALTLS);
+            }
+            final Iterator<String> fieldNames = node.fieldNames();
+            while(fieldNames.hasNext()) {
+                final String fieldName = fieldNames.next();
+                if(fieldName.startsWith("x-")) {
+                    final JsonNode fieldValue = node.get(fieldName);
+                    final Object value = Json.mapper().treeToValue(fieldValue, Object.class);
+                    result.addExtension(fieldName, value);
+                }
             }
         }
 

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/SecurityDefinitionTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/SecurityDefinitionTest.java
@@ -24,6 +24,12 @@ import io.swagger.v3.oas.models.security.Scopes;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.Assert;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -103,5 +109,15 @@ public class SecurityDefinitionTest {
 
         final String json = ResourceUtils.loadClassResource(getClass(), "ModelWithSecurityRequirements.json");
         SerializationMatchers.assertEqualsToJson(oas, json);
+    }
+
+    @Test(description = "Security Scheme deserialization should not remove extensions")
+    public void doNotRemoveExtensions() {
+        final SecurityScheme securityScheme = TestUtils.deserializeJsonFileFromClasspath("specFiles/securitySchemaWithExtension.json", SecurityScheme.class);
+
+        final Map<String, Object> extensions = securityScheme.getExtensions();
+        final Map<String, Object> expected = Collections.singletonMap("x-custom", Collections.singletonMap("key-string", "value-one"));
+
+        assertEquals(extensions, expected);
     }
 }

--- a/modules/swagger-core/src/test/resources/specFiles/securitySchemaWithExtension.json
+++ b/modules/swagger-core/src/test/resources/specFiles/securitySchemaWithExtension.json
@@ -1,0 +1,15 @@
+{
+  "type": "oauth2",
+  "flows": {
+    "implicit": {
+      "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+      "scopes": {
+        "write:pets": "modify pets in your account",
+        "read:pets": "read your pets"
+      }
+    }
+  },
+  "x-custom": {
+    "key-string": "value-one"
+  }
+}


### PR DESCRIPTION
Motivation
According to the specification the "Security Scheme Object" may be extended with Specification Extensions.

Modification
* Add test to highlight the bug
* SecuritySchemeDeserializer now parse other field