### PR TITLE
Missing array type when using @ArraySchema

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -507,7 +507,7 @@ public abstract class AnnotationsUtils {
             arraySchemaObject = new ArraySchema();
         } else {
             if (existingSchema == null) {
-                arraySchemaObject = new JsonSchema();
+                arraySchemaObject = new ArraySchema();
             } else {
                 arraySchemaObject = existingSchema;
             }


### PR DESCRIPTION
By creating an ArraySchema rather than JsonSchema, the type is correctly set to "array".