### PR TITLE
Support proper mapping of the byte array

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -309,10 +309,20 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             isPrimitive = true;
         }
         if (model == null) {
-            PrimitiveType primitiveType = PrimitiveType.fromType(type);
-            if (primitiveType != null) {
-                model = PrimitiveType.fromType(type).createProperty();
-                isPrimitive = true;
+            if (resolvedSchemaAnnotation != null && StringUtils.isEmpty(resolvedSchemaAnnotation.type())) {
+                PrimitiveType primitiveType = PrimitiveType.fromTypeAndFormat(type, resolvedSchemaAnnotation.format());
+                if (primitiveType != null) {
+                    model = primitiveType.createProperty();
+                    isPrimitive = true;
+                }
+            } 
+
+            if (model == null) {
+                PrimitiveType primitiveType = PrimitiveType.fromType(type);
+                if (primitiveType != null) {
+                    model = primitiveType.createProperty();
+                    isPrimitive = true;
+                }
             }
         }
 
@@ -629,7 +639,8 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                         propType = ((AnnotatedMethod)member).getParameterType(0);
                     }
 
-                }
+                } 
+                
                 String propSchemaName = null;
                 io.swagger.v3.oas.annotations.media.Schema ctxSchema = AnnotationsUtils.getSchemaAnnotation(annotations);
                 if (AnnotationsUtils.hasSchemaAnnotation(ctxSchema)) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
@@ -43,13 +43,23 @@ public enum PrimitiveType {
     },
     BYTE(Byte.class, "byte") {
         @Override
-        public ByteArraySchema createProperty() {
+        public Schema createProperty() {
+            if (
+                    (System.getProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY) != null && System.getProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY).equals(Schema.BynaryStringConversion.BINARY_STRING_CONVERSION_STRING_SCHEMA.toString())) ||
+                    (System.getenv(Schema.BINARY_STRING_CONVERSION_PROPERTY) != null && System.getenv(Schema.BINARY_STRING_CONVERSION_PROPERTY).equals(Schema.BynaryStringConversion.BINARY_STRING_CONVERSION_STRING_SCHEMA.toString()))) {
+                return new StringSchema().format("byte");
+            }
             return new ByteArraySchema();
         }
     },
     BINARY(Byte.class, "binary") {
         @Override
-        public BinarySchema createProperty() {
+        public Schema createProperty() {
+            if (
+                    (System.getProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY) != null && System.getProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY).equals(Schema.BynaryStringConversion.BINARY_STRING_CONVERSION_STRING_SCHEMA.toString())) ||
+                    (System.getenv(Schema.BINARY_STRING_CONVERSION_PROPERTY) != null && System.getenv(Schema.BINARY_STRING_CONVERSION_PROPERTY).equals(Schema.BynaryStringConversion.BINARY_STRING_CONVERSION_STRING_SCHEMA.toString()))) {
+                return new StringSchema().format("binary");
+            }
             return new BinarySchema();
         }
     },

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.models.media.UUIDSchema;
 import org.apache.commons.lang3.StringUtils;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -149,6 +151,7 @@ public enum PrimitiveType {
     };
 
     private static final Map<Class<?>, PrimitiveType> KEY_CLASSES;
