### PR TITLE
Fix: Avoid caching AnnotationIntrospector to support custom module loading

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class AbstractModelConverter implements ModelConverter {
     protected final ObjectMapper _mapper;
-    protected final AnnotationIntrospector _intr;
     protected final TypeNameResolver _typeNameResolver;
     /**
      * Minor optimization: no need to keep on resolving same types over and over
@@ -43,7 +42,6 @@ public abstract class AbstractModelConverter implements ModelConverter {
                 });
         _mapper = mapper;
         _typeNameResolver = typeNameResolver;
-        _intr = mapper.getSerializationConfig().getAnnotationIntrospector();
     }
 
     @Override
@@ -53,6 +51,17 @@ public abstract class AbstractModelConverter implements ModelConverter {
         } else {
             return null;
         }
+    }
+
+    /**
+     * Retrieves the current AnnotationIntrospector from the ObjectMapper's serialization configuration.
+     * We do not cache the value of _intr because users can load jackson modules later,
+     * and we want to use their annotation inspection.
+     * 
+     * @return the current AnnotationIntrospector
+     */
+    protected AnnotationIntrospector _intr() {
+        return _mapper.getSerializationConfig().getAnnotationIntrospector();
     }
 
     protected String _typeName(JavaType type) {
@@ -89,7 +98,7 @@ public abstract class AbstractModelConverter implements ModelConverter {
             beanDesc = _mapper.getSerializationConfig().introspectClassAnnotations(type);
         }
 
-        PropertyName rootName = _intr.findRootName(beanDesc.getClassInfo());
+        PropertyName rootName = _intr().findRootName(beanDesc.getClassInfo());
         if (rootName != null && rootName.hasSimpleName()) {
             return rootName.getSimpleName();
         }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -1185,7 +1185,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
     private boolean isSubtype(AnnotatedClass childClass, Class<?> parentClass) {
         final BeanDescription parentDesc = _mapper.getSerializationConfig().introspectClassAnnotations(parentClass);
-        List<NamedType> subTypes =_intr.findSubtypes(parentDesc.getClassInfo());
+        List<NamedType> subTypes = _intr().findSubtypes(parentDesc.getClassInfo());
         if (subTypes == null) {
             return false;
         }
@@ -1232,7 +1232,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         Enum<?>[] enumConstants = enumClass.getEnumConstants();
 
         if (enumConstants != null) {
-            String[] enumValues = _intr.findEnumValues(propClass, enumConstants,
+            String[] enumValues = _intr().findEnumValues(propClass, enumConstants,
                 new String[enumConstants.length]);
 
             for (Enum<?> en : enumConstants) {
@@ -1258,7 +1258,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 } else if (useToString) {
                     n = en.toString();
                 } else {
-                    n = _intr.findEnumValue(en);
+                    n = _intr().findEnumValue(en);
                 }
                 if (property instanceof StringSchema) {
                     StringSchema sp = (StringSchema) property;
@@ -1635,7 +1635,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     }
 
     private boolean resolveSubtypes(Schema model, BeanDescription bean, ModelConverterContext context, JsonView jsonViewAnnotation) {
-        final List<NamedType> types = _intr.findSubtypes(bean.getClassInfo());
+        final List<NamedType> types = _intr().findSubtypes(bean.getClassInfo());
         if (types == null) {
             return false;
         }
@@ -1771,7 +1771,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     private void removeSuperSubTypes(List<NamedType> resultTypes, Class<?> superClass) {
         JavaType superType = _mapper.constructType(superClass);
         BeanDescription superBean = _mapper.getSerializationConfig().introspect(superType);
-        final List<NamedType> superTypes = _intr.findSubtypes(superBean.getClassInfo());
+        final List<NamedType> superTypes = _intr().findSubtypes(superBean.getClassInfo());
         if (superTypes != null) {
             resultTypes.removeAll(superTypes);
         }


### PR DESCRIPTION
Do not cache the value of '_intr' because users can load custom modules later after swagger is configured, and we want to utilize their annotation inspection, just like jackson would do.