### PR TITLE
refs swagger-api/swagger-parser/issues/1757 - boolean schema support for OAS 3.1

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/Schema31Serializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/Schema31Serializer.java
@@ -29,6 +29,10 @@ public class Schema31Serializer extends JsonSerializer<Schema> implements Resolv
             Schema value, JsonGenerator jgen, SerializerProvider provider)
             throws IOException {
 
+        if (value.getBooleanSchemaValue() != null) {
+            jgen.writeBoolean(value.getBooleanSchemaValue());
+            return;
+        }
         if (value.getExampleSetFlag() && value.getExample() == null) {
             jgen.writeStartObject();
             defaultSerializer.unwrappingSerializer(null).serialize(value, jgen, provider);

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/DateSchemaMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/DateSchemaMixin.java
@@ -15,4 +15,7 @@ public abstract class DateSchemaMixin {
 
     @JsonIgnore
     public abstract Map<String, Object> getJsonSchema();
+
+    @JsonIgnore
+    public abstract Boolean getBooleanSchemaValue();
 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/Schema31Mixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/Schema31Mixin.java
@@ -59,6 +59,9 @@ public abstract class Schema31Mixin {
     @JsonIgnore
     public abstract Object getJsonSchemaImpl();
 
+    @JsonIgnore
+    public abstract Boolean getBooleanSchemaValue();
+
     public static class TypeSerializer extends JsonSerializer<Set<String>> {
 
         @Override

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/SchemaMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/SchemaMixin.java
@@ -108,4 +108,7 @@ public abstract class SchemaMixin {
 
     @JsonIgnore
     public abstract Object getConst();
+
+    @JsonIgnore
+    public abstract Boolean getBooleanSchemaValue();
 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ModelDeserializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ModelDeserializer.java
@@ -125,6 +125,9 @@ public class ModelDeserializer extends JsonDeserializer<Schema> {
     }
 
     private Schema deserializeJsonSchema(JsonNode node) {
+        if (node.isBoolean()) {
+            return new Schema().booleanSchemaValue(node.booleanValue());
+        }
         JsonNode additionalProperties = node.get("additionalProperties");
         JsonNode type = node.get("type");
         Schema schema = null;

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/OpenAPI3_1DeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/OpenAPI3_1DeserializationTest.java
@@ -1,10 +1,14 @@
 package io.swagger.v3.core.deserialization;
 
 import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.core.util.ResourceUtils;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.core.util.Yaml31;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -13,6 +17,7 @@ import static org.junit.Assert.assertNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class OpenAPI3_1DeserializationTest {
 
@@ -221,5 +226,30 @@ public class OpenAPI3_1DeserializationTest {
         assertEquals(openAPI.getPaths().get("/pets").getPost().getResponses().get("default").getHeaders().get("head").get$ref(), "#/components/headers/head");
         assertEquals(openAPI.getPaths().get("/pets").getPost().getResponses().get("default").getHeaders().get("head").getDescription(), "ref header description");
 
+    }
+
+    @Test
+    public void testBooleanSchemaDeserialization() throws Exception{
+        OpenAPI openAPI = new OpenAPI()
+                .openapi("3.1.0")
+                .components(new Components().addSchemas("test", new Schema().booleanSchemaValue(true)));
+
+        String json = Json31.pretty(openAPI);
+        String yaml = Yaml31.pretty(openAPI);
+        OpenAPI oas = Json31.mapper().readValue(json, OpenAPI.class);
+        assertTrue(Boolean.TRUE.equals(oas.getComponents().getSchemas().get("test").getBooleanSchemaValue()));
+        Schema schema = Json31.mapper().readValue("true", Schema.class);
+        assertTrue(Boolean.TRUE.equals(schema.getBooleanSchemaValue()));
+        oas = Yaml31.mapper().readValue(yaml, OpenAPI.class);
+        assertTrue(Boolean.TRUE.equals(oas.getComponents().getSchemas().get("test").getBooleanSchemaValue()));
+        schema = Yaml31.mapper().readValue("true", Schema.class);
+        assertTrue(Boolean.TRUE.equals(schema.getBooleanSchemaValue()));
+
+        json = Json.pretty(openAPI);
+        yaml = Yaml.pretty(openAPI);
+        oas = Json.mapper().readValue(json, OpenAPI.class);
+        assertNull(oas.getComponents().getSchemas().get("test").getBooleanSchemaValue());
+        oas = Yaml.mapper().readValue(yaml, OpenAPI.class);
+        assertNull(oas.getComponents().getSchemas().get("test").getBooleanSchemaValue());
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/OpenAPI3_1SerializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/OpenAPI3_1SerializationTest.java
@@ -1,7 +1,10 @@
 package io.swagger.v3.core.serialization;
 
 import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.core.util.ResourceUtils;
+import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -1357,5 +1360,56 @@ public class OpenAPI3_1SerializationTest {
                 "}");
     }
 
+    @Test
+    public void testBooleanSchemaSerialization() {
+        OpenAPI openAPI = new OpenAPI()
+                .openapi("3.1.0")
+                .components(new Components().addSchemas("test", new Schema().booleanSchemaValue(true)));
+
+        System.out.println("--------- root ----------");
+        Json31.prettyPrint(openAPI);
+        assertEquals(Json31.pretty(openAPI), "{\n" +
+                "  \"openapi\" : \"3.1.0\",\n" +
+                "  \"components\" : {\n" +
+                "    \"schemas\" : {\n" +
+                "      \"test\" : true\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+        System.out.println("--------- schema ----------");
+        Json31.prettyPrint(openAPI.getComponents().getSchemas().get("test"));
+        assertEquals(Json31.pretty(openAPI.getComponents().getSchemas().get("test")), "true");
+        System.out.println("--------- root YAML----------");
+        Yaml31.prettyPrint(openAPI);
+        assertEquals(Yaml31.pretty(openAPI), "openapi: 3.1.0\n" +
+                "components:\n" +
+                "  schemas:\n" +
+                "    test: true\n");
+        System.out.println("--------- schema YAML ----------");
+        Yaml31.prettyPrint(openAPI.getComponents().getSchemas().get("test"));
+        assertEquals(Yaml31.pretty(openAPI.getComponents().getSchemas().get("test")), "true\n");
+        System.out.println("--------- root 3.0 ----------");
+        Json.prettyPrint(openAPI);
+        assertEquals(Json.pretty(openAPI), "{\n" +
+                "  \"openapi\" : \"3.1.0\",\n" +
+                "  \"components\" : {\n" +
+                "    \"schemas\" : {\n" +
+                "      \"test\" : { }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+        System.out.println("--------- schema 3.0 ----------");
+        Json.prettyPrint(openAPI.getComponents().getSchemas().get("test"));
+        assertEquals(Json.pretty(openAPI.getComponents().getSchemas().get("test")), "{ }");
+        System.out.println("--------- root YAML 3.0 ----------");
+        Yaml.prettyPrint(openAPI);
+        assertEquals(Yaml.pretty(openAPI), "openapi: 3.1.0\n" +
+                "components:\n" +
+                "  schemas:\n" +
+                "    test: {}\n");
+        System.out.println("--------- schema YAML 3.0 ----------");
+        Yaml.prettyPrint(openAPI.getComponents().getSchemas().get("test"));
+        assertEquals(Yaml.pretty(openAPI.getComponents().getSchemas().get("test")), "{}\n");
+    }
 
 }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -246,6 +246,14 @@ public class Schema<T> {
     private List<T> examples;
 
     /**
+     * @since 2.2.2 (OpenAPI 3.1.0)
+     *
+     * when set, this represents a boolean schema value
+     */
+    @OpenAPI31
+    private Boolean booleanSchemaValue;
+
+    /**
      *
      * @since 2.2.0 (OpenAPI 3.1.0)
      */
@@ -2122,6 +2130,34 @@ public class Schema<T> {
     @OpenAPI31
     public Schema _const(Object _const) {
         this._const = cast(_const);
+        return this;
+    }
+
+    /**
+     *
+     * @since 2.2.2 (OpenAPI 3.1.0)
+     */
+    @OpenAPI31
+    public Boolean getBooleanSchemaValue() {
+        return booleanSchemaValue;
+    }
+
+    /**
+     *
+     * @since 2.2.2 (OpenAPI 3.1.0)
+     */
+    @OpenAPI31
+    public void setBooleanSchemaValue(Boolean booleanSchemaValue) {
+        this.booleanSchemaValue = booleanSchemaValue;
+    }
+
+    /**
+     *
+     * @since 2.2.2 (OpenAPI 3.1.0)
+     */
+    @OpenAPI31
+    public Schema booleanSchemaValue(Boolean booleanSchemaValue) {
+        this.booleanSchemaValue = booleanSchemaValue;
         return this;
     }
 }


### PR DESCRIPTION
refs swagger-api/swagger-parser/issues/1757

implements boolean schema support for OAS 3.1 by (de)serializing to/from field `booleanSchemaValue`