### PR TITLE
set schema name for EnumTypes

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -305,6 +305,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
         if (model == null && type.isEnumType()) {
             model = new StringSchema();
+            model.setName(name);
             _addEnumProps(type.getRawClass(), model);
             isPrimitive = true;
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/ModelConverterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/ModelConverterTest.java
@@ -3,6 +3,7 @@ package io.swagger.v3.core.converting;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.matchers.SerializationMatchers;
 import io.swagger.v3.core.oas.models.Cat;
@@ -231,7 +232,7 @@ public class ModelConverterTest {
     @Test(description = "it should convert a model with enum array")
     public void convertModelWithEnumArray() {
         final Map<String, Schema> schemas = readAll(ModelWithEnumArray.class);
-        assertEquals(schemas.size(), 1);
+        assertEquals(schemas.keySet(), Sets.newHashSet("ModelWithEnumArray", "Action"));
     }
 
     private Type getGenericType(Class<?> cls) throws Exception {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ModelResolverOAS31Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ModelResolverOAS31Test.java
@@ -8,8 +8,6 @@ import io.swagger.v3.core.resolving.SwaggerTestBase;
 import io.swagger.v3.core.resolving.v31.model.AnnotatedArray;
 import io.swagger.v3.core.resolving.v31.model.ModelWithDependentSchema;
 import io.swagger.v3.core.resolving.v31.model.ModelWithOAS31Stuff;
-import io.swagger.v3.core.resolving.v31.model.ModelWithOAS31StuffMinimal;
-import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.models.media.Schema;
 import org.testng.annotations.Test;
 
@@ -69,6 +67,11 @@ public class ModelResolverOAS31Test extends SwaggerTestBase {
                 "    creditCard:\n" +
                 "      type: integer\n" +
                 "      format: int32\n" +
+                "CountryEnum:\n" +
+                "  type: string\n" +
+                "  enum:\n" +
+                "    - UNITED_STATES_OF_AMERICA\n" +
+                "    - CANADA\n" +
                 "CreditCard:\n" +
                 "  properties:\n" +
                 "    billingAddress:\n" +

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/EnumTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/EnumTest.java
@@ -48,5 +48,10 @@ public class EnumTest {
             "components:\n" +
             "  schemas:\n" +
             "    TaskDTO:\n" +
-            "      type: object\n";
+            "      type: object\n" +
+            "    TaskType:\n" +
+            "      type: string\n" +
+            "      enum:\n" +
+            "        - A\n" +
+            "        - B";
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -1,7 +1,6 @@
 package io.swagger.v3.jaxrs2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContextImpl;
@@ -15,32 +14,22 @@ import io.swagger.v3.core.util.PrimitiveType;
 import io.swagger.v3.jaxrs2.matchers.SerializationMatchers;
 import io.swagger.v3.jaxrs2.petstore31.PetResource;
 import io.swagger.v3.jaxrs2.petstore31.TagResource;
-import io.swagger.v3.jaxrs2.resources.DefaultResponseResource;
-import io.swagger.v3.jaxrs2.resources.Misc31Resource;
-import io.swagger.v3.jaxrs2.resources.ParameterMaximumValueResource;
-import io.swagger.v3.jaxrs2.resources.ResponseReturnTypeResource;
-import io.swagger.v3.jaxrs2.resources.SchemaAdditionalPropertiesResource;
-import io.swagger.v3.jaxrs2.resources.SchemaPropertiesResource;
-import io.swagger.v3.jaxrs2.resources.SiblingPropResource;
-import io.swagger.v3.jaxrs2.resources.SiblingsResource;
-import io.swagger.v3.jaxrs2.resources.SiblingsResourceRequestBody;
-import io.swagger.v3.jaxrs2.resources.SiblingsResourceRequestBodyMultiple;
-import io.swagger.v3.jaxrs2.resources.SiblingsResourceResponse;
-import io.swagger.v3.jaxrs2.resources.SiblingsResourceSimple;
-import io.swagger.v3.jaxrs2.resources.SingleExampleResource;
 import io.swagger.v3.jaxrs2.resources.BasicFieldsResource;
 import io.swagger.v3.jaxrs2.resources.BookStoreTicket2646;
 import io.swagger.v3.jaxrs2.resources.ClassPathParentResource;
 import io.swagger.v3.jaxrs2.resources.ClassPathSubResource;
 import io.swagger.v3.jaxrs2.resources.CompleteFieldsResource;
+import io.swagger.v3.jaxrs2.resources.DefaultResponseResource;
 import io.swagger.v3.jaxrs2.resources.DeprecatedFieldsResource;
 import io.swagger.v3.jaxrs2.resources.DuplicatedOperationIdResource;
 import io.swagger.v3.jaxrs2.resources.DuplicatedOperationMethodNameResource;
 import io.swagger.v3.jaxrs2.resources.DuplicatedSecurityResource;
 import io.swagger.v3.jaxrs2.resources.EnhancedResponsesResource;
 import io.swagger.v3.jaxrs2.resources.ExternalDocsReference;
+import io.swagger.v3.jaxrs2.resources.Misc31Resource;
 import io.swagger.v3.jaxrs2.resources.MyClass;
 import io.swagger.v3.jaxrs2.resources.MyOtherClass;
+import io.swagger.v3.jaxrs2.resources.ParameterMaximumValueResource;
 import io.swagger.v3.jaxrs2.resources.RefCallbackResource;
 import io.swagger.v3.jaxrs2.resources.RefExamplesResource;
 import io.swagger.v3.jaxrs2.resources.RefHeaderResource;
@@ -53,15 +42,25 @@ import io.swagger.v3.jaxrs2.resources.RefResponsesResource;
 import io.swagger.v3.jaxrs2.resources.RefSecurityResource;
 import io.swagger.v3.jaxrs2.resources.ResourceWithSubResource;
 import io.swagger.v3.jaxrs2.resources.ResponseContentWithArrayResource;
+import io.swagger.v3.jaxrs2.resources.ResponseReturnTypeResource;
 import io.swagger.v3.jaxrs2.resources.ResponsesResource;
+import io.swagger.v3.jaxrs2.resources.SchemaAdditionalPropertiesResource;
+import io.swagger.v3.jaxrs2.resources.SchemaPropertiesResource;
 import io.swagger.v3.jaxrs2.resources.SecurityResource;
 import io.swagger.v3.jaxrs2.resources.ServersResource;
+import io.swagger.v3.jaxrs2.resources.SiblingPropResource;
+import io.swagger.v3.jaxrs2.resources.SiblingsResource;
+import io.swagger.v3.jaxrs2.resources.SiblingsResourceRequestBody;
+import io.swagger.v3.jaxrs2.resources.SiblingsResourceRequestBodyMultiple;
+import io.swagger.v3.jaxrs2.resources.SiblingsResourceResponse;
+import io.swagger.v3.jaxrs2.resources.SiblingsResourceSimple;
 import io.swagger.v3.jaxrs2.resources.SimpleCallbackResource;
 import io.swagger.v3.jaxrs2.resources.SimpleExamplesResource;
 import io.swagger.v3.jaxrs2.resources.SimpleMethods;
 import io.swagger.v3.jaxrs2.resources.SimpleParameterResource;
 import io.swagger.v3.jaxrs2.resources.SimpleRequestBodyResource;
 import io.swagger.v3.jaxrs2.resources.SimpleResponsesResource;
+import io.swagger.v3.jaxrs2.resources.SingleExampleResource;
 import io.swagger.v3.jaxrs2.resources.SubResourceHead;
 import io.swagger.v3.jaxrs2.resources.TagsResource;
 import io.swagger.v3.jaxrs2.resources.Test2607;
@@ -143,9 +142,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.stream.Collectors;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -3985,6 +3982,11 @@ public class ReaderTest {
                 "      properties:\n" +
                 "        country:\n" +
                 "          const: United States\n" +
+                "    CountryEnum:\n" +
+                "      type: string\n" +
+                "      enum:\n" +
+                "        - United States of America\n" +
+                "        - Canada\n" +
                 "    CreditCard:\n" +
                 "      properties:\n" +
                 "        billingAddress:\n" +


### PR DESCRIPTION
At Springwolf we use the parsed schemas to generate Examples. Thereby we use the field `Schema.getName()` for all schemas including enums. 

When enumAsRef is used, the name of the enum is missing in its class schema. Also, when serialized, the name of a schema is ignored because of the `@JsonIgnore` annotation.

This PR adds the schema name for enums. We found the following comment:
https://github.com/swagger-api/swagger-core/blob/5ee9cefe9455bf07d2671d9fd93fce2bd7c7b94f/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java#L379 
And therefore believe that all enum classes should appear as models, resulting in the adaption of the tests.

Relates to #4722