### PR TITLE
Let swagger-core tolerate [2.2,3]

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -50,6 +50,11 @@
     </build>
     <dependencies>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb-api-version}</version>
+        </dependency>
+        <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>2.3.3</version>
@@ -153,6 +158,7 @@
     <properties>
         <!-- TODO increase coverage -->
         <validation-api-version>2.0.2</validation-api-version>
+        <jaxb-api-version>2.2.12</jaxb-api-version>
         <jakarta-ws-rs-api-version>2.1.6</jakarta-ws-rs-api-version>
         <coverage.complexity.minimum>0.60</coverage.complexity.minimum>
         <coverage.line.minimum>0.0</coverage.line.minimum>


### PR DESCRIPTION
Resovles #4590 

This updates the generated MANIFEST.MF file in the swagger-core module to have 
`javax.xml.bind.annotation;version="[2.2,3)`