### PR TITLE
fix: Fields with not null constraint annotations are considered optional if groups attribute is set

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/ModelPropertyTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/ModelPropertyTest.java
@@ -111,6 +111,7 @@ public class ModelPropertyTest {
         assertTrue(model.getRequired().contains("modeRequired"));
         assertFalse(model.getRequired().contains("modeNotRequired"));
         assertFalse(model.getRequired().contains("modeNotRequiredWithAnnotation"));
+        assertFalse(model.getRequired().contains("requiredByAnnotationWithGroupsAttribute"));
     }
 
     @Test

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/RequiredFields.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/RequiredFields.java
@@ -31,4 +31,7 @@ public class RequiredFields {
     @Schema(description = "mode not required with annotation", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     @NotNull
     public Long modeNotRequiredWithAnnotation;
+
+    @NotNull(groups = RequiredFields.class)
+    public Long requiredByAnnotationWithGroupsAttribute;
 }


### PR DESCRIPTION
This PR keeps properties as optional when they are annotated with one of the not-null annoatations and have a value in their groups attribute.
The groups attribute lets you define under which circumstances the annotation is evaluated. For `NotNull` this means, the field can be optional in some cases and mandatory in other cases.
Since we don't know what should apply, the parameter should be considered optional.

@frantuma It would greatly help me if we could merge this asap. I tried a few workarounds but none are fully working.