### PR TITLE
#4804: Only include validation constraints with no groups by default

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ValidationAnnotationFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ValidationAnnotationFilter.java
@@ -1,0 +1,60 @@
+package io.swagger.v3.core.jackson;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+public interface ValidationAnnotationFilter {
+
+    default boolean isNotEmptyAnnotationApplicable(NotEmpty notEmpty) {
+        return annotationGroupMatches(notEmpty.groups());
+    }
+
+    default boolean isNotBlankAnnotationApplicable(NotBlank notBlank) {
+        return annotationGroupMatches(notBlank.groups());
+    }
+
+    default boolean isNotNullAnnotationApplicable(NotNull notNull) {
+        return annotationGroupMatches(notNull.groups());
+    }
+
+    default boolean isMaxAnnotationApplicable(Max max) {
+        return annotationGroupMatches(max.groups());
+    }
+
+    default boolean isMinAnnotationApplicable(Min min) {
+        return annotationGroupMatches(min.groups());
+    }
+
+    default boolean isDecimalMaxAnnotationApplicable(DecimalMax decimalMax) {
+        return annotationGroupMatches(decimalMax.groups());
+    }
+
+    default boolean isDecimalMinAnnotationApplicable(DecimalMin decimalMin) {
+        return annotationGroupMatches(decimalMin.groups());
+    }
+
+    default boolean isSizeAnnotationApplicable(Size size) {
+        return annotationGroupMatches(size.groups());
+    }
+
+    default boolean isPatternAnnotationApplicable(Pattern pattern) {
+        return annotationGroupMatches(pattern.groups());
+    }
+
+    boolean annotationGroupMatches(Class<?>[] annotationGroups);
+
+    class DefaultValidationAnnotationFilter implements ValidationAnnotationFilter {
+
+        @Override
+        public boolean annotationGroupMatches(Class<?>[] annotationGroups) {
+            return annotationGroups.length == 0;
+        }
+    }
+}

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ParameterProcessor.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ParameterProcessor.java
@@ -5,6 +5,8 @@ import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.converter.ResolvedSchema;
 import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.jackson.ValidationAnnotationFilter;
+import io.swagger.v3.core.jackson.ValidationAnnotationFilter.DefaultValidationAnnotationFilter;
 import io.swagger.v3.oas.annotations.enums.Explode;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.models.Components;
@@ -55,7 +57,20 @@ public class ParameterProcessor {
             JsonView jsonViewAnnotation,
             boolean openapi31,
             Schema.SchemaResolution schemaResolution) {
+        return applyAnnotations(parameter, type, annotations, components, classTypes, methodTypes, jsonViewAnnotation, openapi31, schemaResolution, new DefaultValidationAnnotationFilter());
+    }
 
