### PR TITLE
new ReferenceTypeUtils code fails with IllegalArgumentException with type.getType() is null

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReferenceTypeUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReferenceTypeUtils.java
@@ -24,7 +24,7 @@ public abstract class ReferenceTypeUtils {
      */
     public static AnnotatedType unwrapReference(AnnotatedType type) {
 
-        if (type == null) {
+        if (type == null || type.getType() == null) {
             return type;
         }
         try {


### PR DESCRIPTION
New code in ReferenceTypeUtils causes exception when using swagger-core with Scala Options.

```
java.lang.IllegalArgumentException: argument "t" is null
	at com.fasterxml.jackson.databind.ObjectMapper._assertNotNull(ObjectMapper.java:4885)
	at com.fasterxml.jackson.databind.ObjectMapper.constructType(ObjectMapper.java:2211)
	at io.swagger.v3.core.util.ReferenceTypeUtils.unwrapReference(ReferenceTypeUtils.java:35)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:79)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:81)
	at io.swagger.v3.core.converter.ModelConverters.readAll(ModelConverters.java:89)
	at io.swagger.v3.core.converter.ModelConverters.readAll(ModelConverters.java:80)
	at com.github.swagger.akka.converter.ModelPropertyParserTest.$anonfun$new$11(ModelPropertyParserTest.scala:163)
```

