### PR TITLE
Move applySchemaResolution check to a method

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -140,12 +140,6 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
     @Override
     public Schema resolve(AnnotatedType annotatedType, ModelConverterContext context, Iterator<ModelConverter> next) {
-
-
-        boolean applySchemaResolution =
-                !openapi31 ||
-                        (Boolean.parseBoolean(System.getProperty(Schema.APPLY_SCHEMA_RESOLUTION_PROPERTY, "false")) ||
-                                Boolean.parseBoolean(System.getenv(Schema.APPLY_SCHEMA_RESOLUTION_PROPERTY)));
         boolean isPrimitive = false;
         Schema model = null;
         List<String> requiredProps = new ArrayList<>();
@@ -477,7 +471,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                     }
                     if (isObjectSchema(addPropertiesSchema) && pName != null) {
                         if (context.getDefinedModels().containsKey(pName)) {
-                            if (Schema.SchemaResolution.INLINE.equals(containerResolvedSchemaResolution) && applySchemaResolution) {
+                            if (Schema.SchemaResolution.INLINE.equals(containerResolvedSchemaResolution) && applySchemaResolution()) {
                                 addPropertiesSchema = context.getDefinedModels().get(pName);
                             } else {
                                 // create a reference for the items
@@ -529,7 +523,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 }
                 if (isObjectSchema(items) && pName != null) {
                     if (context.getDefinedModels().containsKey(pName)) {
-                        if (Schema.SchemaResolution.INLINE.equals(containerResolvedSchemaResolution) && applySchemaResolution) {
+                        if (Schema.SchemaResolution.INLINE.equals(containerResolvedSchemaResolution) && applySchemaResolution()) {
                             items = context.getDefinedModels().get(pName);
                         } else {
                             // create a reference for the items
@@ -751,7 +745,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 property = context.resolve(aType);
                 property = clone(property);
                 Schema ctxProperty = null;
-                if (!applySchemaResolution) {
+                if (!applySchemaResolution()) {
                     Optional<Schema> reResolvedProperty = AnnotationsUtils.getSchemaFromAnnotation(ctxSchema, annotatedType.getComponents(), null, openapi31, property, schemaResolution, context);
                     if (reResolvedProperty.isPresent()) {
                         property = reResolvedProperty.get();
@@ -835,7 +829,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                                 }
                             }
                         } else if (property.get$ref() != null) {
-                            if (applySchemaResolution) {
+                            if (applySchemaResolution()) {
                                 if (Schema.SchemaResolution.ALL_OF.equals(resolvedSchemaResolution) && ctxProperty != null) {
                                     property = new Schema()
                                             .addAllOfItem(ctxProperty)
@@ -3125,5 +3119,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             }
         }
         return result;
+    }
+
+    protected boolean applySchemaResolution() {
+        return !openapi31 ||
+                        (Boolean.parseBoolean(System.getProperty(Schema.APPLY_SCHEMA_RESOLUTION_PROPERTY, "false")) ||
+                                Boolean.parseBoolean(System.getenv(Schema.APPLY_SCHEMA_RESOLUTION_PROPERTY)));
     }
 }


### PR DESCRIPTION
Simply moves the applySchemaResolution check to a method on ModelResolver.
This way we can configure behavior in a custom ModelResolver subclass by overriding the method. 