### PR TITLE
Added ability to set name for ApiResponse and RequestBody annotations

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/parameters/RequestBody.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/parameters/RequestBody.java
@@ -24,6 +24,14 @@ import static java.lang.annotation.ElementType.PARAMETER;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface RequestBody {
+
+    /**
+     * Unique name to identify this RequestBody component. Used in components block.
+     *
+     * @return the name of the RequestBody
+     */
+    String name() default "";
+
     /**
      * A brief description of the request body.
      *

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/responses/ApiResponse.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/responses/ApiResponse.java
@@ -30,6 +30,14 @@ import static java.lang.annotation.ElementType.TYPE;
 @Inherited
 @Repeatable(ApiResponses.class)
 public @interface ApiResponse {
+
+    /**
+     * Unique name to identify this ApiResponse component. Used in components block.
+     *
+     * @return the name of the ApiResponse
+     */
+    String name() default "";
+
     /**
      * A short description of the response.
      *


### PR DESCRIPTION
It is now possible to specify the name of any component using an annotation, except for RequestBody and ApiResponse. The name of the components is required not only for the linear description of the specification, but also so that these components can be taken out to the #/components/ block.

The idea is to add a new annotation in which the user can describe common components and then refer to these components.

In other words, the RequestBody and ApiResponse annotations currently have a `ref` field to reference the component, but there is no way to add this component to the #/components/ block

My idea is to add an OpenAPIComponents annotation something like this:

<img width="417" alt="{AE43898C-05D9-4203-ADE6-08EC89BF8E8F}" src="https://github.com/user-attachments/assets/8281d33c-fd36-4917-a144-74663f0243a3" />

To allow the code to describe common components, and add annotations with references to common components to methods / fields / parameters
