### PR TITLE
fix: Add class loader to OpenAPIExtensions ServiceLoader

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/ext/OpenAPIExtensions.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/ext/OpenAPIExtensions.java
@@ -28,7 +28,7 @@ public class OpenAPIExtensions {
 
     static {
         extensions = new ArrayList<>();
-        ServiceLoader<OpenAPIExtension> loader = ServiceLoader.load(OpenAPIExtension.class);
+        ServiceLoader<OpenAPIExtension> loader = ServiceLoader.load(OpenAPIExtension.class, OpenAPIExtensions.class.getClassLoader());
         for (OpenAPIExtension ext : loader) {
             LOGGER.debug("adding extension {}", ext);
             extensions.add(ext);


### PR DESCRIPTION
Fixes #3726.

I tested this locally on my own project. When the appropriate file exists in META-INF/services, the OpenAPIExtension is loaded properly by the Gradle plugin after this change.