### PR TITLE
Fix Schema annotation with nullable and "null" example or defaultValue

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -2191,6 +2191,10 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         if (StringUtils.isNotBlank(format) && StringUtils.isBlank(schema.getFormat())) {
             schema.format(format);
         }
+        Boolean nullable = resolveNullable(a, annotations, schemaAnnotation);
+        if (nullable != null) {
+            schema.nullable(nullable);
+        }
         Object defaultValue = resolveDefaultValue(a, annotations, schemaAnnotation);
         if (defaultValue != null) {
             schema.setDefault(defaultValue);
@@ -2202,10 +2206,6 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         Boolean readOnly = resolveReadOnly(a, annotations, schemaAnnotation);
         if (readOnly != null) {
             schema.readOnly(readOnly);
-        }
-        Boolean nullable = resolveNullable(a, annotations, schemaAnnotation);
-        if (nullable != null) {
-            schema.nullable(nullable);
         }
         BigDecimal multipleOf = resolveMultipleOf(a, annotations, schemaAnnotation);
         if (multipleOf != null) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/SchemaSerializer.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/SchemaSerializer.java
@@ -32,10 +32,15 @@ public class SchemaSerializer extends JsonSerializer<Schema> implements Resolvab
 
         if (StringUtils.isBlank(value.get$ref())) {
 
-            if (value.getExampleSetFlag() && value.getExample() == null) {
+            if (value.getExampleSetFlag() && value.getExample() == null || value.getDefaultSetFlag() && value.getDefault() == null) {
                 jgen.writeStartObject();
                 defaultSerializer.unwrappingSerializer(null).serialize(value, jgen, provider);
-                jgen.writeNullField("example");
+                if (value.getExampleSetFlag() && value.getExample() == null) {
+                    jgen.writeNullField("example");
+                }
+                if (value.getDefaultSetFlag() && value.getDefault() == null) {
+                    jgen.writeNullField("default");
+                }
                 jgen.writeEndObject();
             } else {
                 defaultSerializer.serialize(value, jgen, provider);

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/Schema31Mixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/Schema31Mixin.java
@@ -53,6 +53,9 @@ public abstract class Schema31Mixin {
     @JsonIgnore
     public abstract boolean getExampleSetFlag();
 
+    @JsonIgnore
+    public abstract boolean getDefaultSetFlag();
+
     @JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)
     public abstract Object getExample();
 

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/SchemaConverterMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/SchemaConverterMixin.java
@@ -25,6 +25,9 @@ public abstract class SchemaConverterMixin {
     @JsonIgnore
     public abstract boolean getExampleSetFlag();
 
+    @JsonIgnore
+    public abstract boolean getDefaultSetFlag();
+
     @JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)
     public abstract Object getExample();
 

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/SchemaMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/SchemaMixin.java
@@ -22,6 +22,9 @@ public abstract class SchemaMixin {
     @JsonIgnore
     public abstract boolean getExampleSetFlag();
 
+    @JsonIgnore
+    public abstract boolean getDefaultSetFlag();
+
     @JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)
     public abstract Object getExample();
 

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -436,6 +436,9 @@ public abstract class AnnotationsUtils {
         if (StringUtils.isNotBlank(schema.type())) {
             schemaObject.setType(schema.type());
         }
+        if (schema.nullable()) {
+            schemaObject.setNullable(schema.nullable());
+        }
         if (StringUtils.isNotBlank(schema.defaultValue())) {
             schemaObject.setDefault(schema.defaultValue());
         }
@@ -486,9 +489,6 @@ public abstract class AnnotationsUtils {
         if (NumberUtils.isCreatable(schema.minimum())) {
             String filteredMinimum = schema.minimum().replace(Constants.COMMA, StringUtils.EMPTY);
             schemaObject.setMinimum(new BigDecimal(filteredMinimum));
-        }
-        if (schema.nullable()) {
-            schemaObject.setNullable(schema.nullable());
         }
         if (StringUtils.isNotBlank(schema.title())) {
             schemaObject.setTitle(schema.title());

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4339Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4339Test.java
@@ -1,0 +1,54 @@
+package io.swagger.v3.core.resolving;
+
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.core.resolving.resources.TestObjectTicket4339;
+import org.testng.annotations.Test;
+
+public class Ticket4339Test {
+    @Test
+    public void testNullableWithNull() {
+        SerializationMatchers.assertEqualsToYaml(ModelConverters.getInstance().readAll(TestObjectTicket4339.class), "Address:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    streetNumber:\n" +
+                "      type: integer\n" +
+                "      format: int32\n" +
+                "  nullable: true\n" +
+                "  example: null\n" +
+                "  default: null\n" +
+                "TestObjectTicket4339:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    string:\n" +
+                "      type: string\n" +
+                "      nullable: true\n" +
+                "      example: null\n" +
+                "      default: null\n" +
+                "    integer:\n" +
+                "      type: integer\n" +
+                "      format: int32\n" +
+                "      nullable: true\n" +
+                "      example: null\n" +
+                "      default: null\n" +
+                "    number:\n" +
+                "      type: number\n" +
+                "      nullable: true\n" +
+                "      example: null\n" +
+                "      default: null\n" +
+                "    aBoolean:\n" +
+                "      type: boolean\n" +
+                "      nullable: true\n" +
+                "      example: null\n" +
+                "      default: null\n" +
+                "    address:\n" +
+                "      $ref: '#/components/schemas/Address'\n" +
+                "    testObjectTicket4339List:\n" +
+                "      type: array\n" +
+                "      nullable: true\n" +
+                "      items:\n" +
+                "        $ref: '#/components/schemas/TestObjectTicket4339'\n" +
+                "      example: null\n" +
+                "      default: null\n");
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/resources/TestObjectTicket4339.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/resources/TestObjectTicket4339.java
@@ -1,0 +1,33 @@
+package io.swagger.v3.core.resolving.resources;
+
+import io.swagger.v3.core.oas.models.Address;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class TestObjectTicket4339 {
+    // type: string
+    @Schema(nullable = true, example = "null", defaultValue = "null")
+    public String string;
+
+    // type: integer
+    @Schema(nullable = true, example = "null", defaultValue = "null")
+    public Integer integer;
+
+    // type: number
+    @Schema(nullable = true, example = "null", defaultValue = "null")
+    public BigDecimal number;
+
+    // type: boolean
+    @Schema(nullable = true, example = "null", defaultValue = "null")
+    public Boolean aBoolean;
+
+    // type: object
+    @Schema(nullable = true, example = "null", defaultValue = "null")
+    public Address address;
+
+    // type: array
+    @Schema(nullable = true, example = "null", defaultValue = "null")
+    public List<TestObjectTicket4339> testObjectTicket4339List;
+}

--- a/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/GenericOpenApiContext.java
+++ b/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/GenericOpenApiContext.java
@@ -670,6 +670,9 @@ public class GenericOpenApiContext<T extends GenericOpenApiContext> implements O
         @JsonIgnore
         public abstract boolean getExampleSetFlag();
 
+        @JsonIgnore
+        public abstract boolean getDefaultSetFlag();
+
         @JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)
         public abstract Object getExample();
 
@@ -752,6 +755,9 @@ public class GenericOpenApiContext<T extends GenericOpenApiContext> implements O
 
         @JsonIgnore
         public abstract boolean getExampleSetFlag();
+
+        @JsonIgnore
+        public abstract boolean getDefaultSetFlag();
 
         @JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)
         public abstract Object getExample();

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/SortedOutputTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/SortedOutputTest.java
@@ -114,6 +114,9 @@ public class SortedOutputTest {
         @JsonIgnore
         public abstract boolean getExampleSetFlag();
 
+        @JsonIgnore
+        public abstract boolean getDefaultSetFlag();
+
         @JsonInclude(value = JsonInclude.Include.NON_NULL, content = JsonInclude.Include.ALWAYS)
         public abstract Object getExample();
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -1341,9 +1341,14 @@ public class Schema<T> {
     }
 
     public void setExample(Object example) {
-        this.example = cast(example);
-        if (!(example != null && this.example == null)) {
+        if (SpecVersion.V30.equals(specVersion) && Boolean.TRUE.equals(nullable) && (example == null || "null".equals(example.toString()))) {
+            this.example = null;
             exampleSetFlag = true;
+        } else {
+            this.example = cast(example);
+            if (!(example != null && this.example == null)) {
+                exampleSetFlag = true;
+            }
         }
     }
 
@@ -1425,7 +1430,6 @@ public class Schema<T> {
     }
 
     /**
-     *
      * @since 2.2.0 (OpenAPI 3.1.0)
      */
     @OpenAPI31

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -69,6 +69,7 @@ public class Schema<T> {
     private Discriminator discriminator = null;
 
     private boolean exampleSetFlag;
+    private boolean defaultSetFlag;
 
     /**
      * @since 2.2.0 (OpenAPI 3.1.0)
@@ -778,7 +779,15 @@ public class Schema<T> {
     }
 
     public void setDefault(Object _default) {
-        this._default = cast(_default);
+        if (SpecVersion.V30.equals(specVersion) && Boolean.TRUE.equals(nullable) && (_default == null || "null".equals(_default.toString()))) {
+            this._default = null;
+            defaultSetFlag = true;
+        } else {
+            this._default = cast(_default);
+            if (!(_default != null && this._default == null)) {
+                defaultSetFlag = true;
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -1427,6 +1436,20 @@ public class Schema<T> {
 
     public void setExampleSetFlag(boolean exampleSetFlag) {
         this.exampleSetFlag = exampleSetFlag;
+    }
+
+    /**
+     * returns true if default setter has been invoked
+     * Used to flag explicit setting to null of default (vs missing field) while deserializing from json/yaml string
+     *
+     * @return boolean defaultSetFlag
+     **/
+    public boolean getDefaultSetFlag() {
+        return defaultSetFlag;
+    }
+
+    public void setDefaultSetFlag(boolean defaultSetFlag) {
+        this.defaultSetFlag = defaultSetFlag;
     }
 
     /**
@@ -2104,7 +2127,7 @@ public class Schema<T> {
     }
 
     public Schema _default(T _default) {
-        this._default = _default;
+        setDefault(_default);
         return this;
     }
 


### PR DESCRIPTION
This PR does the following:
- When nullable is set to `true` in a `@Schema` annotation we can provide `"null"` to `example` and/or `defaultValue`

Fixes #4339