### PR TITLE
JAX-RS: make Reader more easy to extend

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -97,11 +97,7 @@ public class Reader implements OpenApiReader {
     private static final String OPTIONS_METHOD = "options";
 
     public Reader() {
-        this.openAPI = new OpenAPI();
-        paths = new Paths();
-        openApiTags = new LinkedHashSet<>();
-        components = new Components();
-
+        this(new OpenAPI(), new Paths(), new LinkedHashSet<>(), new Components());
     }
 
     public Reader(OpenAPI openAPI) {
@@ -114,9 +110,19 @@ public class Reader implements OpenApiReader {
         setConfiguration(openApiConfiguration);
     }
 
+    protected Reader(OpenAPI openAPI, Paths paths, Set<Tag> openApiTags, Components components) {
+        this.openAPI = openAPI;
+        this.paths = paths;
+        this.openApiTags = openApiTags;
+        this.components = components;
+    }
+
     public OpenAPI getOpenAPI() {
         return openAPI;
     }
+    protected Set<Tag> getOpenApiTags() { return openApiTags; }
+    protected  Components getComponents() { return components; }
+    protected Paths getPaths() { return paths; }
 
     /**
      * Scans a single class for Swagger annotations - does not invoke ReaderListeners

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -98,6 +98,7 @@ public class Reader implements OpenApiReader {
 
     public Reader() {
         this(new OpenAPI(), new Paths(), new LinkedHashSet<>(), new Components());
+        setConfiguration(new SwaggerConfiguration().openAPI(openAPI));
     }
 
     public Reader(OpenAPI openAPI) {
@@ -1311,7 +1312,7 @@ public class Reader implements OpenApiReader {
         }
     }
 
-    private void setOperationObjectFromApiOperationAnnotation(
+    protected void setOperationObjectFromApiOperationAnnotation(
             Operation operation,
             io.swagger.v3.oas.annotations.Operation apiOperation,
             Produces methodProduces,


### PR DESCRIPTION
We wanted to make a parser to generate openapi specification file for [fluent-http](https://github.com/CodeStory/fluent-http). It is a bit different from JAX-RS but we can reuse annotations (@Parameter, @Operation, ....).

We've seen that some methods, class attributes of Reader are protected that may indicate that the class is extensible.

Unfortunately there are some inconsistencies : for example the private components property is used in utility methods that are private. So even if the field is duplicated in a daughter class, it won't be populated.

This pull request is trying to fix this.

This PR does the following in the JAW-RS Reader class :
* add a protected constructor with `components`, `paths`, `openApiTags` to be able to share instance with children classes
* add protected getters for the previous fields
* change the visibility of the `setOperationObjectFromApiOperationAnnotation`to be able to call it from children classes

Tell us if you have suggestions to do differently (because we'd have misused the intended API) or examples for other framework adaptations. 

Thank you 