### PR TITLE
fix #3998 model schema enum values of jackson fields and private methods

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
@@ -435,10 +435,33 @@ public class ReflectionUtils {
         return type.isArrayType();
     }
 
+    /**
+     * A utility method to get an optional containing result from method or empty optional if unable to access
+     *
+     * @param method from reflect, a method of a class or interface
+     * @param obj the class object in which the method exists
+     * @param args varags of the parameters passed to the method
+     * @return the result of the method, or empty conditional
+     */
     public static Optional<Object> safeInvoke(Method method, Object obj, Object... args) {
         try {
             return Optional.ofNullable(method.invoke(obj, args));
         } catch (IllegalAccessException | InvocationTargetException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * A utility method to get an optional containing value of field or empty optional if unable to access
+     *
+     * @param field from reflect, a field of a class or interface
+     * @param obj the class object in which the field exists
+     * @return optional containing the value of the field on the specified object, or empty optional
+     */
+    public static Optional<Object> safeGet(Field field, Object obj) {
+        try {
+            return Optional.ofNullable(field.get(obj));
+        } catch (IllegalAccessException e) {
             return Optional.empty();
         }
 

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
@@ -219,5 +219,20 @@ public class EnumPropertyTest {
         assertTrue(thirdEnumProperty instanceof StringSchema);
         final StringSchema thirdStringProperty = (StringSchema) thirdEnumProperty;
         assertEquals(thirdStringProperty.getEnum(), Arrays.asList("2", "4", "6"));
+
+        final Schema fourthEnumProperty = (Schema) model.getProperties().get("fourthEnumValue");
+        assertTrue(fourthEnumProperty instanceof StringSchema);
+        final StringSchema fourthStringProperty = (StringSchema) fourthEnumProperty;
+        assertEquals(fourthEnumProperty.getEnum(), Arrays.asList("one", "two", "three"));
+
+        final Schema fifthEnumProperty = (Schema) model.getProperties().get("fifthEnumValue");
+        assertTrue(fifthEnumProperty instanceof StringSchema);
+        final StringSchema fifthStringProperty = (StringSchema) fifthEnumProperty;
+        assertEquals(fifthEnumProperty.getEnum(), Arrays.asList("2", "4", "6"));
+
+        final Schema sixthEnumProperty = (Schema) model.getProperties().get("sixthEnumValue");
+        assertTrue(sixthEnumProperty instanceof StringSchema);
+        final StringSchema sixthStringProperty = (StringSchema) sixthEnumProperty;
+        assertEquals(sixthEnumProperty.getEnum(), Arrays.asList("one", "two", "three"));
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonNumberValueEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonNumberValueEnum.java
@@ -2,6 +2,9 @@ package io.swagger.v3.core.oas.models;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * Enum holds values different from names.  Schema model will derive Integer value from jackson annotation JsonValue on public method.
+ */
 public enum JacksonNumberValueEnum {
     FIRST(2),
     SECOND(4),

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonNumberValueFieldEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonNumberValueFieldEnum.java
@@ -1,0 +1,19 @@
+package io.swagger.v3.core.oas.models;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enum holds values different from names. Schema model will derive Integer value from jackson annotation JsonValue on private field.
+ */
+public enum JacksonNumberValueFieldEnum {
+    FIRST(2),
+    SECOND(4),
+    THIRD(6);
+
+    @JsonValue
+    private final int value;
+
+    JacksonNumberValueFieldEnum(int value) {
+        this.value = value;
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValueFieldEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValueFieldEnum.java
@@ -1,0 +1,19 @@
+package io.swagger.v3.core.oas.models;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enum holds values different from names.  Schema model will derive String value from jackson annotation JsonValue on private field.
+ */
+public enum JacksonValueFieldEnum {
+    FIRST("one"),
+    SECOND("two"),
+    THIRD("three");
+
+    @JsonValue
+    private final String value;
+
+    JacksonValueFieldEnum(String value) {
+        this.value = value;
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValuePrivateEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValuePrivateEnum.java
@@ -3,21 +3,21 @@ package io.swagger.v3.core.oas.models;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * Enum holds values different from names. Schema model will derive String value from jackson annotation JsonValue on public method.
+ * Enum holds values different from names.  Schema model will derive String value from jackson annotation JsonValue on private method.
  */
-public enum JacksonValueEnum {
+public enum JacksonValuePrivateEnum {
     FIRST("one"),
     SECOND("two"),
     THIRD("three");
 
     private final String value;
 
-    JacksonValueEnum(String value) {
+    JacksonValuePrivateEnum(String value) {
         this.value = value;
     }
 
     @JsonValue
-    public String getValue() {
+    private String getValue() {
         return value;
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithJacksonEnumField.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithJacksonEnumField.java
@@ -1,7 +1,13 @@
 package io.swagger.v3.core.oas.models;
 
+/**
+ *  Class of different enums for testing schema model
+ */
 public class ModelWithJacksonEnumField {
     public JacksonPropertyEnum firstEnumValue;
     public JacksonValueEnum secondEnumValue;
     public JacksonNumberValueEnum thirdEnumValue;
+    public JacksonValueFieldEnum fourthEnumValue;
+    public JacksonNumberValueFieldEnum fifthEnumValue;
+    public JacksonValuePrivateEnum sixthEnumValue;
 }


### PR DESCRIPTION
This fixes issue 3998. If there exist jackson fields, or private methods, then jackson will serialize these as the values for an enum. This enables looking for those values first before using the enum field name.