### PR TITLE
Add @JsonTypeName support for wrapped JSON

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.annotation.JsonView;
@@ -1967,6 +1968,10 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 String name = model.getName();
                 if (JsonTypeInfo.Id.CLASS.equals(id)) {
                     name = type.getRawClass().getName();
+                }
+                JsonTypeName typeName = type.getRawClass().getDeclaredAnnotation((JsonTypeName.class));
+                if (JsonTypeInfo.Id.NAME.equals(id) && typeName != null) {
+                    name = typeName.value();
                 }
                 if(JsonTypeInfo.Id.NAME.equals(id) && name == null) {
                     name = type.getRawClass().getSimpleName();

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3699Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3699Test.java
@@ -1,0 +1,32 @@
+package io.swagger.v3.core.resolving;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.core.resolving.resources.TestObject3699;
+import org.testng.annotations.Test;
+
+public class Ticket3699Test extends SwaggerTestBase {
+
+    @Test
+    public void test3699() {
+        final ModelResolver modelResolver = new ModelResolver(mapper());
+
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+        context.resolve(new AnnotatedType(TestObject3699.class));
+
+        SerializationMatchers.assertEqualsToYaml(context.getDefinedModels(), "TestObject3699:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    CustomName:\n" +
+                "      type: object\n" +
+                "      properties:\n" +
+                "        bar:\n" +
+                "          type: string\n" +
+                "        foo:\n" +
+                "          type: array\n" +
+                "          items:\n" +
+                "            type: string\n");
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/resources/TestObject3699.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/resources/TestObject3699.java
@@ -1,0 +1,12 @@
+package io.swagger.v3.core.resolving.resources;
+
+import java.util.List;
+
+@com.fasterxml.jackson.annotation.JsonTypeInfo(
+        use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+        include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.WRAPPER_OBJECT)
+@com.fasterxml.jackson.annotation.JsonTypeName("CustomName")
+public class TestObject3699 {
+    public String bar;
+    public List<String> foo;
+}


### PR DESCRIPTION
Custom name from @JsonTypeName should be used for wrapped JSON with @JsonTypeInfo(use = NAME, include = WRAPPER_OBJECT) (if class is annotated with @JsonTypeName )
See #3699