### PR TITLE
Set parameter schema base on schema or array of the @Parameter annotation

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ParameterProcessor.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ParameterProcessor.java
@@ -164,6 +164,18 @@ public class ParameterProcessor {
                 if (content.isPresent()) {
                     parameter.setContent(content.get());
                     parameter.setSchema(null);
+                } else {
+                    Class<?> schemaImplementation = p.schema().implementation();
+                    boolean isArray = false;
+                    if (schemaImplementation == Void.class) {
+                        schemaImplementation = p.array().schema().implementation();
+                        if (schemaImplementation != Void.class) {
+                            isArray = true;
+                        }
+                    }
+                    if (p.schema().implementation() != Void.class || isArray) {
+                        AnnotationsUtils.getSchema(p.schema(), p.array(), isArray, schemaImplementation, components, jsonViewAnnotation).ifPresent(parameter::setSchema);
+                    }
                 }
                 setParameterStyle(parameter, p);
                 setParameterExplode(parameter, p);

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/petstore/parameter/Parameters31Resource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/petstore/parameter/Parameters31Resource.java
@@ -118,11 +118,17 @@ public class Parameters31Resource {
             })
     @Consumes({"application/json", "application/xml"})
     public Parameters31Resource.SubscriptionResponse subscribe(@Parameter(description = "idParam")
-                                                             @QueryParam("id") final String id) {
+                                                               @QueryParam("id") final String id,
+                                                               @Parameter(schema = @Schema(implementation = SubscriptionType.class))
+                                                               @QueryParam("enumStringParameter") final String enumStringParameter) {
         return null;
     }
 
     public static class SubscriptionResponse {
         public String subscriptionId;
+    }
+
+    enum SubscriptionType {
+        EMAIL, SMS, PHONE_CALL
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/petstore/parameter/ParametersResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/petstore/parameter/ParametersResource.java
@@ -77,11 +77,17 @@ public class ParametersResource {
             })
     @Consumes({"application/json", "application/xml"})
     public ParametersResource.SubscriptionResponse subscribe(@Parameter(description = "idParam")
-                                                             @QueryParam("id") final String id) {
+                                                             @QueryParam("id") final String id,
+                                                             @Parameter(schema = @Schema(implementation = SubscriptionType.class))
+                                                             @QueryParam("enumStringParameter") final String enumStringParameter) {
         return null;
     }
 
     static class SubscriptionResponse {
         public String subscriptionId;
+    }
+
+    enum SubscriptionType {
+        EMAIL, SMS, PHONE_CALL
     }
 }

--- a/modules/swagger-jaxrs2/src/test/resources/petstore/FullPetResource.yaml
+++ b/modules/swagger-jaxrs2/src/test/resources/petstore/FullPetResource.yaml
@@ -822,6 +822,14 @@ paths:
         description: idParam
         schema:
           type: string
+      - name: enumStringParameter
+        in: query
+        schema:
+          type: string
+          enum:
+            - EMAIL
+            - SMS
+            - PHONE_CALL
       responses:
         default:
           description: test description

--- a/modules/swagger-jaxrs2/src/test/resources/petstore/parameters/Parameters31Resource.yaml
+++ b/modules/swagger-jaxrs2/src/test/resources/petstore/parameters/Parameters31Resource.yaml
@@ -82,6 +82,14 @@ paths:
           description: idParam
           schema:
             type: string
+        - name: enumStringParameter
+          in: query
+          schema:
+            type: string
+            enum:
+              - EMAIL
+              - SMS
+              - PHONE_CALL
       responses:
         default:
           description: test description

--- a/modules/swagger-jaxrs2/src/test/resources/petstore/parameters/ParametersResource.yaml
+++ b/modules/swagger-jaxrs2/src/test/resources/petstore/parameters/ParametersResource.yaml
@@ -76,6 +76,14 @@ paths:
         description: idParam
         schema:
           type: string
+      - name: enumStringParameter
+        in: query
+        schema:
+          type: string
+          enum:
+            - EMAIL
+            - SMS
+            - PHONE_CALL
       responses:
         default:
           description: test description


### PR DESCRIPTION
The current implementation ignores the content of `schema` and `array` of the `@Parameter` annotation, when generating the schema for a parameter. So it's impossible to specify the allowed values for a parameter of type `String` by using an `enum`. This PR will fix this.