### PR TITLE
Support of CompletionStage (JaxRS 2.1)

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -69,6 +69,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 public class Reader implements OpenApiReader {
@@ -1071,7 +1072,7 @@ public class Reader implements OpenApiReader {
         Type returnType = method.getGenericReturnType();
 
         if (annotatedMethod != null && annotatedMethod.getType() != null) {
-            returnType = annotatedMethod.getType();
+            returnType = extractTypeFromMethod(annotatedMethod);
         }
 
         final Class<?> subResource = getSubResourceWithJaxRsSubresourceLocatorSpecs(method);
@@ -1131,6 +1132,14 @@ public class Reader implements OpenApiReader {
 
 
         return operation;
+    }
+
+    private Type extractTypeFromMethod(AnnotatedMethod annotatedMethod) {
+        if(CompletionStage.class.isAssignableFrom(annotatedMethod.getType().getRawClass())) {
+            // CompletionStage's 1st generic type is the real return type.
+            return annotatedMethod.getType().getBindings().getBoundType(0);
+        }
+        return annotatedMethod.getType();
     }
 
     protected Content resolveEmptyContent(Produces classProduces, Produces methodProduces) {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -125,7 +125,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -714,6 +717,36 @@ public class ReaderTest {
         @io.swagger.v3.oas.annotations.Operation(tags = "/receiver/rest")
         //public void test1(@QueryParam("aa") String a) {
         public void test1(A a) {
+        }
+    }
+
+    @Test
+    public void testClassWithCompletableFuture() {
+        Reader reader = new Reader(new OpenAPI());
+        OpenAPI openAPI = reader.read(ClassWithCompletableFuture.class);
+        assertNotNull(openAPI);
+
+        assertEquals(
+            openAPI.getPaths()
+                    .get("/myApi")
+                    .getGet()
+                    .getResponses()
+                    .get("default")
+                    .getContent()
+                    .get("application/json")
+                    .getSchema()
+                    .get$ref(),
+                "#/components/schemas/Ret"
+        );
+    }
+
+    static class ClassWithCompletableFuture {
+        @Path("/myApi")
+        @Produces("application/json")
+        @Consumes("application/json")
+        @GET
+        public CompletableFuture<Ret> myApi(A a) {
+            return CompletableFuture.completedFuture(new Ret());
         }
     }
 


### PR DESCRIPTION
Hello,

CompletionStage is officially supported since JavaEE JaxRS2.1 (see official specs [here](https://github.com/javaee/jax-rs-spec/blob/2.1/spec.pdf), page 55: 8.2.2 CompletionStage), same goes for Jakarta restful-ws (see official specs [here](https://jakarta.ee/specifications/restful-ws/3.0/jakarta-restful-ws-spec-3.0.html), 8.2.2 CompletionStage)

This PR adds an extraction of `CompletionStage` associated type.