### PR TITLE
fix-SWG-11909-NPE during webhooks processing with <convertToOpenAPI31>

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
@@ -85,7 +85,7 @@ public class SpecFilter {
 
         if (filteredOpenAPI.getWebhooks() != null) {
             for (String resourcePath : filteredOpenAPI.getWebhooks().keySet()) {
-                PathItem pathItem = filteredOpenAPI.getPaths().get(resourcePath);
+                PathItem pathItem = filteredOpenAPI.getWebhooks().get(resourcePath);
 
                 PathItem filteredPathItem = filterPathItem(filter, pathItem, resourcePath, params, cookies, headers);
                 PathItem clonedPathItem = cloneFilteredPathItem(filter,filteredPathItem, resourcePath, params, cookies, headers, allowedTags, filteredTags);


### PR DESCRIPTION
This PR fixes NPE thrown while resolving @Webhooks annotation with swagger-maven-plugin  <convertToOpenAPI31> configuration