### PR TITLE
allow specifying openAPI version (e.g. 3.0.4, 3.1.1)

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/ExternalDocumentation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/ExternalDocumentation.java
@@ -13,12 +13,12 @@ import static java.lang.annotation.ElementType.METHOD;
 
 /**
  * The annotation may be used at method level or as field of {@link Operation} to add a reference to an external
- * resource for extended documentation of an <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#operationObject">Operation (OpenAPI specification)</a>.
+ * resource for extended documentation of an <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#operation-object">Operation (OpenAPI specification)</a>.
  * <p>It may also be used to add external documentation to {@link io.swagger.v3.oas.annotations.tags.Tag},
  * {@link io.swagger.v3.oas.annotations.headers.Header} or {@link io.swagger.v3.oas.annotations.media.Schema},
  * or as field of {@link OpenAPIDefinition}.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#externalDocumentationObject">External Documentation (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#external-documentation-object">External Documentation (OpenAPI specification)</a>
  * @see OpenAPIDefinition
  **/
 @Target({METHOD, TYPE, ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/ExternalDocumentation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/ExternalDocumentation.java
@@ -13,12 +13,12 @@ import static java.lang.annotation.ElementType.METHOD;
 
 /**
  * The annotation may be used at method level or as field of {@link Operation} to add a reference to an external
- * resource for extended documentation of an <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#operationObject">Operation (OpenAPI specification)</a>.
+ * resource for extended documentation of an <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#operationObject">Operation (OpenAPI specification)</a>.
  * <p>It may also be used to add external documentation to {@link io.swagger.v3.oas.annotations.tags.Tag},
  * {@link io.swagger.v3.oas.annotations.headers.Header} or {@link io.swagger.v3.oas.annotations.media.Schema},
  * or as field of {@link OpenAPIDefinition}.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#externalDocumentationObject">External Documentation (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#externalDocumentationObject">External Documentation (OpenAPI specification)</a>
  * @see OpenAPIDefinition
  **/
 @Target({METHOD, TYPE, ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/OpenAPIDefinition.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/OpenAPIDefinition.java
@@ -19,7 +19,7 @@ import static java.lang.annotation.ElementType.TYPE;
  * The annotation that may be used to populate OpenAPI Object fields info, tags, servers, security and externalDocs
  * If more than one class is annotated with {@link OpenAPIDefinition}, with the same fields defined, behaviour is inconsistent.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#oasObject">OpenAPI (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#oas-object">OpenAPI (OpenAPI specification)</a>
  */
 @Target({TYPE, PACKAGE, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/OpenAPIDefinition.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/OpenAPIDefinition.java
@@ -19,7 +19,7 @@ import static java.lang.annotation.ElementType.TYPE;
  * The annotation that may be used to populate OpenAPI Object fields info, tags, servers, security and externalDocs
  * If more than one class is annotated with {@link OpenAPIDefinition}, with the same fields defined, behaviour is inconsistent.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#oasObject">OpenAPI (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#oasObject">OpenAPI (OpenAPI specification)</a>
  */
 @Target({TYPE, PACKAGE, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Operation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Operation.java
@@ -38,7 +38,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * <li>hidden: @{@link Hidden}</li>
  * </ul>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#operationObject">Operation (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#operation-object">Operation (OpenAPI specification)</a>
  **/
 @Target({METHOD, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Operation.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Operation.java
@@ -38,7 +38,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * <li>hidden: @{@link Hidden}</li>
  * </ul>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#operationObject">Operation (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#operationObject">Operation (OpenAPI specification)</a>
  **/
 @Target({METHOD, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Parameter.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Parameter.java
@@ -30,7 +30,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
  *
  * <p>For method parameters bound to the request body, see {@link io.swagger.v3.oas.annotations.parameters.RequestBody}</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#parameterObject">Parameter (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#parameterObject">Parameter (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.parameters.RequestBody
  * @see Operation
  * @see Schema

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Parameter.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Parameter.java
@@ -30,7 +30,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
  *
  * <p>For method parameters bound to the request body, see {@link io.swagger.v3.oas.annotations.parameters.RequestBody}</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#parameterObject">Parameter (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#parameter-object">Parameter (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.parameters.RequestBody
  * @see Operation
  * @see Schema

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Webhook.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/Webhook.java
@@ -11,7 +11,7 @@ import static java.lang.annotation.ElementType.METHOD;
 /**
  * The annotation may be used to define a method as an OpenAPI Webhook.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#oasWebhooks">Webhook (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#oas-webhooks">Webhook (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  **/
 @Target({METHOD, ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/callbacks/Callback.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/callbacks/Callback.java
@@ -18,7 +18,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 /**
  * The annotation may be used at method level to add one ore more callbacks to the operation definition.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#callbackObject">Callback (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#callbackObject">Callback (OpenAPI specification)</a>
  **/
 @Target({FIELD, METHOD, PARAMETER, TYPE, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/callbacks/Callback.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/callbacks/Callback.java
@@ -18,7 +18,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 /**
  * The annotation may be used at method level to add one ore more callbacks to the operation definition.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#callbackObject">Callback (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#callback-object">Callback (OpenAPI specification)</a>
  **/
 @Target({FIELD, METHOD, PARAMETER, TYPE, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/extensions/Extension.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/extensions/Extension.java
@@ -14,7 +14,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 /**
  * An optionally named list of extension properties.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#specificationExtensions">Specification extensions (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#specification-extensions">Specification extensions (OpenAPI specification)</a>
  */
 @Target({FIELD, METHOD, PARAMETER, TYPE, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/extensions/Extension.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/extensions/Extension.java
@@ -14,7 +14,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 /**
  * An optionally named list of extension properties.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#specificationExtensions">Specification extensions (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#specificationExtensions">Specification extensions (OpenAPI specification)</a>
  */
 @Target({FIELD, METHOD, PARAMETER, TYPE, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/headers/Header.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/headers/Header.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
  * encoding by defining it as field {@link io.swagger.v3.oas.annotations.responses.ApiResponse#headers()} or {@link io.swagger.v3.oas.annotations.media.Content#encoding()}.
  * <p>Please note that request headers are defined as Header {@link io.swagger.v3.oas.annotations.Parameter}.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#headerObject">Header (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#header-object">Header (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.responses.ApiResponse
  * @see io.swagger.v3.oas.annotations.Parameter
  * @see io.swagger.v3.oas.annotations.media.Encoding

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/headers/Header.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/headers/Header.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
  * encoding by defining it as field {@link io.swagger.v3.oas.annotations.responses.ApiResponse#headers()} or {@link io.swagger.v3.oas.annotations.media.Content#encoding()}.
  * <p>Please note that request headers are defined as Header {@link io.swagger.v3.oas.annotations.Parameter}.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#headerObject">Header (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#headerObject">Header (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.responses.ApiResponse
  * @see io.swagger.v3.oas.annotations.Parameter
  * @see io.swagger.v3.oas.annotations.media.Encoding

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/Contact.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/Contact.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 /**
  * The annotation may be used in {@link Info#contact()} to define a contact for the OpenAPI spec.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#contactObject">Contact (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#contactObject">Contact (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  * @see Info
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/Contact.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/Contact.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 /**
  * The annotation may be used in {@link Info#contact()} to define a contact for the OpenAPI spec.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#contactObject">Contact (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#contact-object">Contact (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  * @see Info
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/Info.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/Info.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
 /**
  * The annotation may be used in {@link io.swagger.v3.oas.annotations.OpenAPIDefinition#info()} to populate the Info section of the OpenAPI document.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#infoObject">Info (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#infoObject">Info (OpenAPI specification)</a>
  * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#infoObject">Info (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/Info.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/Info.java
@@ -12,8 +12,8 @@ import java.lang.annotation.Target;
 /**
  * The annotation may be used in {@link io.swagger.v3.oas.annotations.OpenAPIDefinition#info()} to populate the Info section of the OpenAPI document.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#infoObject">Info (OpenAPI specification)</a>
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#infoObject">Info (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#info-object">Info (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#info-object">Info (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  **/
 @Target({ElementType.ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/License.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/License.java
@@ -10,8 +10,8 @@ import java.lang.annotation.Target;
 /**
  * The annotation may be used in {@link Info#license()} to define a license for the OpenAPI spec.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#licenseObject">License (OpenAPI 3.0 pecification)</a>
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#licenseObject">License (OpenAPI 3.1 specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#license-object">License (OpenAPI 3.0 pecification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#license-object">License (OpenAPI 3.1 specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  * @see Info
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/License.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/info/License.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
 /**
  * The annotation may be used in {@link Info#license()} to define a license for the OpenAPI spec.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#licenseObject">License (OpenAPI 3.0 pecification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#licenseObject">License (OpenAPI 3.0 pecification)</a>
  * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#licenseObject">License (OpenAPI 3.1 specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  * @see Info

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/links/Link.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/links/Link.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
 /**
  * The annotation may be applied in {@link io.swagger.v3.oas.annotations.responses.ApiResponse#links()} to add OpenAPI links to a response.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#linkObject">Link (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#link-object">Link (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.responses.ApiResponse
  **/
 @Target({ElementType.ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/links/Link.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/links/Link.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
 /**
  * The annotation may be applied in {@link io.swagger.v3.oas.annotations.responses.ApiResponse#links()} to add OpenAPI links to a response.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#linkObject">Link (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#linkObject">Link (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.responses.ApiResponse
  **/
 @Target({ElementType.ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ArraySchema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ArraySchema.java
@@ -25,8 +25,8 @@ import static java.lang.annotation.ElementType.PARAMETER;
  * <p>The annotation {@link Schema} shall be used for non array elements; {@link ArraySchema} and {@link Schema} cannot
  * coexist</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#schemaObject">Schema (OpenAPI specification)</a>
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schemaObject">Schema (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#schema-object">Schema (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#schema-object">Schema (OpenAPI specification)</a>
  * @see Schema
  **/
 @Target({FIELD, METHOD, PARAMETER, TYPE, ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ArraySchema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ArraySchema.java
@@ -25,7 +25,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
  * <p>The annotation {@link Schema} shall be used for non array elements; {@link ArraySchema} and {@link Schema} cannot
  * coexist</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#schemaObject">Schema (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#schemaObject">Schema (OpenAPI specification)</a>
  * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schemaObject">Schema (OpenAPI specification)</a>
  * @see Schema
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Content.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Content.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
  * JAX-RS annotations, element type and context as input to resolve the annotated element into an OpenAPI schema
  * definition for such element.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#exampleObject">Example (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#exampleObject">Example (OpenAPI specification)</a>
  * @see Schema
  * @see io.swagger.v3.oas.annotations.Parameter
  * @see io.swagger.v3.oas.annotations.responses.ApiResponse

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Content.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Content.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
  * JAX-RS annotations, element type and context as input to resolve the annotated element into an OpenAPI schema
  * definition for such element.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#exampleObject">Example (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#example-object">Example (OpenAPI specification)</a>
  * @see Schema
  * @see io.swagger.v3.oas.annotations.Parameter
  * @see io.swagger.v3.oas.annotations.responses.ApiResponse

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/DiscriminatorMapping.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/DiscriminatorMapping.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
  *
  * <p>Use {@link Schema#discriminatorProperty()} to define a discriminator property.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#discriminatorObject">Discriminator (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#discriminatorObject">Discriminator (OpenAPI specification)</a>
  * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#discriminatorObject">Discriminator (OpenAPI specification)</a>
  * @see Schema
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/DiscriminatorMapping.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/DiscriminatorMapping.java
@@ -15,8 +15,8 @@ import java.lang.annotation.Target;
  *
  * <p>Use {@link Schema#discriminatorProperty()} to define a discriminator property.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#discriminatorObject">Discriminator (OpenAPI specification)</a>
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#discriminatorObject">Discriminator (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#discriminator-object">Discriminator (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#discriminator-object">Discriminator (OpenAPI specification)</a>
  * @see Schema
  **/
 @Target({})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Encoding.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Encoding.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * The annotation may be used to add encoding details to the definition of a parameter, request or response content,
  * by defining it as field {@link Content#encoding()}
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#encodingObject">Encoding (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#encoding-object">Encoding (OpenAPI specification)</a>
  * @see Content
  **/
 @Target({})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Encoding.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Encoding.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * The annotation may be used to add encoding details to the definition of a parameter, request or response content,
  * by defining it as field {@link Content#encoding()}
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#encodingObject">Encoding (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#encodingObject">Encoding (OpenAPI specification)</a>
  * @see Content
  **/
 @Target({})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ExampleObject.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ExampleObject.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * The annotation may be used to add one or more examples to the definition of a parameter, request or response content,
  * by defining it as field {@link io.swagger.v3.oas.annotations.Parameter#examples()} or {@link Content#examples()}
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#exampleObject">Example (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#exampleObject">Example (OpenAPI specification)</a>
  **/
 @Target({ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ExampleObject.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/ExampleObject.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * The annotation may be used to add one or more examples to the definition of a parameter, request or response content,
  * by defining it as field {@link io.swagger.v3.oas.annotations.Parameter#examples()} or {@link Content#examples()}
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#exampleObject">Example (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#example-object">Example (OpenAPI specification)</a>
  **/
 @Target({ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
@@ -30,7 +30,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
  * <p>The annotation {@link ArraySchema} shall be used for array elements; {@link ArraySchema} and {@link Schema} cannot
  * coexist</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#schemaObject">Schema (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#schemaObject">Schema (OpenAPI specification)</a>
  * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schemaObject">Schema (OpenAPI specification)</a>
  * @see ArraySchema
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
@@ -30,8 +30,8 @@ import static java.lang.annotation.ElementType.PARAMETER;
  * <p>The annotation {@link ArraySchema} shall be used for array elements; {@link ArraySchema} and {@link Schema} cannot
  * coexist</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#schemaObject">Schema (OpenAPI specification)</a>
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schemaObject">Schema (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#schema-object">Schema (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#schema-object">Schema (OpenAPI specification)</a>
  * @see ArraySchema
  **/
 @Target({FIELD, METHOD, PARAMETER, TYPE, ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/parameters/RequestBody.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/parameters/RequestBody.java
@@ -16,7 +16,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
  * The annotation may be used on a method parameter to define it as the Request Body of the operation, and/or to define
  * additional properties for such request body.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#requestBodyObject">Request Body (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#request-body-object">Request Body (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.Parameter
  * @see Content
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/parameters/RequestBody.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/parameters/RequestBody.java
@@ -16,7 +16,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
  * The annotation may be used on a method parameter to define it as the Request Body of the operation, and/or to define
  * additional properties for such request body.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#requestBodyObject">Request Body (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#requestBodyObject">Request Body (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.Parameter
  * @see Content
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/responses/ApiResponse.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/responses/ApiResponse.java
@@ -22,7 +22,7 @@ import static java.lang.annotation.ElementType.TYPE;
  * <p>swagger-jaxrs2 reader engine considers this annotation along with method return type and context as input to
  * resolve the OpenAPI Operation responses.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#responseObject">Response (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#response-object">Response (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.Operation
  **/
 @Target({METHOD, TYPE, ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/responses/ApiResponse.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/responses/ApiResponse.java
@@ -22,7 +22,7 @@ import static java.lang.annotation.ElementType.TYPE;
  * <p>swagger-jaxrs2 reader engine considers this annotation along with method return type and context as input to
  * resolve the OpenAPI Operation responses.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#responseObject">Response (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#responseObject">Response (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.Operation
  **/
 @Target({METHOD, TYPE, ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/security/SecurityRequirement.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/security/SecurityRequirement.java
@@ -15,7 +15,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * single operation (when applied at method level) or for all operations of a class (when applied at class level).
  * <p>It can also be used in {@link io.swagger.v3.oas.annotations.OpenAPIDefinition#security()} to define spec level security.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#securityRequirementObject">Security Requirement (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securityRequirementObject">Security Requirement (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  * @see io.swagger.v3.oas.annotations.Operation
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/security/SecurityRequirement.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/security/SecurityRequirement.java
@@ -15,7 +15,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * single operation (when applied at method level) or for all operations of a class (when applied at class level).
  * <p>It can also be used in {@link io.swagger.v3.oas.annotations.OpenAPIDefinition#security()} to define spec level security.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securityRequirementObject">Security Requirement (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#security-requirement-object">Security Requirement (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  * @see io.swagger.v3.oas.annotations.Operation
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/security/SecurityScheme.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/security/SecurityScheme.java
@@ -17,8 +17,8 @@ import static java.lang.annotation.ElementType.TYPE;
  * The annotation may be used at class level (also on multiple classes) to add securitySchemes to spec
  * components section.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securitySchemeObject">Security Scheme (OpenAPI specification)</a>
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#componentsObject">Components (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#security-scheme-object">Security Scheme (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#components-object">Components (OpenAPI specification)</a>
  **/
 @Target({TYPE, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
@@ -48,7 +48,7 @@ public @interface SecurityScheme {
 
     /**
      * The name of the header or query parameter to be used. Applies to apiKey type.
-     * Maps to "name" property of <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securitySchemeObject">Security Scheme (OpenAPI specification)</a>
+     * Maps to "name" property of <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#security-scheme-object">Security Scheme (OpenAPI specification)</a>
      *
      * @return String paramName
      **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/security/SecurityScheme.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/security/SecurityScheme.java
@@ -17,8 +17,8 @@ import static java.lang.annotation.ElementType.TYPE;
  * The annotation may be used at class level (also on multiple classes) to add securitySchemes to spec
  * components section.
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#securitySchemeObject">Security Scheme (OpenAPI specification)</a>
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#componentsObject">Components (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securitySchemeObject">Security Scheme (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#componentsObject">Components (OpenAPI specification)</a>
  **/
 @Target({TYPE, ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
@@ -48,7 +48,7 @@ public @interface SecurityScheme {
 
     /**
      * The name of the header or query parameter to be used. Applies to apiKey type.
-     * Maps to "name" property of <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#securitySchemeObject">Security Scheme (OpenAPI specification)</a>
+     * Maps to "name" property of <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securitySchemeObject">Security Scheme (OpenAPI specification)</a>
      *
      * @return String paramName
      **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/servers/Server.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/servers/Server.java
@@ -17,7 +17,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * single operation (when applied at method level) or for all operations of a class (when applied at class level).
  * <p>It can also be used in {@link io.swagger.v3.oas.annotations.OpenAPIDefinition#servers()} to define spec level servers.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#serverObject">Server (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#server-object">Server (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  * @see io.swagger.v3.oas.annotations.Operation
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/servers/Server.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/servers/Server.java
@@ -17,7 +17,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * single operation (when applied at method level) or for all operations of a class (when applied at class level).
  * <p>It can also be used in {@link io.swagger.v3.oas.annotations.OpenAPIDefinition#servers()} to define spec level servers.</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#serverObject">Server (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#serverObject">Server (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  * @see io.swagger.v3.oas.annotations.Operation
  **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/tags/Tag.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/tags/Tag.java
@@ -21,7 +21,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * if additional fields are also defined, like description or externalDocs, the Tag will also be added to openAPI.tags
  * field</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#tagObject">Tag (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#tagObject">Tag (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  **/
 @Target({METHOD, TYPE, ANNOTATION_TYPE})

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/tags/Tag.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/tags/Tag.java
@@ -21,7 +21,7 @@ import static java.lang.annotation.ElementType.METHOD;
  * if additional fields are also defined, like description or externalDocs, the Tag will also be added to openAPI.tags
  * field</p>
  *
- * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#tagObject">Tag (OpenAPI specification)</a>
+ * @see <a target="_new" href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#tag-object">Tag (OpenAPI specification)</a>
  * @see io.swagger.v3.oas.annotations.OpenAPIDefinition
  **/
 @Target({METHOD, TYPE, ANNOTATION_TYPE})

--- a/modules/swagger-gradle-plugin/README.md
+++ b/modules/swagger-gradle-plugin/README.md
@@ -99,12 +99,13 @@ Parameter | Description | Required | Default
 `defaultResponseCode`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)|false|
 `openapi31`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
 `schemaResolution`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| DEFAULT |
+`openAPIVersion`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| `3.0.1/3.1.0` |
 
 **Note** parameter `openApiFile` corresponds to [config](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties) openAPI. It points to a location of a file in YAML or JSON format representing the input spec that will be merged with the resolved spec. Typically used to add Info section, or any other meta data.
 An example of such file:
 
 ```yaml
-openapi: 3.0.1
+openapi: 3.0.4
 info:
   version: '1.0'
   title: Swagger Pet Sample App Config File
@@ -128,3 +129,4 @@ Since version 2.1.15, `skipResolveAppPath` parameter is available, allowing to s
 Since version 2.2.17, `defaultResponseCode` parameter is available, allowing to set the code used when resolving responses with no http status code annotation
 Since version 2.2.17, `defaultResponseCode` parameter is available, allowing to set the code used when resolving responses with no http status code annotation
 Since version 2.2.24, `schemaResolution` parameter is available, allowing to specify how object schemas and object properties within schemas are resolved for OAS 3.0 specification
+Since version 2.2.28, `openAPIVersion` parameter is available, allowing to specify the version of the OpenAPI specification to be used for the resolved spec.

--- a/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/tasks/ResolveTask.java
+++ b/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/tasks/ResolveTask.java
@@ -131,7 +131,7 @@ public class ResolveTask extends DefaultTask {
 
     @Input
     @Optional
-    private String openAPIVersion;
+    private Property<String> openAPIVersion = getProject().getObjects().property(String.class);;
 
     @Input
     @Optional

--- a/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/tasks/ResolveTask.java
+++ b/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/tasks/ResolveTask.java
@@ -128,6 +128,11 @@ public class ResolveTask extends DefaultTask {
     @Input
     @Optional
     public final Property<String> schemaResolution = getProject().getObjects().property(String.class);
+
+    @Input
+    @Optional
+    private String openAPIVersion;
+
     @Input
     @Optional
     public final Property<String> defaultResponseCode = getProject().getObjects().property(String.class);
@@ -398,6 +403,14 @@ public class ResolveTask extends DefaultTask {
         this.schemaResolution.set(schemaResolution);
     }
 
+    public Property<String> getOpenAPIVersion() {
+        return openAPIVersion;
+    }
+
+    public void setOpenAPIVersion(String openAPIVersion) {
+        this.openAPIVersion.set(openAPIVersion);
+    }
+
     @TaskAction
     public void resolve() throws GradleException {
         if (skip.getOrElse(false)) {
@@ -528,6 +541,11 @@ public class ResolveTask extends DefaultTask {
                 method = swaggerLoaderClass.getDeclaredMethod("setSchemaResolution", String.class);
                 method.invoke(swaggerLoader, schemaResolution.get());
             }
+            if (openAPIVersion.isPresent()) {
+                method = swaggerLoaderClass.getDeclaredMethod("setOpenAPIVersion", String.class);
+                method.invoke(swaggerLoader, openAPIVersion.get());
+            }
+
             method = swaggerLoaderClass.getDeclaredMethod("resolve");
             Map<String, String> specs = (Map<String, String>) method.invoke(swaggerLoader);
 

--- a/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/GenericOpenApiContext.java
+++ b/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/GenericOpenApiContext.java
@@ -78,6 +78,8 @@ public class GenericOpenApiContext<T extends GenericOpenApiContext> implements O
 
     private Schema.SchemaResolution schemaResolution;
 
+    private String openAPIVersion;
+
     public long getCacheTTL() {
         return cacheTTL;
     }
@@ -354,6 +356,28 @@ public class GenericOpenApiContext<T extends GenericOpenApiContext> implements O
         return (T) this;
     }
 
+    /**
+     * @since 2.2.28
+     */
+    public String getOpenAPIVersion() {
+        return openAPIVersion;
+    }
+
+    /**
+     * @since 2.2.28
+     */
+    public void setOpenAPIVersion(String openAPIVersion) {
+        this.openAPIVersion = openAPIVersion;
+    }
+
+    /**
+     * @since 2.2.28
+     */
+    public T openAPIVersion(String openAPIVersion) {
+        this.openAPIVersion = openAPIVersion;
+        return (T) this;
+    }
+
     protected void register() {
         OpenApiContextLocator.getInstance().putOpenApiContext(id, this);
     }
@@ -492,6 +516,10 @@ public class GenericOpenApiContext<T extends GenericOpenApiContext> implements O
             ((SwaggerConfiguration) openApiConfiguration).setOpenAPI31(openAPI31);
             ((SwaggerConfiguration) openApiConfiguration).setConvertToOpenAPI31(convertToOpenAPI31);
             if (schemaResolution != null) {
+                ((SwaggerConfiguration) openApiConfiguration).setSchemaResolution(schemaResolution);
+            }
+            if (openAPIVersion != null && !openAPIVersion.isEmpty()) {
+                ((SwaggerConfiguration) openApiConfiguration).openAPIVersion(openAPIVersion);
                 ((SwaggerConfiguration) openApiConfiguration).setSchemaResolution(schemaResolution);
             }
         }

--- a/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/SwaggerConfiguration.java
+++ b/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/SwaggerConfiguration.java
@@ -43,6 +43,8 @@ public class SwaggerConfiguration implements OpenAPIConfiguration {
 
     private Schema.SchemaResolution schemaResolution = Schema.SchemaResolution.DEFAULT;
 
+    private String openAPIVersion = "3.0.1";
+
     @Override
     public String getDefaultResponseCode() {
         return defaultResponseCode;
@@ -388,6 +390,29 @@ public class SwaggerConfiguration implements OpenAPIConfiguration {
 
     public SwaggerConfiguration schemaResolution(Schema.SchemaResolution schemaResolution) {
         this.setSchemaResolution(schemaResolution);
+        return this;
+    }
+
+    /**
+     * @since 2.2.28
+     */
+    @Override
+    public String getOpenAPIVersion() {
+        return openAPIVersion;
+    }
+
+    /**
+     * @since 2.2.28
+     */
+    public void setOpenAPIVersion(String openAPIVersion) {
+        this.openAPIVersion = openAPIVersion;
+    }
+
+    /**
+     * @since 2.2.28
+     */
+    public SwaggerConfiguration openAPIVersion(String openAPIVersion) {
+        this.setOpenAPIVersion(openAPIVersion);
         return this;
     }
 }

--- a/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/api/OpenAPIConfiguration.java
+++ b/modules/swagger-integration/src/main/java/io/swagger/v3/oas/integration/api/OpenAPIConfiguration.java
@@ -74,4 +74,9 @@ public interface OpenAPIConfiguration {
      * @since 2.2.24
      */
     public Schema.SchemaResolution getSchemaResolution();
+
+    /**
+     * @since 2.2.28
+     */
+    public String getOpenAPIVersion();
 }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -122,6 +122,10 @@ public class Reader implements OpenApiReader {
         this.openApiTags = openApiTags;
         this.components = components;
         setConfiguration(openApiConfiguration);
+        if (openApiConfiguration != null && StringUtils.isNotBlank(openApiConfiguration.getOpenAPIVersion())) {
+            this.openAPI.openapi(openApiConfiguration.getOpenAPIVersion());
+        }
+
     }
 
 

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/ServletConfigContextUtils.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/ServletConfigContextUtils.java
@@ -68,6 +68,12 @@ public class ServletConfigContextUtils {
      */
     public static final String OPENAPI_CONFIGURATION_SCHEMA_RESOLUTION_KEY = "openApi.configuration.schemaResolution";
 
+    /**
+     * @since 2.2.28
+     */
+    public static final String OPENAPI_CONFIGURATION_OPENAPI_VERSION_KEY = "openApi.configuration.openAPIVersion";
+
+
     public static Set<String> resolveResourcePackages(ServletConfig servletConfig) {
         if (!isServletConfigAvailable(servletConfig)) {
             return null;

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/ServletOpenApiConfigurationLoader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/ServletOpenApiConfigurationLoader.java
@@ -26,6 +26,7 @@ import static io.swagger.v3.jaxrs2.integration.ServletConfigContextUtils.OPENAPI
 import static io.swagger.v3.jaxrs2.integration.ServletConfigContextUtils.OPENAPI_CONFIGURATION_READER_KEY;
 import static io.swagger.v3.jaxrs2.integration.ServletConfigContextUtils.OPENAPI_CONFIGURATION_SCANNER_KEY;
 import static io.swagger.v3.jaxrs2.integration.ServletConfigContextUtils.OPENAPI_CONFIGURATION_SCHEMA_RESOLUTION_KEY;
+import static io.swagger.v3.jaxrs2.integration.ServletConfigContextUtils.OPENAPI_CONFIGURATION_OPENAPI_VERSION_KEY;
 import static io.swagger.v3.jaxrs2.integration.ServletConfigContextUtils.OPENAPI_CONFIGURATION_SKIPRESOLVEAPPPATH_KEY;
 import static io.swagger.v3.jaxrs2.integration.ServletConfigContextUtils.OPENAPI_CONFIGURATION_SORTOUTPUT_KEY;
 import static io.swagger.v3.jaxrs2.integration.ServletConfigContextUtils.OPENAPI_CONFIGURATION_ALWAYSRESOLVEAPPPATH_KEY;
@@ -74,6 +75,9 @@ public class ServletOpenApiConfigurationLoader implements OpenApiConfigurationLo
                     .modelConverterClasses(resolveModelConverterClasses(servletConfig));
             if (getInitParam(servletConfig, OPENAPI_CONFIGURATION_SCHEMA_RESOLUTION_KEY) != null) {
                 configuration.schemaResolution(Schema.SchemaResolution.valueOf(getInitParam(servletConfig, OPENAPI_CONFIGURATION_SCHEMA_RESOLUTION_KEY)));
+            }
+            if (getInitParam(servletConfig, OPENAPI_CONFIGURATION_OPENAPI_VERSION_KEY) != null) {
+                configuration.openAPIVersion(getInitParam(servletConfig, OPENAPI_CONFIGURATION_OPENAPI_VERSION_KEY));
             }
             return configuration;
 

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/SwaggerLoader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/SwaggerLoader.java
@@ -52,6 +52,8 @@ public class SwaggerLoader {
 
     private String schemaResolution;
 
+    private String openAPIVersion;
+
     /**
      * @since 2.0.6
      */
@@ -267,6 +269,20 @@ public class SwaggerLoader {
         this.schemaResolution = schemaResolution;
     }
 
+    /**
+     *  @since 2.2.28
+     */
+    public String getOpenAPIVersion() {
+        return openAPIVersion;
+    }
+
+    /**
+     *  @since 2.2.28
+     */
+    public void setOpenAPIVersion(String openAPIVersion) {
+        this.openAPIVersion = openAPIVersion;
+    }
+
     public Map<String, String> resolve() throws Exception{
 
         Set<String> ignoredRoutesSet = null;
@@ -320,6 +336,9 @@ public class SwaggerLoader {
                 .convertToOpenAPI31(convertToOpenAPI31);
         if (schemaResolution != null) {
             config.schemaResolution(Schema.SchemaResolution.valueOf(schemaResolution));
+        }
+        if (openAPIVersion != null) {
+            config.openAPIVersion(openAPIVersion);
         }
         try {
             GenericOpenApiContextBuilder builder = new JaxrsOpenApiContextBuilder()

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -4165,4 +4165,25 @@ public class ReaderTest {
                 "          type: string\n";
         SerializationMatchers.assertEqualsToYaml(openAPI, yaml);
     }
+
+    @Test(description = "openAPIVersion")
+    public void testOpenAPIVersion() {
+        SwaggerConfiguration config = new SwaggerConfiguration().openAPIVersion("3.0.4");
+        Reader reader = new Reader(config);
+
+        OpenAPI openAPI = reader.read(DefaultResponseResource.class);
+        String yaml = "openapi: 3.0.4\n" +
+                "paths:\n" +
+                "  /:\n" +
+                "    get:\n" +
+                "      operationId: test\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            '*/*':\n" +
+                "              schema:\n" +
+                "                type: string\n";
+        SerializationMatchers.assertEqualsToYaml(openAPI, yaml);
+    }
 }

--- a/modules/swagger-maven-plugin/README.md
+++ b/modules/swagger-maven-plugin/README.md
@@ -176,32 +176,33 @@ Both `javax` and `jakarta` examples are provided below
  ``` 
 
 #### Parameters
-Parameter | Description | Required | Default
---------- | ----------- |---------| -------
-`outputPath`|output path where file(s) are saved| true    |
-`outputFileName`|file name (no extension)| false   |`openapi`
-`outputFormat`|file format (`JSON`, `YAML`, `JSONANDYAML`| false   |`JSON`
-`skip`|if `TRUE` skip execution| false   |`FALSE`
-`encoding`|encoding of output file(s)| false   |
-`resourcePackages`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`resourceClasses`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`prettyPrint`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |`TRUE`
-`sortOutput`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |`FALSE`
-`alwaysResolveAppPath`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |`FALSE`
-`skipResolveAppPath`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |`FALSE`
-`openapiFilePath`|path to openapi file to be merged with resolved specification, see [config](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`configurationFilePath`|path to swagger config file to be merged with resolved specification, see [config](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration)| false   |
-`filterClass`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`readerClass`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`scannerClass`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`readAllResources`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`ignoredRoutes`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`objectMapperProcessorClass`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`defaultResponseCode`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`modelConverterClasses`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`contextId`|see [Context](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#context)| false   |${project.artifactId}
-`openapi31`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false   |
-`schemaResolution`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| DEFAULT |
+Parameter | Description | Required      | Default
+--------- | ----------- |---------------| -------
+`outputPath`|output path where file(s) are saved| true          |
+`outputFileName`|file name (no extension)| false         |`openapi`
+`outputFormat`|file format (`JSON`, `YAML`, `JSONANDYAML`| false         |`JSON`
+`skip`|if `TRUE` skip execution| false         |`FALSE`
+`encoding`|encoding of output file(s)| false         |
+`resourcePackages`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`resourceClasses`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`prettyPrint`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |`TRUE`
+`sortOutput`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |`FALSE`
+`alwaysResolveAppPath`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |`FALSE`
+`skipResolveAppPath`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |`FALSE`
+`openapiFilePath`|path to openapi file to be merged with resolved specification, see [config](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`configurationFilePath`|path to swagger config file to be merged with resolved specification, see [config](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration)| false         |
+`filterClass`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`readerClass`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`scannerClass`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`readAllResources`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`ignoredRoutes`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`objectMapperProcessorClass`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`defaultResponseCode`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`modelConverterClasses`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`contextId`|see [Context](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#context)| false         |${project.artifactId}
+`openapi31`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| false         |
+`schemaResolution`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| DEFAULT       |
+`openAPIVersion`|see [configuration property](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Integration-and-Configuration#configuration-properties)| `3.0.1/3.1.0` |
 
 ***
 
@@ -214,3 +215,4 @@ Since version 2.2.12, `openapi31` parameter is available, if set to true the res
 Since version 2.1.15, `skipResolveAppPath` parameter is available, allowing to skip resolving of Application Path from annotation
 Since version 2.2.17, `defaultResponseCode` parameter is available, allowing to set the code used when resolving responses with no http status code annotation
 Since version 2.2.24, `schemaResolution` parameter is available, allowing to specify how object schemas and object properties within schemas are resolved for OAS 3.0 specification
+Since version 2.2.28, `openAPIVersion` parameter is available, allowing to specify the version of the OpenAPI specification to be used for the resolved spec.

--- a/modules/swagger-maven-plugin/src/main/java/io/swagger/v3/plugin/maven/SwaggerMojo.java
+++ b/modules/swagger-maven-plugin/src/main/java/io/swagger/v3/plugin/maven/SwaggerMojo.java
@@ -361,6 +361,10 @@ public class SwaggerMojo extends AbstractMojo {
             config.schemaResolution(Schema.SchemaResolution.valueOf(schemaResolution));
         }
 
+        if (StringUtils.isNotBlank(openAPIVersion)) {
+            config.openAPIVersion(openAPIVersion);
+        }
+
         return config;
     }
 
@@ -464,6 +468,12 @@ public class SwaggerMojo extends AbstractMojo {
      */
     @Parameter(property = "resolve.schemaResolution")
     private String schemaResolution;
+
+    /**
+     * @since 2.2.28
+     */
+    @Parameter(property = "resolve.openAPIVersion")
+    private String openAPIVersion;
 
     private String projectEncoding = "UTF-8";
     private SwaggerConfiguration config;

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
@@ -18,8 +18,8 @@ import java.util.Objects;
 /**
  * Components
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#componentsObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#componentsObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#components-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#components-object"
  */
 
 public class Components {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Components.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 /**
  * Components
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#componentsObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#componentsObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#componentsObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/ExternalDocumentation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/ExternalDocumentation.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * ExternalDocumentation
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#externalDocumentationObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#externalDocumentationObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#externalDocumentationObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/ExternalDocumentation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/ExternalDocumentation.java
@@ -7,8 +7,8 @@ import java.util.Objects;
 /**
  * ExternalDocumentation
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#externalDocumentationObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#externalDocumentationObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#external-documentation-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#external-documentation-object"
  */
 
 public class ExternalDocumentation {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  * OpenAPI
  *
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md"
  */
 
 public class OpenAPI {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/OpenAPI.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 /**
  * OpenAPI
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Operation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Operation.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 /**
  * Operation
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#operationObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#operationObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#operationObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Operation.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Operation.java
@@ -17,8 +17,8 @@ import java.util.Objects;
 /**
  * Operation
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#operationObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#operationObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#operation-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#operation-object"
  */
 
 public class Operation {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
@@ -12,7 +12,7 @@ import java.util.Map;
 /**
  * PathItem
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#pathItemObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#pathItemObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#pathItemObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
@@ -12,8 +12,8 @@ import java.util.Map;
 /**
  * PathItem
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#pathItemObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#pathItemObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#path-item-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#path-item-object"
  */
 
 public class PathItem {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Paths.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Paths.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 /**
  * Paths
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#pathsObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#pathsObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#pathsObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Paths.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/Paths.java
@@ -8,8 +8,8 @@ import java.util.Objects;
 /**
  * Paths
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#pathsObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#pathsObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#paths-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#paths-object"
  */
 
 public class Paths extends LinkedHashMap<String, PathItem> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/callbacks/Callback.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/callbacks/Callback.java
@@ -9,8 +9,8 @@ import java.util.Objects;
 /**
  * Callback
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#callbackObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#callbackObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#callback-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#callback-object"
  */
 
 public class Callback extends LinkedHashMap<String, PathItem> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/callbacks/Callback.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/callbacks/Callback.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 /**
  * Callback
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#callbackObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#callbackObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#callbackObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/examples/Example.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/examples/Example.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.models.annotations.OpenAPI31;
 /**
  * Example
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#exampleObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#exampleObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#exampleObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/examples/Example.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/examples/Example.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.models.annotations.OpenAPI31;
 /**
  * Example
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#exampleObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#exampleObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#example-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#example-object"
  */
 
 public class Example {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/headers/Header.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/headers/Header.java
@@ -11,8 +11,8 @@ import java.util.Objects;
 /**
  * Header
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#headerObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#headerObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#header-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#header-object"
  */
 
 public class Header {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/headers/Header.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/headers/Header.java
@@ -11,7 +11,7 @@ import java.util.Objects;
 /**
  * Header
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#headerObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#headerObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#headerObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Contact.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Contact.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * Contact
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#contactObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#contactObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#contactObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Contact.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Contact.java
@@ -7,8 +7,8 @@ import java.util.Objects;
 /**
  * Contact
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#contactObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#contactObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#contact-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#contact-object"
  */
 
 public class Contact {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Info.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Info.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.models.annotations.OpenAPI31;
 import java.util.Objects;
 
 /**
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#infoObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#infoObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#info-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#info-object"
  */
 
 public class Info {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Info.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/Info.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.models.annotations.OpenAPI31;
 import java.util.Objects;
 
 /**
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#infoObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#infoObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#infoObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/License.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/License.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * License
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#licenseObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#licenseObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#licenseObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/License.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/info/License.java
@@ -7,8 +7,8 @@ import java.util.Objects;
 /**
  * License
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#licenseObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#licenseObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#license-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#license-object"
  */
 
 public class License {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
@@ -10,7 +10,7 @@ import java.util.Map;
 /**
  * Link
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#linkObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#linkObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#linkObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/links/Link.java
@@ -10,8 +10,8 @@ import java.util.Map;
 /**
  * Link
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#linkObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#linkObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#link-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#link-object"
  */
 
 public class Link {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Content.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Content.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 /**
  * Content
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#contentObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#content-object"
  */
 
 public class Content extends LinkedHashMap<String, MediaType> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Content.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Content.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 /**
  * Content
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#contentObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#contentObject"
  */
 
 public class Content extends LinkedHashMap<String, MediaType> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Encoding.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Encoding.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 /**
  * Encoding
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#encodingObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#encoding-object"
  */
 
 public class Encoding {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Encoding.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Encoding.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 /**
  * Encoding
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#encodingObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#encodingObject"
  */
 
 public class Encoding {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/EncodingProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/EncodingProperty.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 /**
  * EncodingProperty
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#encodingPropertyObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#encoding-property-object"
  */
 
 public class EncodingProperty {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/EncodingProperty.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/EncodingProperty.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 /**
  * EncodingProperty
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#encodingPropertyObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#encodingPropertyObject"
  */
 
 public class EncodingProperty {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/MediaType.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/MediaType.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 /**
  * MediaType
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#mediaTypeObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#media-type-object"
  */
 
 public class MediaType {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/MediaType.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/MediaType.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 /**
  * MediaType
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#mediaTypeObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#mediaTypeObject"
  */
 
 public class MediaType {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -21,7 +21,7 @@ import java.util.Set;
 /**
  * Schema
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#schemaObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#schemaObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schemaObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -21,8 +21,8 @@ import java.util.Set;
 /**
  * Schema
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#schemaObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#schemaObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#schema-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#schema-object"
  */
 
 public class Schema<T> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/XML.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/XML.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * XML
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#xmlObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#xml-object"
  */
 
 public class XML {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/XML.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/XML.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * XML
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#xmlObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#xmlObject"
  */
 
 public class XML {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/Parameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/Parameter.java
@@ -12,8 +12,8 @@ import java.util.Objects;
 /**
  * Parameter
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#parameterObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#parameterObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#parameter-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#parameter-object"
  */
 
 public class Parameter {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/Parameter.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/Parameter.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 /**
  * Parameter
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#parameterObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#parameterObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#parameterObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/RequestBody.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/RequestBody.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.models.media.Content;
 /**
  * RequestBody
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#requestBodyObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#requestBodyObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#requestBodyObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/RequestBody.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/parameters/RequestBody.java
@@ -6,8 +6,8 @@ import io.swagger.v3.oas.models.media.Content;
 /**
  * RequestBody
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#requestBodyObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#requestBodyObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#requestBody-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#request-body-object"
  */
 
 public class RequestBody {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponse.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponse.java
@@ -12,8 +12,8 @@ import java.util.Objects;
 /**
  * ApiResponse
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#responseObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#responseObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#response-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#response-object"
  */
 
 public class ApiResponse {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponse.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponse.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 /**
  * ApiResponse
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#responseObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#responseObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#responseObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponses.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponses.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 /**
  * ApiResponses
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#responsesObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#responsesObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#responsesObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponses.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/responses/ApiResponses.java
@@ -8,8 +8,8 @@ import java.util.Objects;
 /**
  * ApiResponses
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#responsesObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#responsesObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#responses-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#responses-object"
  */
 
 public class ApiResponses extends LinkedHashMap<String, ApiResponse> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlow.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlow.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * OAuthFlow
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#oauthFlowsObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#oauthFlowsObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#oauthFlowsObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlow.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlow.java
@@ -7,8 +7,8 @@ import java.util.Objects;
 /**
  * OAuthFlow
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#oauthFlowsObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#oauthFlowsObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#oauth-flows-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#oauth-flows-object"
  */
 
 public class OAuthFlow {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlows.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlows.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * OAuthFlows
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#oauthFlowsObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#oauthFlowsObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#oauthFlowsObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlows.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/OAuthFlows.java
@@ -7,8 +7,8 @@ import java.util.Objects;
 /**
  * OAuthFlows
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#oauthFlowsObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#oauthFlowsObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#oauth-flows-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#oauth-flows-object"
  */
 
 public class OAuthFlows {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/Scopes.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/Scopes.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 /**
  * Scopes
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#scopedObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#scopedObject"
  */
 
 public class Scopes extends LinkedHashMap<String, String> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/Scopes.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/Scopes.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 /**
  * Scopes
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#scopedObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#scoped-object"
  */
 
 public class Scopes extends LinkedHashMap<String, String> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityRequirement.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityRequirement.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 /**
  * SecurityRequirement
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#securityRequirementObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securityRequirementObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#securityRequirementObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityRequirement.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityRequirement.java
@@ -9,8 +9,8 @@ import java.util.Objects;
 /**
  * SecurityRequirement
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securityRequirementObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#securityRequirementObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#security-requirement-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#security-requirement-object"
  */
 
 public class SecurityRequirement extends LinkedHashMap<String, List<String>> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityScheme.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityScheme.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.models.annotations.OpenAPI31;
 /**
  * SecurityScheme
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securitySchemeObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#securitySchemeObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#security-scheme-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#security-scheme-object"
  */
 
 public class SecurityScheme {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityScheme.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/security/SecurityScheme.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.models.annotations.OpenAPI31;
 /**
  * SecurityScheme
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#securitySchemeObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#securitySchemeObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#securitySchemeObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/Server.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/Server.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * Server
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#serverObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#serverObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#serverObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/Server.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/Server.java
@@ -7,8 +7,8 @@ import java.util.Objects;
 /**
  * Server
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#serverObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#serverObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#server-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#server-object"
  */
 
 public class Server {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariable.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariable.java
@@ -9,8 +9,8 @@ import java.util.Objects;
 /**
  * ServerVariable
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#serverVariableObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#serverVariableObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#server-variable-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#server-variable-object"
  */
 
 public class ServerVariable {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariable.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariable.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 /**
  * ServerVariable
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#serverVariableObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#serverVariableObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#serverVariableObject"
  */
 

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariables.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariables.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 /**
  * ServerVariables
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#serverVariablesObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#server-variables-object"
  */
 
 public class ServerVariables extends LinkedHashMap<String, ServerVariable> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariables.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/servers/ServerVariables.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 /**
  * ServerVariables
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#serverVariablesObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#serverVariablesObject"
  */
 
 public class ServerVariables extends LinkedHashMap<String, ServerVariable> {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/tags/Tag.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/tags/Tag.java
@@ -8,8 +8,8 @@ import java.util.Objects;
 /**
  * Tag
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#tagObject"
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#tagObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#tag-object"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#tag-object"
  */
 
 public class Tag {

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/tags/Tag.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/tags/Tag.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 /**
  * Tag
  *
- * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.1/versions/3.0.1.md#tagObject"
+ * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#tagObject"
  * @see "https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#tagObject"
  */
 


### PR DESCRIPTION
* [allow specifying openAPI version (e.g. 3.0.4, 3.1.1)](https://github.com/swagger-api/swagger-core/commit/26b19d336fdc7e7d6543647eda02211acb9ed765)

* [updated links to spec (see https://github.com/OAI/OpenAPI-Specification/pull/3548)](https://github.com/swagger-api/swagger-core/commit/3e8f85843522c4235e784d31c678a4f97bca6f4c)