### PR TITLE
Fix thread safety in `Json.mapper()`

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Json.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Json.java
@@ -6,13 +6,12 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 public class Json {
 
-    private static ObjectMapper mapper;
+    private static final class ObjectMapperHolder {
+        private static final ObjectMapper MAPPER = ObjectMapperFactory.createJson();
+    }
 
     public static ObjectMapper mapper() {
-        if (mapper == null) {
-            mapper = ObjectMapperFactory.createJson();
-        }
-        return mapper;
+        return ObjectMapperHolder.MAPPER;
     }
 
     public static ObjectWriter pretty() {


### PR DESCRIPTION
Closes #4672 

Instead of following the suggested approach in the issue, a more elegant method was used, where the initialization is delegated to the JVM code for static initialization.

See https://stackoverflow.com/questions/8297705/how-to-implement-thread-safe-lazy-initialization for a thread about this implementation.
See also https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom for the chosen pattern.