+    public static Parameter applyAnnotations(
+            Parameter parameter,
+            Type type,
+            List<Annotation> annotations,
+            Components components,
+            String[] classTypes,
+            String[] methodTypes,
+            JsonView jsonViewAnnotation,
+            boolean openapi31,
+            Schema.SchemaResolution schemaResolution,
+            ValidationAnnotationFilter validationAnnotationFilter) {
         final AnnotationsHelper helper = new AnnotationsHelper(annotations, type);
         if (helper.isContext()) {
             return null;
@@ -252,7 +267,7 @@ public class ParameterProcessor {
                 } catch (Exception e) {
                     LOGGER.error("failed on " + annotation.annotationType().getName(), e);
                 }
-            } else if (ModelResolver.NOT_NULL_ANNOTATIONS.contains(annotation.annotationType().getSimpleName())) {
+            } else if (ModelResolver.hasNotNullAnnotation(annotation, validationAnnotationFilter)) {
                 parameter.setRequired(true);
             }
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4804Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4804Test.java
@@ -1,0 +1,74 @@
+package io.swagger.v3.core.resolving;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.Schema.SchemaResolution;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class Ticket4804Test {
+
+    @BeforeMethod
+    public void beforeTest() {
+        ModelConverters.reset();
+        System.clearProperty(Schema.APPLY_SCHEMA_RESOLUTION_PROPERTY);
+    }
+
+    @Test
+    public void shouldIncludeOnlyNonGroupedJakartaValidatedFieldsAsMandatoryByDefault() {
+        ResolvedSchema schema = ModelConverters.getInstance(false).resolveAsResolvedSchema(new AnnotatedType().type(CustomClass.class));
+        String expectedJson = "{\"schema\":{\"required\":[\"nonGroupValidatedField\"],\"type\":\"object\",\"properties\":{\"nonGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField\":{\"type\":\"integer\",\"format\":\"int32\"},\"multipleGroupValidatedField\":{\"type\":\"number\"},\"otherGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField2\":{\"type\":\"string\"}}},\"referencedSchemas\":{\"CustomClass\":{\"required\":[\"nonGroupValidatedField\"],\"type\":\"object\",\"properties\":{\"nonGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField\":{\"type\":\"integer\",\"format\":\"int32\"},\"multipleGroupValidatedField\":{\"type\":\"number\"},\"otherGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField2\":{\"type\":\"string\"}}}}}";
+        SerializationMatchers.assertEqualsToJson(schema, expectedJson);
+    }
+
+    @Test
+    public void shouldIncludeAllJakartaValidatedFieldsAsMandatoryIfFilterAlwaysTrue() {
+        ResolvedSchema schema = ModelConverters.getInstance(false, SchemaResolution.DEFAULT, annotationGroups -> true).resolveAsResolvedSchema(new AnnotatedType().type(CustomClass.class));
+        String expectedJson = "{\"schema\":{\"required\":[\"nonGroupValidatedField\",\"singleGroupValidatedField2\"],\"type\":\"object\",\"properties\":{\"nonGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField\":{\"minimum\":1,\"type\":\"integer\",\"format\":\"int32\"},\"multipleGroupValidatedField\":{\"minimum\":1,\"exclusiveMinimum\":false,\"type\":\"number\"},\"otherGroupValidatedField\":{\"pattern\":\".*\",\"type\":\"string\"},\"singleGroupValidatedField2\":{\"type\":\"string\"}}},\"referencedSchemas\":{\"CustomClass\":{\"required\":[\"nonGroupValidatedField\",\"singleGroupValidatedField2\"],\"type\":\"object\",\"properties\":{\"nonGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField\":{\"minimum\":1,\"type\":\"integer\",\"format\":\"int32\"},\"multipleGroupValidatedField\":{\"minimum\":1,\"exclusiveMinimum\":false,\"type\":\"number\"},\"otherGroupValidatedField\":{\"pattern\":\".*\",\"type\":\"string\"},\"singleGroupValidatedField2\":{\"type\":\"string\"}}}}}";
+        SerializationMatchers.assertEqualsToJson(schema, expectedJson);
+    }
+
+
+    @Test
+    public void shouldIncludeOnlyJakartaValidatedFieldsMatchingConditionInFilter() {
+        ResolvedSchema schema = ModelConverters.getInstance(false, SchemaResolution.ALL_OF, annotationGroups -> annotationGroups.length == 0 || Arrays.stream(annotationGroups).anyMatch(group -> group == ValidationGroup.class)).resolveAsResolvedSchema(new AnnotatedType().type(CustomClass.class));
+        String expectedJson = "{\"schema\":{\"required\":[\"nonGroupValidatedField\",\"singleGroupValidatedField2\"],\"type\":\"object\",\"properties\":{\"nonGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField\":{\"minimum\":1,\"type\":\"integer\",\"format\":\"int32\"},\"multipleGroupValidatedField\":{\"minimum\":1,\"exclusiveMinimum\":false,\"type\":\"number\"},\"otherGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField2\":{\"type\":\"string\"}}},\"referencedSchemas\":{\"CustomClass\":{\"required\":[\"nonGroupValidatedField\",\"singleGroupValidatedField2\"],\"type\":\"object\",\"properties\":{\"nonGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField\":{\"minimum\":1,\"type\":\"integer\",\"format\":\"int32\"},\"multipleGroupValidatedField\":{\"minimum\":1,\"exclusiveMinimum\":false,\"type\":\"number\"},\"otherGroupValidatedField\":{\"type\":\"string\"},\"singleGroupValidatedField2\":{\"type\":\"string\"}}}}}";
+        SerializationMatchers.assertEqualsToJson(schema, expectedJson);
+    }
+
+
+    private interface ValidationGroup {
+
+    }
+
+    private interface OtherValidationGroup {
+
+    }
+
+
+    private static class CustomClass {
+
+        @NotNull
+        public String nonGroupValidatedField;
+        @Min(value = 1, groups = ValidationGroup.class)
+        public Integer singleGroupValidatedField;
+        @DecimalMin(value = "1.0", groups = {ValidationGroup.class, OtherValidationGroup.class})
+        public BigDecimal multipleGroupValidatedField;
+        @Pattern(regexp = ".*", groups = OtherValidationGroup.class)
+        public String otherGroupValidatedField;
+        @NotEmpty(groups = ValidationGroup.class)
+        public String singleGroupValidatedField2;
+    }
+}

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/DefaultParameterExtension.java
@@ -120,7 +120,11 @@ public class DefaultParameterExtension extends AbstractOpenAPIExtension {
                     annotations,
                     components,
                     classConsumes == null ? new String[0] : classConsumes.value(),
-                    methodConsumes == null ? new String[0] : methodConsumes.value(), jsonViewAnnotation, openapi31, this.schemaResolution);
+                    methodConsumes == null ? new String[0] : methodConsumes.value(),
+                    jsonViewAnnotation,
+                    openapi31,
+                    this.schemaResolution,
+                    validationAnnotationFilter);
             if (unknownParameter != null) {
                 if (StringUtils.isNotBlank(unknownParameter.getIn()) && !"form".equals(unknownParameter.getIn())) {
                     extractParametersResult.parameters.add(unknownParameter);
@@ -142,7 +146,8 @@ public class DefaultParameterExtension extends AbstractOpenAPIExtension {
                     methodConsumes == null ? new String[0] : methodConsumes.value(),
                     jsonViewAnnotation,
                     openapi31,
-                    this.schemaResolution);
+                    this.schemaResolution,
+                    validationAnnotationFilter);
             if (processedParameter != null) {
                 extractParametersResult.parameters.add(processedParameter);
             }
@@ -267,7 +272,8 @@ public class DefaultParameterExtension extends AbstractOpenAPIExtension {
                             methodConsumes == null ? new String[0] : methodConsumes.value(),
                             jsonViewAnnotation,
                             openapi31,
-                            this.schemaResolution);
+                            this.schemaResolution,
+                            validationAnnotationFilter);
                     if (processedParam != null) {
                         parameters.add(processedParam);
                     }
