### PR TITLE
Avoid locale-dependent NumberFormat in IntegerSchema

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/IntegerSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/IntegerSchema.java
@@ -33,14 +33,11 @@ public class IntegerSchema extends Schema<Number> {
     @Override
     protected Number cast(Object value) {
         if (value != null) {
-            try {
-                Number casted = NumberFormat.getInstance().parse(value.toString());
-                if (Integer.MIN_VALUE <= casted.longValue() && casted.longValue() <= Integer.MAX_VALUE) {
-                    return Integer.parseInt(value.toString());
-                } else {
-                    return Long.parseLong(value.toString());
-                }
-            } catch (Exception e) {
+            long casted = Long.parseLong(value.toString());
+            if (Integer.MIN_VALUE <= casted && casted <= Integer.MAX_VALUE) {
+                return (int)casted;
+            } else {
+                return casted;
             }
         }
         return null;


### PR DESCRIPTION
NumberFormat.getInstance().parse(Integer.toString(-1)) always throws exception in the following locales: ar· ·ckb· ·he· ·ks· ·pa_Arab· ·ur· ·fa· ·ps· ·uz_Arab· ·eo· ·et· ·fi· ·fo· ·gsw· ·ksh· ·lt· ·nb· ·nn· ·rm· ·se· ·sv· (see https://bugs.openjdk.java.net/browse/JDK-8189097)

To see this in action, try running the following code:

```java
import java.text.NumberFormat;
import java.text.ParseException;
import java.util.Locale;

public class NumberFormatIsBroken {
    public static void main(String[] args) throws ParseException {
        Locale.setDefault(new Locale("no"));
        NumberFormat.getInstance().parse(Long.toString(-1));
    }
}
```

In addition to using `Long.parseLong` which doesn't have this locale-problem, I propose getting rid of the try/catch block as the statement `Long.parseLong(value.toString())` should never throw