### PR TITLE
Replace log error with warning in reflection with type not found

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ReflectionUtils.java
@@ -34,7 +34,7 @@ public class ReflectionUtils {
         try {
             return loadClassByName(type);
         } catch (Exception e) {
-            LOGGER.error(String.format("Failed to resolve '%s' into class", type), e);
+            LOGGER.warn(String.format("Failed to resolve '%s' into class", type), e);
         }
         return null;
     }


### PR DESCRIPTION
refs #4589 relatively to the `error` log