@@ -286,7 +292,8 @@ public class DefaultParameterExtension extends AbstractOpenAPIExtension {
                             methodConsumes == null ? new String[0] : methodConsumes.value(),
                             jsonViewAnnotation,
                             openapi31,
-                            this.schemaResolution);
+                            this.schemaResolution,
+                            validationAnnotationFilter);
                     if (processedParam != null) {
                         formParameters.add(processedParam);
                     }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.converter.ResolvedSchema;
+import io.swagger.v3.core.jackson.ValidationAnnotationFilter.DefaultValidationAnnotationFilter;
 import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Json31;
@@ -1531,6 +1532,7 @@ public class Reader implements OpenApiReader {
         extension.setOpenAPI31(Boolean.TRUE.equals(config.isOpenAPI31()));
         Schema.SchemaResolution curSchemaResolution = config.getSchemaResolution();
         extension.setSchemaResolution(config.getSchemaResolution());
+        extension.setValidationAnnotationFilter(new DefaultValidationAnnotationFilter());
         ResolvedParameter resolvedParameter = extension.extractParameters(annotations, type, typesToSkip, components, classConsumes, methodConsumes, true, jsonViewAnnotation, chain);
         ((SwaggerConfiguration)config).setSchemaResolution(curSchemaResolution);
         return resolvedParameter;

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/ext/AbstractOpenAPIExtension.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/ext/AbstractOpenAPIExtension.java
@@ -3,6 +3,7 @@ package io.swagger.v3.jaxrs2.ext;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import io.swagger.v3.core.jackson.ValidationAnnotationFilter;
 import io.swagger.v3.jaxrs2.ResolvedParameter;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.Operation;
@@ -19,6 +20,7 @@ public abstract class AbstractOpenAPIExtension implements OpenAPIExtension {
 
     protected boolean openapi31;
     protected Schema.SchemaResolution schemaResolution;
+    protected ValidationAnnotationFilter validationAnnotationFilter;
 
     @Override
     public String extractOperationMethod(Method method, Iterator<OpenAPIExtension> chain) {
@@ -74,5 +76,10 @@ public abstract class AbstractOpenAPIExtension implements OpenAPIExtension {
     @Override
     public void setSchemaResolution(Schema.SchemaResolution schemaResolution) {
         this.schemaResolution = schemaResolution;
+    }
+
+    @Override
+    public void setValidationAnnotationFilter(ValidationAnnotationFilter validationAnnotationFilter) {
+        this.validationAnnotationFilter = validationAnnotationFilter;
     }
 }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/ext/OpenAPIExtension.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/ext/OpenAPIExtension.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.jaxrs2.ext;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import io.swagger.v3.core.jackson.ValidationAnnotationFilter;
 import io.swagger.v3.jaxrs2.ResolvedParameter;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.Operation;
@@ -34,6 +35,10 @@ public interface OpenAPIExtension {
     }
 
     default void setSchemaResolution(Schema.SchemaResolution schemaResolution) {
+        //todo: override me!
+    }
+
+    default void setValidationAnnotationFilter(ValidationAnnotationFilter validationAnnotationFilter) {
         //todo: override me!
     }
 }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
@@ -1,6 +1,8 @@
 package io.swagger.v3.jaxrs2.util;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import io.swagger.v3.core.jackson.ValidationAnnotationFilter;
+import io.swagger.v3.core.jackson.ValidationAnnotationFilter.DefaultValidationAnnotationFilter;
 import io.swagger.v3.core.util.ParameterProcessor;
 import io.swagger.v3.core.util.ReflectionUtils;
 import io.swagger.v3.jaxrs2.ext.OpenAPIExtension;
@@ -47,6 +49,10 @@ public class ReaderUtils {
      * @return the collection of supported parameters
      */
     public static List<Parameter> collectConstructorParameters(Class<?> cls, Components components, javax.ws.rs.Consumes classConsumes, JsonView jsonViewAnnotation, Schema.SchemaResolution schemaResolution) {
+        return collectConstructorParameters(cls, components, classConsumes, jsonViewAnnotation, schemaResolution, new DefaultValidationAnnotationFilter());
+    }
+
+    public static List<Parameter> collectConstructorParameters(Class<?> cls, Components components, javax.ws.rs.Consumes classConsumes, JsonView jsonViewAnnotation, Schema.SchemaResolution schemaResolution, ValidationAnnotationFilter validationAnnotationFilter) {
         if (cls.isLocalClass() || (cls.isMemberClass() && !Modifier.isStatic(cls.getModifiers()))) {
             return Collections.emptyList();
         }
@@ -81,7 +87,10 @@ public class ReaderUtils {
                                     components,
                                     classConsumes == null ? new String[0] : classConsumes.value(),
                                     null,
-                                    jsonViewAnnotation, false, schemaResolution);
+                                    jsonViewAnnotation,
+                                    false,
+                                    schemaResolution,
+                                    validationAnnotationFilter);
                             if (processedParameter != null) {
                                 parameters.add(processedParameter);
                             }


### PR DESCRIPTION
The current process for adding constraints into the schema presumes that all javax or jakarta validation annotations enforce a constraint, and doesn't take into account the 'groups' property of the annotation. This results in constrains being added to the schema that would only be applied for certain request, so incorrectly marks fields as required in the resulting schema where they may only be mandatory on a subset of requests. To overcome this, a new `ValidationAnnotationFilter` is being introduced which only treats a validation annotation as constraining the schema where the conditions on the filter are met be the annotation. The default implementation of this filter only treats constraints from annotations with no groups as being enforced to bring it inline with how the default Java Beans validation operates.