### PR TITLE
Fix java.lang.NullPointerException and remove stack trace output from ModelResolver

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -1128,13 +1128,16 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
     private Boolean isRecordType(BeanPropertyDefinition propDef){
         try {
-            Class<?> clazz = propDef.getPrimaryMember().getDeclaringClass();
-            Method isRecordMethod = Class.class.getMethod("isRecord");
-            return (Boolean) isRecordMethod.invoke(clazz);
+            if (propDef.getPrimaryMember() != null) {
+                Class<?> clazz = propDef.getPrimaryMember().getDeclaringClass();
+                Method isRecordMethod = Class.class.getMethod("isRecord");
+                return (Boolean) isRecordMethod.invoke(clazz);
+            } else {
+                return false;
+            }
         } catch (NoSuchMethodException e) {
             return false;
         } catch (Exception e) {
-            e.printStackTrace();
             return false;
         }
     }


### PR DESCRIPTION
The latest Swagger Core `2.2.26` raises `java.lang.NullPointerException` and prints the stack trace into the console while attempting to introspect if the type is a record or not:

```
java.lang.NullPointerException: Cannot invoke "com.fasterxml.jackson.databind.introspect.AnnotatedMember.getDeclaringClass()" because the return value of "com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition.getPrimaryMember()" is null
	at io.swagger.v3.core.jackson.ModelResolver.isRecordType(ModelResolver.java:1131)
	at io.swagger.v3.core.jackson.ModelResolver.extractGenericTypeArgumentAnnotations(ModelResolver.java:1109)
	at io.swagger.v3.core.jackson.ModelResolver.addGenericTypeArgumentAnnotationsForOptionalField(ModelResolver.java:1104)
	at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:865)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
	at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:751)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
	at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:751)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
	at io.swagger.v3.core.jackson.ModelResolver.resolve(ModelResolver.java:751)
	at io.swagger.v3.core.converter.ModelConverterContextImpl.resolve(ModelConverterContextImpl.java:97)
	at io.swagger.v3.core.converter.ModelConverters.resolveAsResolvedSchema(ModelConverters.java:192)
	at io.swagger.v3.jaxrs2.Reader.parseMethod(Reader.java:1168)
	at io.swagger.v3.jaxrs2.Reader.parseMethod(Reader.java:956)
	at io.swagger.v3.jaxrs2.Reader.read(Reader.java:502)
	at io.swagger.v3.jaxrs2.Reader.read(Reader.java:642)
	at io.swagger.v3.jaxrs2.Reader.read(Reader.java:199)
	at io.swagger.v3.jaxrs2.Reader.read(Reader.java:228)
	at io.swagger.v3.oas.integration.GenericOpenApiContext.read(GenericOpenApiContext.java:693)
	at io.swagger.v3.jaxrs2.integration.resources.BaseOpenApiResource.getOpenApi(BaseOpenApiResource.java:51)
	at io.swagger.v3.jaxrs2.integration.resources.OpenApiResource.getOpenApi(OpenApiResource.java:32)
```