### PR TITLE
Update Jackson to v2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -581,8 +581,8 @@
         <servlet-api-version>2.5</servlet-api-version>
         <jersey-version>1.19.4</jersey-version>
         <jersey2-version>2.41</jersey2-version>
-        <jackson-version>2.17.0</jackson-version>
-        <jackson-databind-version>2.17.0</jackson-databind-version>
+        <jackson-version>2.17.1</jackson-version>
+        <jackson-databind-version>2.17.1</jackson-databind-version>
         <snakeyaml-version>2.2</snakeyaml-version>
         <logback-version>1.5.3</logback-version>
         <reflections-version>0.10.2</reflections-version>


### PR DESCRIPTION
Interestingly enough, swagger-core 1.5.x uses a newer Jackson version than 2.x … this leads to version conflicts within swagger-parser:

```terminal
[INFO]    +- io.swagger.parser.v3:swagger-parser:jar:2.1.22:compile
[INFO]    |  +- io.swagger.parser.v3:swagger-parser-v2-converter:jar:2.1.22:compile
[INFO]    |  |  +- io.swagger:swagger-core:jar:1.6.14:compile
[INFO]    |  |  |  +- (com.fasterxml.jackson.core:jackson-annotations:jar:2.12.6:compile - version managed from 2.17.0; omitted for duplicate)
[INFO]    |  |  |  +- (com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile - version managed from 2.17.0; omitted for duplicate)
[INFO]    |  |  |  \- io.swagger:swagger-models:jar:1.6.14:compile
[INFO]    |  |  |     \- (com.fasterxml.jackson.core:jackson-annotations:jar:2.12.6:compile - version managed from 2.17.0; omitted for duplicate)
[INFO]    |  |  +- io.swagger:swagger-compat-spec-parser:jar:1.0.70:compile
[INFO]    |  |  |  +- com.github.java-json-tools:json-schema-validator:jar:2.2.14:compile
[INFO]    |  |  |  |  +- com.github.java-json-tools:jackson-coreutils-equivalence:jar:1.0:compile
[INFO]    |  |  |  |  |  \- (com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:runtime - version managed from 2.11.0; omitted for duplicate)
[INFO]    |  |  |  |  \- com.github.java-json-tools:json-schema-core:jar:1.2.14:compile
[INFO]    |  |  |  |     \- (com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile - version managed from 2.11.0; omitted for duplicate)
[INFO]    |  |  |  \- com.github.java-json-tools:json-patch:jar:1.13:compile
[INFO]    |  |  |     +- (com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile - version managed from 2.11.0; omitted for duplicate)
[INFO]    |  |  |     \- com.github.java-json-tools:jackson-coreutils:jar:2.0:compile (scope not updated to compile)
[INFO]    |  |  |        \- (com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:runtime - version managed from 2.11.0; omitted for duplicate)
[INFO]    |  |  \- io.swagger.core.v3:swagger-models:jar:2.2.21:compile
[INFO]    |  |     \- (com.fasterxml.jackson.core:jackson-annotations:jar:2.12.6:compile - version managed from 2.16.2; omitted for duplicate)
[INFO]    |  \- io.swagger.parser.v3:swagger-parser-v3:jar:2.1.22:compile
[INFO]    |     +- io.swagger.core.v3:swagger-core:jar:2.2.21:compile
[INFO]    |     |  +- (com.fasterxml.jackson.core:jackson-annotations:jar:2.12.6:compile - version managed from 2.16.2; omitted for duplicate)
[INFO]    |     |  \- (com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile - version managed from 2.16.2; omitted for duplicate)
[INFO]    |     +- (com.fasterxml.jackson.core:jackson-annotations:jar:2.12.6:compile - version managed from 2.16.2; omitted for duplicate)
[INFO]    |     +- (com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile - version managed from 2.16.2; omitted for duplicate)
[INFO]    |     \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.12.6:compile (version managed from 2.16.2)
[INFO]    |        +- (com.fasterxml.jackson.core:jackson-databind:jar:2.16.2:compile - version managed from 2.12.6; omitted for duplicate)
[INFO]    |        \- (com.fasterxml.jackson.core:jackson-core:jar:2.12.6:compile - version managed from 2.12.6; omitted for duplicate)
```

This PR syncs the versions together with #4680