### PR TITLE
Defining grouping in swagger 

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
@@ -325,6 +325,14 @@ public @interface Schema {
      */
     AdditionalPropertiesValue additionalProperties() default AdditionalPropertiesValue.USE_ADDITIONAL_PROPERTIES_ANNOTATION;
 
+    /**
+     * Specify one or more groups to link to a specific @RequestBody annotation.
+     * To define custom groups annotations for the sole purpose of using them as type-safe group arguments.
+     *
+     * @since 2.2.3
+     */
+    Class<?>[] groups() default {};
+
     enum AccessMode {
         AUTO,
         READ_ONLY,

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/parameters/RequestBody.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/parameters/RequestBody.java
@@ -60,4 +60,12 @@ public @interface RequestBody {
      **/
     String ref() default "";
 
+    /**
+     * Specify one or more groups to link to a specific @Schema annotation.
+     * To define custom groups annotations for the sole purpose of using them as type-safe group arguments.
+     *
+     * @since 2.2.3
+     */
+    Class<?>[] groups() default {};
+
 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -1780,6 +1780,15 @@ public abstract class AnnotationsUtils {
                 }
                 return patch.additionalProperties();
             }
+
+            @Override
+            public Class<?>[] groups() {
+                if ((master.groups() != null || patch.groups() == null) && (master.groups().length > 0 || (patch.groups() != null && patch.groups().length == 0))) {
+                    return master.groups();
+                }
+                return patch.groups();
+
+            }
         };
 
         return (io.swagger.v3.oas.annotations.media.Schema)schema;

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -254,6 +254,14 @@ public class Schema<T> {
     private Boolean booleanSchemaValue;
 
     /**
+     * @since 2.2.3
+     *
+     * when set, this represents the groups which the schema is created from if any
+     */
+    @JsonIgnore
+    private Class<?>[] groups;
+
+    /**
      *
      * @since 2.2.0 (OpenAPI 3.1.0)
      */
@@ -2160,6 +2168,30 @@ public class Schema<T> {
     @OpenAPI31
     public Schema booleanSchemaValue(Boolean booleanSchemaValue) {
         this.booleanSchemaValue = booleanSchemaValue;
+        return this;
+    }
+    /**
+     *
+     * @since 2.2.3
+     */
+    public Class<?>[] getGroups() {
+        return groups;
+    }
+
+    /**
+     *
+     * @since 2.2.3
+     */
+    public void setGroups(Class<?>[] groups) {
+        this.groups = groups;
+    }
+
+    /**
+     *
+     * @since 2.2.3
+     */
+    public Schema groups(Class<?>[] groups) {
+        this.groups = groups;
         return this;
     }
 }


### PR DESCRIPTION
Defining grouping in swagger endpoints to reduce the challenges brought in creating a per class request models in huge system for better maintainability and for less class redundancy.