### PR TITLE
fix handling for case where type.getType() is null

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReferenceTypeUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReferenceTypeUtils.java
@@ -24,8 +24,10 @@ public abstract class ReferenceTypeUtils {
      */
     public static AnnotatedType unwrapReference(AnnotatedType type) {
 
-        if (type == null || type.getType() == null) {
+        if (type == null) {
             return type;
+        } else if (type.getType() == null) {
+            return null;
         }
         try {
             final JavaType jtype;


### PR DESCRIPTION
Relates to https://github.com/swagger-api/swagger-core/pull/4297