### PR TITLE
Fix for #4362 - Resolving Schema for system enums fails if enumsAsRef is enabled

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -188,7 +188,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             if (!annotatedType.isSkipSchemaName() && resolvedSchemaAnnotation != null && !resolvedSchemaAnnotation.name().isEmpty()) {
                 name = resolvedSchemaAnnotation.name();
             }
-            if (StringUtils.isBlank(name) && !ReflectionUtils.isSystemType(type)) {
+            if (StringUtils.isBlank(name) && (type.isEnumType() || !ReflectionUtils.isSystemType(type))) {
                 name = _typeName(type, beanDesc);
             }
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4362Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4362Test.java
@@ -1,0 +1,43 @@
+package io.swagger.v3.core.resolving;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+
+public class Ticket4362Test extends SwaggerTestBase {
+
+    @AfterMethod
+    public void afterTest() {
+        ModelResolver.enumsAsRef = false;
+    }
+
+    @Test
+    public void testAnyOf() throws Exception {
+        ModelResolver.enumsAsRef = true;
+
+        final ModelResolver modelResolver = new ModelResolver(mapper());
+
+        final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        final Schema model = context
+                .resolve(new AnnotatedType(DayOfWeek.class));
+
+        SerializationMatchers.assertEqualsToYaml(context.getDefinedModels(), "DayOfWeek:\n" +
+                "  type: string\n" +
+                "  enum:\n" +
+                "  - MONDAY\n" +
+                "  - TUESDAY\n" +
+                "  - WEDNESDAY\n" +
+                "  - THURSDAY\n" +
+                "  - FRIDAY\n" +
+                "  - SATURDAY\n" +
+                "  - SUNDAY");
+    }
+
+}


### PR DESCRIPTION
This PR does the following:
- Fixes `NullPointerException` thrown when `ModelResolver.enumsAsRef` is set to `true`  and schema is being resolved for enum located `java.` or `javax.` package (e.g. `java.time.DayOfWeek` or `java.time.Month`)

Fixes https://github.com/swagger-api/swagger-core/issues/4362