### PR TITLE
refs #4212 - update jackson API usage to support Jackson < 2.9

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
-import com.fasterxml.jackson.databind.introspect.AnnotationMap;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
@@ -577,11 +576,8 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             if (member != null && !ignore(member, xmlAccessorTypeAnnotation, propName, propertiesToIgnore, propDef)) {
 
                 List<Annotation> annotationList = new ArrayList<>();
-                AnnotationMap annotationMap = member.getAllAnnotations();
-                if (annotationMap != null) {
-                    for (Annotation a : annotationMap.annotations()) {
-                        annotationList.add(a);
-                    }
+                for (Annotation a : member.annotations()) {
+                    annotationList.add(a);
                 }
 
                 annotations = annotationList.toArray(new Annotation[annotationList.size()]);
@@ -1120,11 +1116,8 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                             return PrimitiveType.createProperty(propType);
                         } else {
                             List<Annotation> list = new ArrayList<>();
-                            AnnotationMap annotationMap = propMember.getAllAnnotations();
-                            if (annotationMap != null) {
-                                for (Annotation a : annotationMap.annotations()) {
-                                    list.add(a);
-                                }
+                            for (Annotation a : propMember.annotations()) {
+                                list.add(a);
                             }
                             Annotation[] annotations = list.toArray(new Annotation[list.size()]);
                             AnnotatedType aType = new AnnotatedType()

--- a/modules/swagger-project-jakarta/pom.xml
+++ b/modules/swagger-project-jakarta/pom.xml
@@ -575,12 +575,8 @@
         <servlet-api-version>5.0.0</servlet-api-version>
         <jersey2-version>3.0.1</jersey2-version>
         <junit-version>4.13.1</junit-version>
-        <jackson-version>2.13.2</jackson-version>
-        <!--
-          2.13.2 is still affected by CVE-2020-36518.
-          This version pin for jackson-databind can be removed when bumping jackson to 2.14
-          -->
-        <jackson-databind-version>2.13.2.2</jackson-databind-version>
+        <jackson-version>2.13.3</jackson-version>
+        <jackson-databind-version>2.13.3</jackson-databind-version>
         <logback-version>1.2.9</logback-version>
         <classgraph-version>4.8.138</classgraph-version>
         <guava-version>31.0.1-jre</guava-version>

--- a/pom.xml
+++ b/pom.xml
@@ -655,12 +655,8 @@
         <servlet-api-version>4.0.3</servlet-api-version>
         <jersey2-version>2.26</jersey2-version>
         <junit-version>4.13.1</junit-version>
-        <jackson-version>2.13.2</jackson-version>
-        <!--
-          jackson-databind 2.13.2 is still affected by CVE-2020-36518.
-          This version pin for jackson-databind can be removed when bumping jackson to 2.14
-          -->
-        <jackson-databind-version>2.13.2.2</jackson-databind-version>
+        <jackson-version>2.13.3</jackson-version>
+        <jackson-databind-version>2.13.3</jackson-databind-version>
         <logback-version>1.2.9</logback-version>
         <classgraph-version>4.8.138</classgraph-version>
         <guava-version>31.0.1-jre</guava-version>


### PR DESCRIPTION
refs https://github.com/swagger-api/swagger-core/issues/4212 - update jackson API usage to support Jackson < 2.9