### PR TITLE
feat: replace required attribute on @Schema by requiredMode

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
@@ -164,9 +164,24 @@ public @interface Schema {
     /**
      * Mandates that the annotated item is required or not.
      *
+     * @deprecated As of 2.3.1, replaced by {@link #requiredMode()}
+     *
      * @return whether or not this schema is required
      **/
+    @Deprecated
     boolean required() default false;
+
+    /**
+     * Allows to specify the required mode (RequiredMode.AUTO, REQUIRED, NOT_REQUIRED)
+     *
+     * RequiredMode.AUTO: will let the library decide based on its heuristics.
+     * RequiredMode.REQUIRED: will force the item to be considered as required regardless of heuristics.
+     * RequiredMode.NOT_REQUIRED: will force the item to be considered as not required regardless of heuristics.
+     *
+     * @return the requiredMode for this schema (property)
+     *
+     */
+    RequiredMode requiredMode() default RequiredMode.AUTO;
 
     /**
      * A description of the schema.
@@ -336,5 +351,11 @@ public @interface Schema {
         TRUE,
         FALSE,
         USE_ADDITIONAL_PROPERTIES_ANNOTATION;
+    }
+
+    enum RequiredMode {
+        AUTO,
+        REQUIRED,
+        NOT_REQUIRED;
     }
 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -332,7 +332,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             if (xml != null) {
                 model.xml(xml);
             }
-            applyBeanValidatorAnnotations(model, annotatedType.getCtxAnnotations(), null);
+            applyBeanValidatorAnnotations(model, annotatedType.getCtxAnnotations(), null, false);
             resolveSchemaMembers(model, annotatedType);
             if (resolvedArrayAnnotation != null) {
                 ArraySchema schema = new ArraySchema();
@@ -622,6 +622,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                                         (io.swagger.v3.oas.annotations.media.Schema) propSchemaOrArray;
 
                 io.swagger.v3.oas.annotations.media.Schema.AccessMode accessMode = resolveAccessMode(propDef, type, propResolvedSchemaAnnotation);
+                io.swagger.v3.oas.annotations.media.Schema.RequiredMode requiredMode = resolveRequiredMode(propResolvedSchemaAnnotation);
 
 
                 AnnotatedType aType = new AnnotatedType()
@@ -694,7 +695,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                     }
                     property.setName(propName);
                     JAXBAnnotationsHelper.apply(propBeanDesc.getClassInfo(), annotations, property);
-                    applyBeanValidatorAnnotations(property, annotations, model);
+                    if (property != null && io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED.equals(requiredMode)) {
+                        addRequiredItem(model, property.getName());
+                    }
+                    final boolean applyNotNullAnnotations = io.swagger.v3.oas.annotations.media.Schema.RequiredMode.AUTO.equals(requiredMode);
+                    applyBeanValidatorAnnotations(property, annotations, model, applyNotNullAnnotations);
 
                     props.add(property);
                 }
@@ -1267,14 +1272,14 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         }
     }
 
-    protected void applyBeanValidatorAnnotations(Schema property, Annotation[] annotations, Schema parent) {
+    protected void applyBeanValidatorAnnotations(Schema property, Annotation[] annotations, Schema parent, boolean applyNotNullAnnotations) {
         Map<String, Annotation> annos = new HashMap<>();
         if (annotations != null) {
             for (Annotation anno : annotations) {
                 annos.put(anno.annotationType().getName(), anno);
             }
         }
-        if (parent != null && annotations != null) {
+        if (parent != null && annotations != null && applyNotNullAnnotations) {
             boolean requiredItem = Arrays.stream(annotations).anyMatch(annotation ->
                     NOT_NULL_ANNOTATIONS.contains(annotation.annotationType().getSimpleName())
             );
@@ -1684,6 +1689,15 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         }
 
         return null;
+    }
+
+    protected io.swagger.v3.oas.annotations.media.Schema.RequiredMode resolveRequiredMode(io.swagger.v3.oas.annotations.media.Schema schema) {
+        if (schema != null && !schema.requiredMode().equals(io.swagger.v3.oas.annotations.media.Schema.RequiredMode.AUTO)) {
+            return schema.requiredMode();
+        } else if (schema != null && schema.required()) {
+            return io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+        }
+        return io.swagger.v3.oas.annotations.media.Schema.RequiredMode.AUTO;
     }
 
     protected io.swagger.v3.oas.annotations.media.Schema.AccessMode resolveAccessMode(BeanPropertyDefinition propDef, JavaType type, io.swagger.v3.oas.annotations.media.Schema schema) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -77,6 +77,7 @@ public abstract class AnnotationsUtils {
                 && schema.maxProperties() == 0
                 && schema.requiredProperties().length == 0
                 && !schema.required()
+                && schema.requiredMode().equals(io.swagger.v3.oas.annotations.media.Schema.RequiredMode.AUTO)
                 && !schema.nullable()
                 && !schema.readOnly()
                 && !schema.writeOnly()
@@ -244,6 +245,9 @@ public abstract class AnnotationsUtils {
             return false;
         }
         if (thisSchema.required() != thatSchema.required()) {
+            return false;
+        }
+        if (!thisSchema.requiredMode().equals(thatSchema.requiredMode())) {
             return false;
         }
         if (thisSchema.nullable() != thatSchema.nullable()) {
@@ -1614,6 +1618,14 @@ public abstract class AnnotationsUtils {
                     return master.required();
                 }
                 return patch.required();
+            }
+
+            @Override
+            public RequiredMode requiredMode() {
+                if (!master.requiredMode().equals(RequiredMode.AUTO) || patch.requiredMode().equals(RequiredMode.AUTO)) {
+                    return master.requiredMode();
+                }
+                return patch.requiredMode();
             }
 
             @Override

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/ModelPropertyTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/ModelPropertyTest.java
@@ -7,6 +7,7 @@ import io.swagger.v3.core.oas.models.ModelWithBooleanProperty;
 import io.swagger.v3.core.oas.models.ModelWithModelPropertyOverrides;
 import io.swagger.v3.core.oas.models.ModelWithPrimitiveArray;
 import io.swagger.v3.core.oas.models.ReadOnlyFields;
+import io.swagger.v3.core.oas.models.RequiredFields;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.BooleanSchema;
 import io.swagger.v3.oas.models.media.IntegerSchema;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -95,6 +97,20 @@ public class ModelPropertyTest {
         final Map<String, Schema> models = ModelConverters.getInstance().readAll(ReadOnlyFields.class);
         Schema model = models.get("ReadOnlyFields");
         assertTrue(((Schema) model.getProperties().get("id")).getReadOnly());
+    }
+
+    @Test
+    public void testRequiredProperty() {
+        final Map<String, Schema> models = ModelConverters.getInstance().readAll(RequiredFields.class);
+        Schema model = models.get("RequiredFields");
+        assertTrue(model.getRequired().contains("required"));
+        assertFalse(model.getRequired().contains("notRequired"));
+        assertTrue(model.getRequired().contains("notRequiredWithAnnotation"));
+        assertFalse(model.getRequired().contains("modeAuto"));
+        assertTrue(model.getRequired().contains("modeAutoWithAnnotation"));
+        assertTrue(model.getRequired().contains("modeRequired"));
+        assertFalse(model.getRequired().contains("modeNotRequired"));
+        assertFalse(model.getRequired().contains("modeNotRequiredWithAnnotation"));
     }
 
     @Test

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/RequiredFields.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/RequiredFields.java
@@ -1,0 +1,34 @@
+package io.swagger.v3.core.oas.models;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.NotNull;
+
+public class RequiredFields {
+    @Schema(description = "required", required = true)
+    public Long required;
+
+    @Schema(description = "not required")
+    public Long notRequired;
+
+    @Schema(description = "not required with annotation")
+    @NotNull
+    public Long notRequiredWithAnnotation;
+
+    @Schema(description = "mode auto", requiredMode = Schema.RequiredMode.AUTO)
+    public Long modeAuto;
+
+    @Schema(description = "mode auto with annotation", requiredMode = Schema.RequiredMode.AUTO)
+    @NotNull
+    public Long modeAutoWithAnnotation;
+
+    @Schema(description = "mode required", requiredMode = Schema.RequiredMode.REQUIRED)
+    public Long modeRequired;
+
+    @Schema(description = "mode not required", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    public Long modeNotRequired;
+
+    @Schema(description = "mode not required with annotation", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @NotNull
+    public Long modeNotRequiredWithAnnotation;
+}


### PR DESCRIPTION
Add a property `requiredMode` on `@Schema` annotations that allows deciding if the heuristics on annotations like `@NotNull` should apply, so we can have a property annotated `@NotNull` but still have `required = false` in the openapi spec.

This is a second proposal for issue #4213, other proposal was #4216