### PR TITLE
Ignore @JsonBackReference when resolving the model

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -1,5 +1,6 @@
 package io.swagger.v3.core.jackson;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIdentityReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -1178,7 +1179,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         if (propertiesToIgnore.contains(propName)) {
             return true;
         }
-        if (member.hasAnnotation(JsonIgnore.class) && member.getAnnotation(JsonIgnore.class).value()) {
+        if ((member.hasAnnotation(JsonIgnore.class) && member.getAnnotation(JsonIgnore.class).value()) || member.hasAnnotation(JsonBackReference.class)) {
             return true;
         }
         if (hasHiddenAnnotation(member)) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/JsonBackReferenceTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/JsonBackReferenceTest.java
@@ -1,0 +1,43 @@
+package io.swagger.v3.core.resolving;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+public class JsonBackReferenceTest {
+
+    @Test(description = "it should ignore a reference field")
+    public void testReferenceField() {
+        final Map<String, Schema> models = ModelConverters.getInstance().readAll(Parent.class);
+
+        final Schema parent = models.get("Parent");
+        assertNotNull(parent);
+        assertEquals(parent.getProperties().size(), 1);
+
+        final Schema child = models.get("Child");
+        assertNotNull(child);
+        assertNull(child.getProperties());
+    }
+
+    static class Parent {
+
+        public List<Child> children = null;
+
+    }
+
+    static class Child {
+
+        @JsonBackReference
+        public Parent parent = null;
+
+    }
+
+}


### PR DESCRIPTION
Removes properties annotated with `@JsonBackReference` from the model, as Jackson automatically populates this with the parent. Without this, you must annotation the model with `@Schema(hidden = true)`

fixes #3682 and #3960