### PR TITLE
Move SecurityScheme annotation to model mapping to core

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/SecurityParser.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/SecurityParser.java
@@ -1,6 +1,5 @@
-package io.swagger.v3.jaxrs2;
+package io.swagger.v3.core.util;
 
-import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.oas.annotations.security.OAuthScope;
 import io.swagger.v3.oas.models.security.OAuthFlow;
 import io.swagger.v3.oas.models.security.OAuthFlows;

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -16,6 +16,7 @@ import io.swagger.v3.core.util.KotlinDetector;
 import io.swagger.v3.core.util.ParameterProcessor;
 import io.swagger.v3.core.util.PathUtils;
 import io.swagger.v3.core.util.ReflectionUtils;
+import io.swagger.v3.core.util.SecurityParser;
 import io.swagger.v3.jaxrs2.ext.OpenAPIExtension;
 import io.swagger.v3.jaxrs2.ext.OpenAPIExtensions;
 import io.swagger.v3.jaxrs2.util.ReaderUtils;


### PR DESCRIPTION
This moves the `SecurityParser` class responsible for populating `SecurityScheme` models from `SecurityScheme` annotations to the `core` module.
The move allows using it without taking a dependency on JAX-RS and to use it for building integrations for other technologies.

I'm opening this very simple pull request as a probe. Is moving the code for mapping annotations to models out of the jaxrs module desirable for the project? Some related code is already in the `AnnotationsUtils` class in the `core` module.