+    private static final Map<Class<?>, Collection<PrimitiveType>> MULTI_KEY_CLASSES;
     private static final Map<Class<?>, PrimitiveType> BASE_CLASSES;
     /**
      * Adds support of a small number of "well-known" types, specifically for
@@ -243,6 +246,11 @@ public enum PrimitiveType {
         addKeys(keyClasses, FILE, java.io.File.class);
         addKeys(keyClasses, OBJECT, Object.class);
         KEY_CLASSES = Collections.unmodifiableMap(keyClasses);
+
+        final Map<Class<?>, Collection<PrimitiveType>> multiKeyClasses = new HashMap<>();
+        addMultiKeys(multiKeyClasses, BYTE, byte[].class);
+        addMultiKeys(multiKeyClasses, BINARY, byte[].class);
+        MULTI_KEY_CLASSES = Collections.unmodifiableMap(multiKeyClasses);
 
         final Map<Class<?>, PrimitiveType> baseClasses = new HashMap<>();
         addKeys(baseClasses, DATE_TIME, java.util.Date.class, java.util.Calendar.class);
@@ -343,12 +351,34 @@ public enum PrimitiveType {
         return nonSystemTypePackages;
     }
 
+    public static PrimitiveType fromTypeAndFormat(Type type, String format) {
+        final Class<?> raw = TypeFactory.defaultInstance().constructType(type).getRawClass();
+        final Collection<PrimitiveType> keys = MULTI_KEY_CLASSES.get(raw);
+        if (keys == null || keys.isEmpty() || StringUtils.isBlank(format)) {
+            return fromType(type);
+        } else {
+            return keys
+                .stream()
+                .filter(t -> t.getCommonName().equalsIgnoreCase(format))
+                .findAny()
+                .orElse(null);
+        }
+    }
+    
     public static PrimitiveType fromType(Type type) {
         final Class<?> raw = TypeFactory.defaultInstance().constructType(type).getRawClass();
         final PrimitiveType key = KEY_CLASSES.get(raw);
         if (key != null) {
             if (!customExcludedClasses.contains(raw.getName())) {
                 return key;
+            }
+        }
+        
+        final Collection<PrimitiveType> keys = MULTI_KEY_CLASSES.get(raw);
+        if (keys != null && !keys.isEmpty()) {
+            final PrimitiveType first = keys.iterator().next();
+            if (!customExcludedClasses.contains(raw.getName())) {
+                return first;
             }
         }
 
@@ -421,6 +451,15 @@ public enum PrimitiveType {
     private static <K> void addKeys(Map<K, PrimitiveType> map, PrimitiveType type, K... keys) {
         for (K key : keys) {
             map.put(key, type);
+        }
+    }
+
+    private static <K> void addMultiKeys(Map<K, Collection<PrimitiveType>> map, PrimitiveType type, K... keys) {
+        for (K key : keys) {
+            if (!map.containsKey(key)) {
+                map.put(key, new ArrayList<>());
+            }
+            map.get(key).add(type);
         }
     }
 

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/BinaryParameterResourceTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/BinaryParameterResourceTest.java
@@ -1,0 +1,15 @@
+package io.swagger.v3.jaxrs2;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+import io.swagger.v3.jaxrs2.annotations.AbstractAnnotationTest;
+import io.swagger.v3.jaxrs2.resources.BinaryParameterResource;
+
+public class BinaryParameterResourceTest extends AbstractAnnotationTest {
+    @Test(description = "check binary model serialization") // tests issue #2466
+    public void shouldSerializeBinaryParameter() throws IOException {
+        compareAsYaml(BinaryParameterResource.class, getOpenAPIAsString("BinaryParameterResource.yaml"));
+    }
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/BinaryParameterResourceTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/BinaryParameterResourceTest.java
@@ -2,14 +2,44 @@ package io.swagger.v3.jaxrs2;
 
 import java.io.IOException;
 
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import io.swagger.v3.jaxrs2.annotations.AbstractAnnotationTest;
 import io.swagger.v3.jaxrs2.resources.BinaryParameterResource;
 
 public class BinaryParameterResourceTest extends AbstractAnnotationTest {
-    @Test(description = "check binary model serialization") // tests issue #2466
-    public void shouldSerializeBinaryParameter() throws IOException {
-        compareAsYaml(BinaryParameterResource.class, getOpenAPIAsString("BinaryParameterResource.yaml"));
+
+    @Test(description = "check binary model serialization with base64", singleThreaded = true) // tests issue #2466
+    public void shouldSerializeBinaryParameterBase64() throws IOException {
+        try {
+            System.setProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY, Schema.BynaryStringConversion.BINARY_STRING_CONVERSION_BASE64.toString());
+            compareAsYaml(BinaryParameterResource.class, getOpenAPIAsString("BinaryParameterResource.yaml"));
+        } finally {
+            System.clearProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY);
+        }
+    }
+
+    @BeforeTest
+    public void before() {
+        System.clearProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY);
+    }
+
+    @AfterTest
+    public void after() {
+        System.clearProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY);
+    }
+
+
+    @Test(description = "check binary model serialization with StringSchema", singleThreaded = true) // tests issue #2466
+    public void shouldSerializeBinaryParameterStringSchema() throws IOException {
+        try {
+            System.setProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY, Schema.BynaryStringConversion.BINARY_STRING_CONVERSION_STRING_SCHEMA.toString());
+            compareAsYaml(BinaryParameterResource.class, getOpenAPIAsString("BinaryParameterResource.yaml"));
+        } finally {
+            System.clearProperty(Schema.BINARY_STRING_CONVERSION_PROPERTY);
+        }
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/BinaryParameterResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/BinaryParameterResource.java
@@ -1,0 +1,44 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import io.swagger.v3.jaxrs2.resources.model.Item;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+@Path("/")
+public class BinaryParameterResource {
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Path("/binary")
+    @POST
+    @Operation(
+        summary = "Create new item",
+        description = "Post operation with entity in a body",
+        responses = {
+            @ApiResponse(
+                content = @Content(
+                    schema = @Schema(implementation = Item.class), 
+                    mediaType = MediaType.APPLICATION_JSON
+                ),
+                headers = @Header(name = "Location"),
+                responseCode = "201"
+            )
+        }
+    )
+    public Response createItem(@Context final UriInfo uriInfo, @Parameter(required = true) final Item item) {
+        return Response
+            .created(uriInfo.getBaseUriBuilder().path(item.getName()).build())
+            .entity(item).build();
+    }
+
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/model/Item.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/model/Item.java
@@ -9,7 +9,9 @@ public class Item {
     private byte[] bytes;
     @Schema(format = "binary", example = "YmluYXJ5")
     private byte[] binary;
-    
+
+    private byte[] byteNoAnnotation;
+
     public Item() {
     }
     
@@ -43,5 +45,13 @@ public class Item {
     
     public byte[] getBytes() {
         return bytes;
+    }
+
+    public void setByteNoAnnotation(byte[] byteNoAnnotation) {
+        this.byteNoAnnotation = byteNoAnnotation;
+    }
+
+    public byte[] getByteNoAnnotation() {
+        return byteNoAnnotation;
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/model/Item.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/model/Item.java
@@ -1,0 +1,46 @@
+package io.swagger.v3.jaxrs2.resources.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class Item {
+    private String name;
+    private String value;
+    private byte[] bytes;
+    @Schema(format = "binary")
+    private byte[] binary;
+    
+    public Item() {
+    }
+    
+    public void setBinary(byte[] binary) {
+        this.binary = binary;
+    }
+    
+    public byte[] getBinary() {
+        return binary;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setValue(String value) {
+        this.value = value;
+    }
+    
+    public String getValue() {
+        return value;
+    }
+    
+    public void setBytes(byte[] bytes) {
+        this.bytes = bytes;
+    }
+    
+    public byte[] getBytes() {
+        return bytes;
+    }
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/model/Item.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/model/Item.java
@@ -5,8 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class Item {
     private String name;
     private String value;
+    @Schema(example = "Ynl0ZQ==")
     private byte[] bytes;
-    @Schema(format = "binary")
+    @Schema(format = "binary", example = "YmluYXJ5")
     private byte[] binary;
     
     public Item() {

--- a/modules/swagger-jaxrs2/src/test/resources/BinaryParameterResource.yaml
+++ b/modules/swagger-jaxrs2/src/test/resources/BinaryParameterResource.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.1
+paths:
+  /binary:
+    post:
+      summary: Create new item
+      description: Post operation with entity in a body
+      operationId: createItem
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Item'
+        required: true
+      responses:
+        "201":
+          headers:
+            Location:
+              style: simple
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        name:
+          type: string
+        value:
+          type: string
+        bytes:
+          type: string
+          format: byte
+        binary:
+          type: string
+          format: binary
+          

--- a/modules/swagger-jaxrs2/src/test/resources/BinaryParameterResource.yaml
+++ b/modules/swagger-jaxrs2/src/test/resources/BinaryParameterResource.yaml
@@ -37,4 +37,6 @@ components:
           type: string
           format: binary
           example: YmluYXJ5
-          
+        byteNoAnnotation:
+          type: string
+          format: byte

--- a/modules/swagger-jaxrs2/src/test/resources/BinaryParameterResource.yaml
+++ b/modules/swagger-jaxrs2/src/test/resources/BinaryParameterResource.yaml
@@ -32,7 +32,9 @@ components:
         bytes:
           type: string
           format: byte
+          example: Ynl0ZQ==
         binary:
           type: string
           format: binary
+          example: YmluYXJ5
           

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/BinarySchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/BinarySchema.java
@@ -37,11 +37,15 @@ public class BinarySchema extends Schema<byte[]> {
             try {
                 if (value instanceof byte[]) {
                     return (byte[]) value;
+                } else if (value instanceof String) {
+                    if (
+                            (System.getProperty(BINARY_STRING_CONVERSION_PROPERTY) != null && System.getProperty(BINARY_STRING_CONVERSION_PROPERTY).equals(BynaryStringConversion.BINARY_STRING_CONVERSION_BASE64.toString())) ||
+                            (System.getenv(BINARY_STRING_CONVERSION_PROPERTY) != null && System.getenv(BINARY_STRING_CONVERSION_PROPERTY).equals(BynaryStringConversion.BINARY_STRING_CONVERSION_BASE64.toString()))) {
+                        return Base64.getDecoder().decode((String) value);
+                    }
+                    return value.toString().getBytes();
                 } else {
                     return value.toString().getBytes();
-                }
-                if (value instanceof String) {
-                    return Base64.getDecoder().decode((String) value);
                 }
             } catch (Exception e) {
             }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/BinarySchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/BinarySchema.java
@@ -1,5 +1,6 @@
 package io.swagger.v3.oas.models.media;
 
+import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
 
@@ -38,6 +39,9 @@ public class BinarySchema extends Schema<byte[]> {
                     return (byte[]) value;
                 } else {
                     return value.toString().getBytes();
+                }
+                if (value instanceof String) {
+                    return Base64.getDecoder().decode((String) value);
                 }
             } catch (Exception e) {
             }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ByteArraySchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ByteArraySchema.java
@@ -37,11 +37,15 @@ public class ByteArraySchema extends Schema<byte[]> {
             try {
                 if (value instanceof byte[]) {
                     return (byte[]) value;
+                } else if (value instanceof String) {
+                    if (
+                            (System.getProperty(BINARY_STRING_CONVERSION_PROPERTY) != null && System.getProperty(BINARY_STRING_CONVERSION_PROPERTY).equals(BynaryStringConversion.BINARY_STRING_CONVERSION_BASE64.toString())) ||
+                            (System.getenv(BINARY_STRING_CONVERSION_PROPERTY) != null && System.getenv(BINARY_STRING_CONVERSION_PROPERTY).equals(BynaryStringConversion.BINARY_STRING_CONVERSION_BASE64.toString()))) {
+                        return Base64.getDecoder().decode((String) value);
+                    }
+                    return value.toString().getBytes();
                 } else {
                     return value.toString().getBytes();
-                }
-                if (value instanceof String) {
-                    return Base64.getDecoder().decode((String) value);
                 }
             } catch (Exception e) {
             }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ByteArraySchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ByteArraySchema.java
@@ -1,5 +1,6 @@
 package io.swagger.v3.oas.models.media;
 
+import java.util.Base64;
 import java.util.List;
 import java.util.Objects;
 
@@ -38,6 +39,9 @@ public class ByteArraySchema extends Schema<byte[]> {
                     return (byte[]) value;
                 } else {
                     return value.toString().getBytes();
+                }
+                if (value instanceof String) {
+                    return Base64.getDecoder().decode((String) value);
                 }
             } catch (Exception e) {
             }

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -27,6 +27,22 @@ import java.util.Set;
 public class Schema<T> {
 
     public static final String BIND_TYPE_AND_TYPES = "bind-type";
+    public static final String BINARY_STRING_CONVERSION_PROPERTY = "binary-string-conversion";
+    public enum BynaryStringConversion {
+        BINARY_STRING_CONVERSION_BASE64("base64"),
+        BINARY_STRING_CONVERSION_DEFAULT_CHARSET("default"),
+        BINARY_STRING_CONVERSION_STRING_SCHEMA("string-schema");
+        private String value;
+
+        BynaryStringConversion(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+    }
 
     protected T _default;
 


### PR DESCRIPTION
Includes and replaces https://github.com/swagger-api/swagger-core/pull/3955

Closes https://github.com/swagger-api/swagger-core/issues/3944 and https://github.com/swagger-api/swagger-core/issues/3511.

See also https://github.com/swagger-api/swagger-parser/issues/1630


It introduces [binary-string-conversion](https://github.com/swagger-api/swagger-core/pull/4659/files#diff-cb2ef0df3091032171d05fded8d3f06c1679574101437806921706be09cad764R30) env or system variable, allowing to define behavior for resolution and conversion of byte arrays:

binary-string-conversion = base64 : resolves into ByteArraySchema/BinarySchema using Base64 for casting/conversion
binary-string-conversion = string-schema : resolves into StringSchema 

