### PR TITLE
Fix for record component annotations on fields with JsonProperty annotations

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -1112,7 +1112,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
     private Stream<Annotation> getRecordComponentAnnotations(BeanPropertyDefinition propDef) {
         try {
-            Method accessor = propDef.getPrimaryMember().getDeclaringClass().getDeclaredMethod(propDef.getName());
+            Method accessor = propDef.getPrimaryMember().getDeclaringClass().getDeclaredMethod(propDef.getPrimaryMember().getName());
             return getGenericTypeArgumentAnnotations(accessor.getAnnotatedReturnType());
         } catch (NoSuchMethodException e) {
             LOGGER.error("Accessor for record component not found");

--- a/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/JavaRecordTest.java
+++ b/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/JavaRecordTest.java
@@ -1,5 +1,6 @@
 package io.swagger.v3.java17.resolving;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.java17.matchers.SerializationMatchers;
@@ -117,4 +118,25 @@ public class JavaRecordTest {
             List<@Min(1)@Max(10000) Integer> id
     ){
     }
+
+    @Test
+    public void testJavaRecordWithJsonPropertyAnnotationNotMatchingFieldName() {
+        String expectedYaml = "JavaRecordWithJsonPropertyAnnotationNotMatchingFieldName:\n" +
+            "  type: object\n" +
+            "  properties:\n" +
+            "    listOfStrings:\n" +
+            "      type: array\n" +
+            "      items:\n" +
+            "        maxLength: 5\n" +
+            "        minLength: 1\n" +
+            "        type: string";
+
+        Map<String, Schema> stringSchemaMap = ModelConverters.getInstance(false).readAll(JavaRecordWithJsonPropertyAnnotationNotMatchingFieldName.class);
+        SerializationMatchers.assertEqualsToYaml(stringSchemaMap, expectedYaml);
+    }
+
+    public record JavaRecordWithJsonPropertyAnnotationNotMatchingFieldName(
+        @JsonProperty("listOfStrings") List<@Size(min = 1, max = 5)String> stringList
+    ) { }
+
 }


### PR DESCRIPTION
Add support for record classes with `@JsonProperty` annotations that do not match the field names when getting the component annotations. 

When these two differ a NoSuchMethodException is throw. Instead access the declared method using the name of the primary member. 