### PR TITLE
Removed unnecessary cast that crashes for 3.1 schema

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -849,21 +849,21 @@ public abstract class AnnotationsUtils {
             Class<?>[] schemaImplementations = schema.oneOf();
             for (Class<?> schemaImplementation : schemaImplementations) {
                 Schema oneOfSchemaObject = resolveSchemaFromType(schemaImplementation, components, jsonViewAnnotation, openapi31, null, null, context);
-                ((ComposedSchema) schemaObject).addOneOfItem(oneOfSchemaObject);
+                schemaObject.addOneOfItem(oneOfSchemaObject);
             }
         }
         if (schema.anyOf().length > 0) {
             Class<?>[] schemaImplementations = schema.anyOf();
             for (Class<?> schemaImplementation : schemaImplementations) {
                 Schema anyOfSchemaObject = resolveSchemaFromType(schemaImplementation, components, jsonViewAnnotation, openapi31, null, null, context);
-                ((ComposedSchema) schemaObject).addAnyOfItem(anyOfSchemaObject);
+                schemaObject.addAnyOfItem(anyOfSchemaObject);
             }
         }
         if (schema.allOf().length > 0) {
             Class<?>[] schemaImplementations = schema.allOf();
             for (Class<?> schemaImplementation : schemaImplementations) {
                 Schema allOfSchemaObject = resolveSchemaFromType(schemaImplementation, components, jsonViewAnnotation, openapi31, null, null, context);
-                ((ComposedSchema) schemaObject).addAllOfItem(allOfSchemaObject);
+                schemaObject.addAllOfItem(allOfSchemaObject);
             }
         }
         if (schema.additionalProperties().equals(io.swagger.v3.oas.annotations.media.Schema.AdditionalPropertiesValue.TRUE)) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/OpenAPI3_1SerializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/OpenAPI3_1SerializationTest.java
@@ -1468,11 +1468,11 @@ public class OpenAPI3_1SerializationTest {
 
         openAPI = Yaml31.mapper().readValue(expectedYaml, OpenAPI.class);
         ser = Yaml31.pretty(openAPI);
-        assertEquals(ser, withJacksonSystemLineSeparator(expectedYaml));
+        assertEquals(ser, expectedYaml);
         assertTrue(Boolean.TRUE.equals(openAPI.getComponents().getSchemas().get("test").getAdditionalProperties()));
         openAPI = Yaml.mapper().readValue(expectedYaml, OpenAPI.class);
         ser = Yaml.pretty(openAPI);
-        assertEquals(ser, withJacksonSystemLineSeparator(expectedYaml));
+        assertEquals(ser, expectedYaml);
         assertTrue(Boolean.TRUE.equals(openAPI.getComponents().getSchemas().get("test").getAdditionalProperties()));
 
         expectedJson = "{\n" +
@@ -1505,11 +1505,11 @@ public class OpenAPI3_1SerializationTest {
 
         openAPI = Yaml31.mapper().readValue(expectedYaml, OpenAPI.class);
         ser = Yaml31.pretty(openAPI);
-        assertEquals(ser, withJacksonSystemLineSeparator(expectedYaml));
+        assertEquals(ser, expectedYaml);
         assertTrue(Boolean.TRUE.equals(openAPI.getComponents().getSchemas().get("test").getAdditionalProperties()));
         openAPI = Yaml.mapper().readValue(expectedYaml, OpenAPI.class);
         ser = Yaml.pretty(openAPI);
-        assertEquals(ser, withJacksonSystemLineSeparator(expectedYaml));
+        assertEquals(ser, expectedYaml);
         assertTrue(Boolean.TRUE.equals(openAPI.getComponents().getSchemas().get("test").getAdditionalProperties()));
     }
 


### PR DESCRIPTION
Fixes #4657

Extra: fixed yaml checks - yaml by default always uses \n separator