### PR TITLE
Change ModelResolver to better handle JsonIgnoreProperties

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -2150,6 +2150,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         		propertiesToIgnore.addAll(Arrays.asList(ignoreProperties.value()));
         	}
         }
+        propertiesToIgnore.addAll(resolveIgnoredProperties(annotations));
         return propertiesToIgnore;
     }
     

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -2146,20 +2146,23 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         Set<String> propertiesToIgnore = new HashSet<>();
         JsonIgnoreProperties ignoreProperties = a.get(JsonIgnoreProperties.class);
         if (ignoreProperties != null) {
-            propertiesToIgnore.addAll(Arrays.asList(ignoreProperties.value()));
+        	if(!ignoreProperties.allowGetters()) {
+        		propertiesToIgnore.addAll(Arrays.asList(ignoreProperties.value()));
+        	}
         }
-        propertiesToIgnore.addAll(resolveIgnoredProperties(annotations));
         return propertiesToIgnore;
     }
-
+    
     protected Set<String> resolveIgnoredProperties(Annotation[] annotations) {
 
         Set<String> propertiesToIgnore = new HashSet<>();
         if (annotations != null) {
             for (Annotation annotation : annotations) {
                 if (annotation instanceof JsonIgnoreProperties) {
-                    propertiesToIgnore.addAll(Arrays.asList(((JsonIgnoreProperties) annotation).value()));
-                    break;
+                    if (!((JsonIgnoreProperties) annotation).allowGetters()) {
+                        propertiesToIgnore.addAll(Arrays.asList(((JsonIgnoreProperties) annotation).value()));
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Rather than ignoring all properties with @JsonIgnoreProperties, we only ignore if it doesn't have the "allowGetters" = true

Since if it allowsGetters, you are going to receive it as part of the response

https://github.com/swagger-api/swagger-core/issues/3410

https://github.com/swagger-api/swagger-core/issues/4416


For example, the following line would cause var1 and var2 to be excluded:

`@JsonIgnoreProperties(value = { "var1" , "var2" })`

However if it has allowGetters, it isn't excluded
`@JsonIgnoreProperties(value = { "var1" , "var2" }, allowGetters = true`