### PR TITLE
fix #4466 locate @JsonValue on enum interface method

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -1096,13 +1096,17 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         final boolean useToString = _mapper.isEnabled(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
 
         Optional<Method> jsonValueMethod = Arrays.stream(propClass.getDeclaredMethods())
-                .filter(m -> m.isAnnotationPresent(JsonValue.class))
-                .filter(m -> m.getAnnotation(JsonValue.class).value())
+                .filter(method -> {
+                    JsonValue annotation = ReflectionUtils.getAnnotation(method, JsonValue.class);
+                    return annotation != null && annotation.value();
+                })
                 .findFirst();
 
         Optional<Field> jsonValueField = Arrays.stream(propClass.getDeclaredFields())
-                .filter(f -> f.isAnnotationPresent(JsonValue.class))
-                .filter(f -> f.getAnnotation(JsonValue.class).value())
+                .filter(field -> {
+                    JsonValue annotation = field.getAnnotation(JsonValue.class);
+                    return annotation != null && annotation.value();
+                })
                 .findFirst();
 
         jsonValueMethod.ifPresent(m -> m.setAccessible(true));

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
@@ -223,16 +223,21 @@ public class EnumPropertyTest {
         final Schema fourthEnumProperty = (Schema) model.getProperties().get("fourthEnumValue");
         assertTrue(fourthEnumProperty instanceof StringSchema);
         final StringSchema fourthStringProperty = (StringSchema) fourthEnumProperty;
-        assertEquals(fourthEnumProperty.getEnum(), Arrays.asList("one", "two", "three"));
+        assertEquals(fourthStringProperty.getEnum(), Arrays.asList("one", "two", "three"));
 
         final Schema fifthEnumProperty = (Schema) model.getProperties().get("fifthEnumValue");
         assertTrue(fifthEnumProperty instanceof StringSchema);
         final StringSchema fifthStringProperty = (StringSchema) fifthEnumProperty;
-        assertEquals(fifthEnumProperty.getEnum(), Arrays.asList("2", "4", "6"));
+        assertEquals(fifthStringProperty.getEnum(), Arrays.asList("2", "4", "6"));
 
         final Schema sixthEnumProperty = (Schema) model.getProperties().get("sixthEnumValue");
         assertTrue(sixthEnumProperty instanceof StringSchema);
         final StringSchema sixthStringProperty = (StringSchema) sixthEnumProperty;
-        assertEquals(sixthEnumProperty.getEnum(), Arrays.asList("one", "two", "three"));
+        assertEquals(sixthStringProperty.getEnum(), Arrays.asList("one", "two", "three"));
+
+        final Schema seventhEnumProperty = (Schema) model.getProperties().get("seventhEnumValue");
+        assertTrue(seventhEnumProperty instanceof StringSchema);
+        final StringSchema seventhStringProperty = (StringSchema) seventhEnumProperty;
+        assertEquals(seventhStringProperty.getEnum(), Arrays.asList("one", "two", "three"));
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/IEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/IEnum.java
@@ -1,0 +1,9 @@
+package io.swagger.v3.core.oas.models;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public interface IEnum {
+
+    @JsonValue
+    String getValue();
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValueImplementingEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonValueImplementingEnum.java
@@ -1,0 +1,25 @@
+package io.swagger.v3.core.oas.models;
+
+import io.swagger.v3.oas.annotations.Hidden;
+
+/**
+ * Enum holds values different from names.
+ * Schema model will derive String value from jackson annotation JsonValue on public implemented method.
+ */
+public enum JacksonValueImplementingEnum implements IEnum {
+    FIRST("one"),
+    SECOND("two"),
+    THIRD("three"),
+    @Hidden HIDDEN("hidden");
+
+    private final String value;
+
+    JacksonValueImplementingEnum(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithJacksonEnumField.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithJacksonEnumField.java
@@ -10,4 +10,5 @@ public class ModelWithJacksonEnumField {
     public JacksonValueFieldEnum fourthEnumValue;
     public JacksonNumberValueFieldEnum fifthEnumValue;
     public JacksonValuePrivateEnum sixthEnumValue;
+    public JacksonValueImplementingEnum seventhEnumValue;
 }


### PR DESCRIPTION
This fixes issue #4466.

- If there is an interface method annotated with @JsonValue, then Jackson will serialize any enums implementing the interface using the concrete method to generate the enum values. This change enables the Model Resolver to look for @JsonValue on enum interfaces in addition to the enum class methods.