### PR TITLE
add support of visibility of properties not annotated with jsonview b…

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/converter/AnnotatedType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/converter/AnnotatedType.java
@@ -22,6 +22,7 @@ public class AnnotatedType {
     private Annotation[] ctxAnnotations;
     private boolean resolveAsRef;
     private JsonView jsonViewAnnotation;
+    private boolean includePropertiesWithoutJSONView = true;
     private boolean skipSchemaName;
     private boolean skipJsonIdentity;
     private String propertyName;
@@ -188,6 +189,19 @@ public class AnnotatedType {
 
     public AnnotatedType jsonViewAnnotation(JsonView jsonViewAnnotation) {
         this.jsonViewAnnotation = jsonViewAnnotation;
+        return this;
+    }
+
+    public boolean isIncludePropertiesWithoutJSONView() {
+        return includePropertiesWithoutJSONView;
+    }
+
+    public void setIncludePropertiesWithoutJSONView(boolean includePropertiesWithoutJSONView) {
+        this.includePropertiesWithoutJSONView = includePropertiesWithoutJSONView;
+    }
+
+    public AnnotatedType includePropertiesWithoutJSONView(boolean includePropertiesWithoutJSONView) {
+        this.includePropertiesWithoutJSONView = includePropertiesWithoutJSONView;
         return this;
     }
 

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -2879,7 +2879,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             return false;
 
         Class<?>[] filters = jsonView.value();
-        boolean containsJsonViewAnnotation = false;
+        boolean containsJsonViewAnnotation = !type.isIncludePropertiesWithoutJSONView();
         for (Annotation ant : annotations) {
             if (ant instanceof JsonView) {
                 containsJsonViewAnnotation = true;

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/JsonViewTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/JsonViewTest.java
@@ -1,0 +1,82 @@
+package io.swagger.v3.core.resolving;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.resolving.resources.JsonViewObject;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.Test;
+import org.testng.Assert;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import static io.swagger.v3.core.resolving.SwaggerTestBase.mapper;
+
+public class JsonViewTest {
+
+  @Test
+  @JsonView(JsonViewObject.View.Protected.class)
+  public void includePropertiesToWhichJsonviewIsNotAnnotated() throws NoSuchMethodException {
+    ObjectMapper mapper = mapper();
+    final ModelResolver modelResolver = new ModelResolver(mapper);
+    final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+    Schema model = context
+        .resolve(new AnnotatedType(JsonViewObject.Person.class)
+            .jsonViewAnnotation(new JsonView() {
+              public Class<? extends Annotation> annotationType() {
+                return JsonView.class;
+              }
+              public Class<?>[] value() {
+                return new Class[] {JsonViewObject.View.Protected.class};
+              }
+            })
+            .ctxAnnotations(
+                this.getClass()
+                    .getMethod("includePropertiesToWhichJsonviewIsNotAnnotated")
+                    .getAnnotations()));
+
+    Map<String, Schema> properties = model.getProperties();
+    Assert.assertEquals(properties.size(), 4);
+    Assert.assertNotNull(properties.get("id"));
+    Assert.assertNotNull(properties.get("firstName"));
+    Assert.assertNotNull(properties.get("lastName"));
+    Assert.assertNotNull(properties.get("email"));
+  }
+
+  @Test
+  @JsonView(JsonViewObject.View.Protected.class)
+  public void notIncludePropertiesToWhichJsonviewIsNotAnnotated() throws NoSuchMethodException {
+    ObjectMapper mapper = mapper();
+    mapper.disable(MapperFeature.DEFAULT_VIEW_INCLUSION);
+
+    final ModelResolver modelResolver = new ModelResolver(mapper);
+    final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+    Schema model = context
+        .resolve(new AnnotatedType(JsonViewObject.Person.class)
+            .jsonViewAnnotation(new JsonView() {
+              public Class<? extends Annotation> annotationType() {
+                return JsonView.class;
+              }
+              public Class<?>[] value() {
+                return new Class[] {JsonViewObject.View.Protected.class};
+              }
+            })
+            .includePropertiesWithoutJSONView(false)
+            .ctxAnnotations(
+                this.getClass()
+                    .getMethod("includePropertiesToWhichJsonviewIsNotAnnotated")
+                    .getAnnotations()));
+
+    Map<String, Schema> properties = model.getProperties();
+    Assert.assertEquals(properties.size(), 3);
+    Assert.assertNotNull(properties.get("id"));
+    Assert.assertNotNull(properties.get("firstName"));
+    Assert.assertNotNull(properties.get("lastName"));
+  }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/resources/JsonViewObject.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/resources/JsonViewObject.java
@@ -1,0 +1,34 @@
+package io.swagger.v3.core.resolving.resources;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+public class JsonViewObject {
+  public static class View {
+
+    public interface Public {
+    }
+
+    public interface Protected {
+    }
+
+    public interface Private {
+    }
+  }
+
+  public static class Person {
+
+    @JsonView({View.Public.class, View.Protected.class, View.Private.class})
+    public String id;
+
+    @JsonView({View.Protected.class, View.Private.class})
+    public String firstName;
+
+    @JsonView({View.Protected.class, View.Private.class})
+    public String lastName;
+
+    @JsonView(View.Private.class)
+    public String address;
+
+    public String email;
+  }
+}


### PR DESCRIPTION
fix #4127.

In jackson, the DEFAULT_VIEW_INCLUSION feature changes whether or not to display properties that do not have the jsonview annotation.
This is a pr to deal with it.