### PR TITLE
Fix to "Backslashes are added in long texts" issue.

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ObjectMapperFactory.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ObjectMapperFactory.java
@@ -12,7 +12,9 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactoryBuilder;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.fasterxml.jackson.dataformat.yaml.util.StringQuotingChecker;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.swagger.v3.core.jackson.ExampleSerializer;
 import io.swagger.v3.core.jackson.Schema31Serializer;
@@ -68,6 +70,7 @@ import io.swagger.v3.oas.models.servers.ServerVariable;
 import io.swagger.v3.oas.models.servers.ServerVariables;
 import io.swagger.v3.oas.models.tags.Tag;
 
+import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -78,7 +81,9 @@ public class ObjectMapperFactory {
     }
 
     protected static ObjectMapper createYaml(boolean openapi31) {
-        YAMLFactory factory = new YAMLFactory();
+        YAMLFactory factory = new YAMLFactoryBuilder(new YAMLFactory())
+                .stringQuotingChecker(new QuotingChecker())
+                .build();
         factory.disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER);
         factory.enable(YAMLGenerator.Feature.MINIMIZE_QUOTES);
         factory.enable(YAMLGenerator.Feature.SPLIT_LINES);

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/QuotingChecker.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/QuotingChecker.java
@@ -1,0 +1,49 @@
+package io.swagger.v3.core.util;
+
+import com.fasterxml.jackson.dataformat.yaml.util.StringQuotingChecker;
+
+import java.io.Serializable;
+
+public class QuotingChecker extends StringQuotingChecker implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    protected boolean valueHasQuotableChar(String inputStr) {
+        int end = inputStr.length();
+
+        for(int i = 0; i < end; ++i) {
+            char d;
+            switch(inputStr.charAt(i)) {
+                case '#':
+                    if (i > 0) {
+                        d = inputStr.charAt(i - 1);
+                        if (' ' == d || '\t' == d) {
+                            return true;
+                        }
+                    }
+                    break;
+                case '[':
+                case ']':
+                case '{':
+                case '}':
+                    return true;
+                case ':':
+                    if (i < end - 1) {
+                        d = inputStr.charAt(i + 1);
+                        if (' ' == d || '\t' == d) {
+                            return true;
+                        }
+                    }
+            }
+        }
+
+        return false;
+    }
+
+    public boolean needToQuoteName(String name) {
+        return this.isReservedKeyword(name) || this.looksLikeYAMLNumber(name) || this.nameHasQuotableChar(name);
+    }
+
+    public boolean needToQuoteValue(String value) {
+        return this.isReservedKeyword(value) || this.valueHasQuotableChar(value);
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/YamlSerializerTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/YamlSerializerTest.java
@@ -2,7 +2,12 @@ package io.swagger.v3.core.serialization;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
 import org.testng.annotations.Test;
+
+import java.util.Arrays;
 
 import static org.testng.Assert.assertEquals;
 
@@ -68,5 +73,31 @@ public class YamlSerializerTest {
         String serializedYaml = Yaml.pretty(node);
 
         assertEquals(serializedYaml, yaml);
+    }
+
+    @Test
+    public void testNoBackSlashesAddedInYaml() throws Exception {
+        OpenAPI openAPI = new OpenAPI()
+                .openapi("3.0.0")
+                .info(new Info()
+                        .title("Test long description")
+                        .version("1.0.0")
+                        .description("Lorem ipsum dolor sit amet consectetur adipiscing elit, ligula integer tempus proin mattis fusce. Proin vivamus phasellus tincidunt sapien inceptos viverra turpis vehicula neque sociosqu, nostra rhoncus sagittis cursus dapibus dignissim ornare consequat curabitur, imperdiet lacus facilisis ridiculus ante molestie convallis accumsan donec. Laoreet pulvinar feugiat velit proin rhoncus dis ullamcorper, curae nullam at penatibus tempor quis."))
+                .servers(Arrays.asList(new Server().url("/")));
+
+        String serializedYaml = Yaml.pretty(openAPI);
+
+        assertEquals(serializedYaml, "openapi: 3.0.0\n" +
+                "info:\n" +
+                "  title: Test long description\n" +
+                "  description: Lorem ipsum dolor sit amet consectetur adipiscing elit, ligula integer\n" +
+                "    tempus proin mattis fusce. Proin vivamus phasellus tincidunt sapien inceptos viverra\n" +
+                "    turpis vehicula neque sociosqu, nostra rhoncus sagittis cursus dapibus dignissim\n" +
+                "    ornare consequat curabitur, imperdiet lacus facilisis ridiculus ante molestie\n" +
+                "    convallis accumsan donec. Laoreet pulvinar feugiat velit proin rhoncus dis ullamcorper,\n" +
+                "    curae nullam at penatibus tempor quis.\n" +
+                "  version: 1.0.0\n" +
+                "servers:\n" +
+                "- url: /\n");
     }
 }


### PR DESCRIPTION
The problem is related to a quoating check feature added in jackson.
https://github.com/FasterXML/jackson-dataformats-text/blob/2.15/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/YAMLGenerator.java#L664-L668

Basically any text that contains a comma `,` will be quoted on serialization.
https://github.com/FasterXML/jackson-dataformats-text/blob/2.15/yaml/src/main/java/com/fasterxml/jackson/dataformat/yaml/util/StringQuotingChecker.java#L132-L165

On long text this makes that backslashes be added when the text is wrapped.

So, this PR is filed to ignore the comma `,` on quoting checking to keep the text without quotes and avoid the present of backslashes.