### PR TITLE
add nullValues attribute in Schema and resolve it in ModelResolver

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
@@ -256,6 +256,13 @@ public @interface Schema {
     String example() default "";
 
     /**
+     * Set value of example to null if array contains the value of example
+     *
+     * @return Array of string that each element must be set to null if it equals example
+     */
+    String[] nullValues() default {};
+
+    /**
      * Additional external documentation for this schema.
      *
      * @return additional schema documentation

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -2035,6 +2035,18 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         return null;
     }
 
+    protected Boolean resolveNullValues(Annotated a, Annotation[] annotations, io.swagger.v3.oas.annotations.media.Schema schema) {
+        if (schema != null) {
+            for (String nullValue : schema.nullValues()) {
+                if (nullValue.equals(schema.example())) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     protected io.swagger.v3.oas.annotations.media.Schema.RequiredMode resolveRequiredMode(io.swagger.v3.oas.annotations.media.Schema schema) {
         if (schema != null && !schema.requiredMode().equals(io.swagger.v3.oas.annotations.media.Schema.RequiredMode.AUTO)) {
             return schema.requiredMode();
@@ -2800,6 +2812,10 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         Object example = resolveExample(a, annotations, schemaAnnotation);
         if (example != null) {
             schema.example(example);
+        }
+        Boolean nullValue = resolveNullValues(a, annotations, schemaAnnotation);
+        if (nullValue) {
+            schema.example(null);
         }
         Boolean readOnly = resolveReadOnly(a, annotations, schemaAnnotation);
         if (readOnly != null) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -2310,6 +2310,14 @@ public abstract class AnnotationsUtils {
             }
 
             @Override
+            public String[] nullValues() {
+                if (master.nullValues().length > 0 || patch.nullValues().length == 0) {
+                    return master.nullValues();
+                }
+                return patch.nullValues();
+            }
+
+            @Override
             public io.swagger.v3.oas.annotations.ExternalDocumentation externalDocs() {
                 if (getExternalDocumentation(master.externalDocs()).isPresent() || !getExternalDocumentation(patch.externalDocs()).isPresent()) {
                     return master.externalDocs();


### PR DESCRIPTION
Hello,
I thought there could be better way to set null in request example.
I got hint from @CsvValues of Junit, which can set nullValues easily with the annotation attributes.
I raised an issue #4767 and suggest this new feature in this PR.

commit summarize
- Schema: added nullValues attribute
- AnnotationUtils: added nullValues method
- ModelResolver: added resolveNullValues method and call it in resolveSchemaMembers