### PR TITLE
fix #3581: recognize Hidden annotation on enum values.

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -1064,6 +1064,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             for (Enum<?> en : enumConstants) {
                 String n;
 
+                Field enumField = ReflectionUtils.findField(en.name(), enumClass);
+                if (null != enumField && enumField.isAnnotationPresent(Hidden.class)) {
+                    continue;
+                }
+
                 String enumValue = enumValues[en.ordinal()];
                 String methodValue = jsonValueMethod.flatMap(m -> ReflectionUtils.safeInvoke(m, en)).map(Object::toString).orElse(null);
                 String fieldValue = jsonValueField.flatMap(f -> ReflectionUtils.safeGet(f, en)).map(Object::toString).orElse(null);

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
@@ -161,6 +161,24 @@ public class ReflectionUtils {
     }
 
     /**
+     * Searches the field name in given class cls. If the field is found returns it, else return null.
+     *
+     * @param name is the field to search
+     * @param cls  is the class or interface where to search
+     * @return field if it is found
+     */
+    public static Field findField(String name, Class<?> cls) {
+        if (cls == null) {
+            return null;
+        }
+        try {
+            return cls.getField(name);
+        } catch (NoSuchFieldException nsfe) {
+            return null;
+        }
+    }
+
+    /**
      * Searches the method methodToFind in given class cls. If the method is found returns it, else return null.
      *
      * @param methodToFind is the method to search

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonNumberValueEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonNumberValueEnum.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.core.oas.models;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.Hidden;
 
 /**
  * Enum holds values different from names.  Schema model will derive Integer value from jackson annotation JsonValue on public method.
@@ -8,7 +9,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum JacksonNumberValueEnum {
     FIRST(2),
     SECOND(4),
-    THIRD(6);
+    THIRD(6),
+    @Hidden HIDDEN(-1);
 
     private final int value;
 

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonNumberValueFieldEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonNumberValueFieldEnum.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.core.oas.models;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.Hidden;
 
 /**
  * Enum holds values different from names. Schema model will derive Integer value from jackson annotation JsonValue on private field.
@@ -8,7 +9,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum JacksonNumberValueFieldEnum {
     FIRST(2),
     SECOND(4),
-    THIRD(6);
+    THIRD(6),
+    @Hidden HIDDEN(-1);
 
     @JsonValue
     private final int value;

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonPropertyEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonPropertyEnum.java
@@ -1,10 +1,12 @@
 package io.swagger.v3.core.oas.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.Hidden;
 
 public enum JacksonPropertyEnum {
     @JsonProperty("p1") PRIVATE,
     @JsonProperty("p2") PUBLIC,
     SYSTEM,
-    INVITE_ONLY
+    INVITE_ONLY,
+    @Hidden HIDDEN
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValueEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValueEnum.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.core.oas.models;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.Hidden;
 
 /**
  * Enum holds values different from names. Schema model will derive String value from jackson annotation JsonValue on public method.
@@ -8,7 +9,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum JacksonValueEnum {
     FIRST("one"),
     SECOND("two"),
-    THIRD("three");
+    THIRD("three"),
+    @Hidden HIDDEN("hidden");
 
     private final String value;
 

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValueFieldEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValueFieldEnum.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.core.oas.models;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.Hidden;
 
 /**
  * Enum holds values different from names.  Schema model will derive String value from jackson annotation JsonValue on private field.
@@ -8,7 +9,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum JacksonValueFieldEnum {
     FIRST("one"),
     SECOND("two"),
-    THIRD("three");
+    THIRD("three"),
+    @Hidden HIDDEN("hidden");
 
     @JsonValue
     private final String value;

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValuePrivateEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValuePrivateEnum.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.core.oas.models;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.Hidden;
 
 /**
  * Enum holds values different from names.  Schema model will derive String value from jackson annotation JsonValue on private method.
@@ -8,7 +9,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum JacksonValuePrivateEnum {
     FIRST("one"),
     SECOND("two"),
-    THIRD("three");
+    THIRD("three"),
+    @Hidden HIDDEN("hidden");
 
     private final String value;
 


### PR DESCRIPTION
This fixes #3581

If you place Hidden annotation on enum constant this value will be excluded from swagger model.