### PR TITLE
Make Jackson ObjectMapper initialization thread safe

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Json.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Json.java
@@ -6,13 +6,12 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 public class Json {
 
-    private static ObjectMapper mapper;
+    private static final class MapperHolder {
+        static final ObjectMapper mapper = ObjectMapperFactory.createJson();
+    }
 
     public static ObjectMapper mapper() {
-        if (mapper == null) {
-            mapper = ObjectMapperFactory.createJson();
-        }
-        return mapper;
+        return MapperHolder.mapper;
     }
 
     public static ObjectWriter pretty() {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Yaml.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Yaml.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
 public class Yaml {
-    static ObjectMapper mapper;
+
+    private static final class MapperHolder {
+        static final ObjectMapper mapper = ObjectMapperFactory.createYaml();
+    }
 
     public static ObjectMapper mapper() {
-        if (mapper == null) {
-            mapper = ObjectMapperFactory.createYaml();
-        }
-        return mapper;
+        return MapperHolder.mapper;
     }
 
     public static ObjectWriter pretty() {


### PR DESCRIPTION
Using the https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom here for thread safety.