### PR TITLE
fix: Replace $ in the FQN of the class

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/TypeNameResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/TypeNameResolver.java
@@ -60,7 +60,7 @@ public class TypeNameResolver {
     }
 
     protected String getNameOfClass(Class<?> cls) {
-        return useFqn?cls.getName():cls.getSimpleName();
+        return useFqn ? cls.getName().replace("$", ".") : cls.getSimpleName();
     }
 
     protected String nameForGenericType(JavaType type, Set<Options> options) {


### PR DESCRIPTION
Fixes swagger semantic errors:
1. Component names can only contain the characters A-Z a-z 0-9 - . _
2. $ref values must be RFC3986-compliant percent-encoded URIs