### PR TITLE
CVE-2020-36518: Bump jackson-databind to 2.13.2.2

### DIFF
--- a/modules/swagger-project-jakarta/pom.xml
+++ b/modules/swagger-project-jakarta/pom.xml
@@ -494,7 +494,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-version}</version>
+                <version>${jackson-databind-version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>jakarta.activation</groupId>
@@ -576,6 +576,11 @@
         <jersey2-version>3.0.1</jersey2-version>
         <junit-version>4.13.1</junit-version>
         <jackson-version>2.13.2</jackson-version>
+        <!--
+          2.13.2 is still affected by CVE-2020-36518.
+          This version pin for jackson-databind can be removed when bumping jackson to 2.14
+          -->
+        <jackson-databind-version>2.13.2.2</jackson-databind-version>
         <logback-version>1.2.9</logback-version>
         <classgraph-version>4.8.138</classgraph-version>
         <guava-version>31.0.1-jre</guava-version>

--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-version}</version>
+                <version>${jackson-databind-version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -656,6 +656,11 @@
         <jersey2-version>2.26</jersey2-version>
         <junit-version>4.13.1</junit-version>
         <jackson-version>2.13.2</jackson-version>
+        <!--
+          jackson-databind 2.13.2 is still affected by CVE-2020-36518.
+          This version pin for jackson-databind can be removed when bumping jackson to 2.14
+          -->
+        <jackson-databind-version>2.13.2.2</jackson-databind-version>
         <logback-version>1.2.9</logback-version>
         <classgraph-version>4.8.138</classgraph-version>
         <guava-version>31.0.1-jre</guava-version>


### PR DESCRIPTION
This resolves #4145, the jackson-databind CVE.
A similar patch is also made in swagger-parser (swagger-parser#1690)