### PR TITLE
update Schema resolution and casting - add `explicit-object-schema` and `use-arbitrary-schema` sys/env props

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -506,7 +506,7 @@ public abstract class AnnotationsUtils {
             arraySchemaObject = new ArraySchema();
         } else {
             if (existingSchema == null) {
-                arraySchemaObject = new ArraySchema();
+                arraySchemaObject = new JsonSchema().typesItem("array");
             } else {
                 arraySchemaObject = existingSchema;
             }
@@ -889,7 +889,7 @@ public abstract class AnnotationsUtils {
         Schema schemaObject;
         PrimitiveType primitiveType = PrimitiveType.fromType(schemaImplementation);
         if (primitiveType != null) {
-            schemaObject = primitiveType.createProperty();
+            schemaObject = openapi31 ? primitiveType.createProperty31() : primitiveType.createProperty();
         } else {
             schemaObject = new Schema();
             ResolvedSchema resolvedSchema = null;
@@ -1583,7 +1583,7 @@ public abstract class AnnotationsUtils {
                 }
                 if (annotationContent.schemaProperties().length > 0) {
                     if (mediaType.getSchema() == null) {
-                        mediaType.schema(new Schema<Object>().type("object"));
+                        mediaType.schema(openapi31 ? new JsonSchema().typesItem("object") : new Schema<Object>().type("object"));
                     }
                     Schema oSchema = mediaType.getSchema();
                     for (SchemaProperty sp: annotationContent.schemaProperties()) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ParameterProcessor.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ParameterProcessor.java
@@ -253,8 +253,8 @@ public class ParameterProcessor {
                     if (parameter.getSchema() == null) {
                         parameter.setSchema(new ArraySchema());
                     }
-                    if (parameter.getSchema() instanceof ArraySchema) {
-                        ArraySchema as = (ArraySchema) parameter.getSchema();
+                    if (isArraySchema(parameter.getSchema())) {
+                        Schema as = parameter.getSchema();
                         Integer min = (Integer) annotation.annotationType().getMethod("min").invoke(annotation);
                         if (min != null) {
                             as.setMinItems(min);
@@ -281,10 +281,9 @@ public class ParameterProcessor {
             }
         }
         if (paramSchema != null) {
-            if (paramSchema instanceof ArraySchema) {
-                ArraySchema as = (ArraySchema) paramSchema;
+            if (isArraySchema(paramSchema)) {
                 if (defaultValue != null) {
-                    as.getItems().setDefault(defaultValue);
+                    paramSchema.getItems().setDefault(defaultValue);
                 }
             } else {
                 if (defaultValue != null) {
@@ -293,6 +292,10 @@ public class ParameterProcessor {
             }
         }
         return parameter;
+    }
+
+    public static boolean isArraySchema(Schema schema) {
+        return "array".equals(schema.getType()) || (schema.getTypes() != null && schema.getTypes().contains("array"));
     }
 
     public static void setParameterExplode(Parameter parameter, io.swagger.v3.oas.annotations.Parameter p) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.media.DateSchema;
 import io.swagger.v3.oas.models.media.DateTimeSchema;
 import io.swagger.v3.oas.models.media.FileSchema;
 import io.swagger.v3.oas.models.media.IntegerSchema;
+import io.swagger.v3.oas.models.media.JsonSchema;
 import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -29,16 +30,25 @@ import java.util.concurrent.ConcurrentHashMap;
  * of classes into Swagger primitive types.
  */
 public enum PrimitiveType {
+
     STRING(String.class, "string") {
         @Override
         public Schema createProperty() {
             return new StringSchema();
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string");
         }
     },
     BOOLEAN(Boolean.class, "boolean") {
         @Override
         public Schema createProperty() {
             return new BooleanSchema();
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("boolean");
         }
     },
     BYTE(Byte.class, "byte") {
@@ -51,6 +61,10 @@ public enum PrimitiveType {
             }
             return new ByteArraySchema();
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("byte");
+        }
     },
     BINARY(Byte.class, "binary") {
         @Override
@@ -62,11 +76,19 @@ public enum PrimitiveType {
             }
             return new BinarySchema();
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("binary");
+        }
     },
     URI(java.net.URI.class, "uri") {
         @Override
         public Schema createProperty() {
             return new StringSchema().format("uri");
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("uri");
         }
     },
     URL(java.net.URL.class, "url") {
@@ -74,11 +96,19 @@ public enum PrimitiveType {
         public Schema createProperty() {
             return new StringSchema().format("url");
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("url");
+        }
     },
     EMAIL(String.class, "email") {
         @Override
         public Schema createProperty() {
             return new StringSchema().format("email");
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("email");
         }
     },
     UUID(java.util.UUID.class, "uuid") {
@@ -86,11 +116,19 @@ public enum PrimitiveType {
         public UUIDSchema createProperty() {
             return new UUIDSchema();
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("uuid");
+        }
     },
     INT(Integer.class, "integer") {
         @Override
         public IntegerSchema createProperty() {
             return new IntegerSchema();
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("integer").format("int32");
         }
     },
     LONG(Long.class, "long") {
@@ -98,11 +136,19 @@ public enum PrimitiveType {
         public Schema createProperty() {
             return new IntegerSchema().format("int64");
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("integer").format("int64");
+        }
     },
     FLOAT(Float.class, "float") {
         @Override
         public Schema createProperty() {
             return new NumberSchema().format("float");
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("number").format("float");
         }
     },
     DOUBLE(Double.class, "double") {
@@ -110,11 +156,19 @@ public enum PrimitiveType {
         public Schema createProperty() {
             return new NumberSchema().format("double");
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("number").format("double");
+        }
     },
     INTEGER(java.math.BigInteger.class) {
         @Override
         public Schema createProperty() {
             return new IntegerSchema().format(null);
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("integer");
         }
     },
     DECIMAL(java.math.BigDecimal.class, "number") {
@@ -122,11 +176,19 @@ public enum PrimitiveType {
         public Schema createProperty() {
             return new NumberSchema();
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("number");
+        }
     },
     NUMBER(Number.class, "number") {
         @Override
         public Schema createProperty() {
             return new NumberSchema();
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("number");
         }
     },
     DATE(DateStub.class, "date") {
@@ -134,11 +196,19 @@ public enum PrimitiveType {
         public DateSchema createProperty() {
             return new DateSchema();
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("date");
+        }
     },
     DATE_TIME(java.util.Date.class, "date-time") {
         @Override
         public DateTimeSchema createProperty() {
             return new DateTimeSchema();
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("date-time");
         }
     },
     PARTIAL_TIME(java.time.LocalTime.class, "partial-time") {
@@ -146,20 +216,34 @@ public enum PrimitiveType {
         public Schema createProperty() {
             return new StringSchema().format("partial-time");
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("partial-time");
+        }
     },
     FILE(java.io.File.class, "file") {
         @Override
         public FileSchema createProperty() {
             return new FileSchema();
         }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema().typesItem("string").format("binary");
+        }
     },
     OBJECT(Object.class) {
+
         @Override
         public Schema createProperty() {
-            return new Schema().type("object");
+            return explicitObjectType == null || explicitObjectType ? new Schema().type("object"): new Schema();
+        }
+        @Override
+        public Schema createProperty31() {
+            return new JsonSchema();
         }
     };
 
+    public static Boolean explicitObjectType;
     private static final Map<Class<?>, PrimitiveType> KEY_CLASSES;
     private static final Map<Class<?>, Collection<PrimitiveType>> MULTI_KEY_CLASSES;
     private static final Map<Class<?>, PrimitiveType> BASE_CLASSES;
@@ -289,6 +373,12 @@ public enum PrimitiveType {
         addKeys(names, INT, "int");
         addKeys(names, OBJECT, "object");
         NAMES = Collections.unmodifiableMap(names);
+
+        if (System.getenv(Schema.EXPLICIT_OBJECT_SCHEMA_PROPERTY) != null) {
+            explicitObjectType = Boolean.parseBoolean(System.getenv(Schema.EXPLICIT_OBJECT_SCHEMA_PROPERTY));
+        } else if (System.getProperty(Schema.EXPLICIT_OBJECT_SCHEMA_PROPERTY) != null) {
+            explicitObjectType = Boolean.parseBoolean(System.getProperty(Schema.EXPLICIT_OBJECT_SCHEMA_PROPERTY));
+        }
     }
 
     private PrimitiveType(Class<?> keyClass) {
@@ -434,13 +524,21 @@ public enum PrimitiveType {
     }
 
     public static Schema createProperty(Type type) {
+        return createProperty(type, false);
+    }
+
+    public static Schema createProperty(Type type, boolean openapi31) {
         final PrimitiveType item = fromType(type);
-        return item == null ? null : item.createProperty();
+        return item == null ? null : openapi31 ? item.createProperty31() : item.createProperty();
     }
 
     public static Schema createProperty(String name) {
+        return createProperty(name, false);
+    }
+
+    public static Schema createProperty(String name, boolean openapi31) {
         final PrimitiveType item = fromName(name);
-        return item == null ? null : item.createProperty();
+        return item == null ? null : openapi31 ? item.createProperty31() : item.createProperty();
     }
 
     public static String getCommonName(Type type) {
@@ -457,6 +555,7 @@ public enum PrimitiveType {
     }
 
     public abstract Schema createProperty();
+    public abstract Schema createProperty31();
 
     private static <K> void addKeys(Map<K, PrimitiveType> map, PrimitiveType type, K... keys) {
         for (K key : keys) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ModelResolverOAS31Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ModelResolverOAS31Test.java
@@ -65,11 +65,12 @@ public class ModelResolverOAS31Test extends SwaggerTestBase {
                 "      - UNITED_STATES_OF_AMERICA\n" +
                 "      - CANADA\n" +
                 "  propertyNames:\n" +
-                "    $ref: \"#/components/schemas/PropertyNamesPattern\"\n" +
+                "    pattern: \"^[A-Za-z_][A-Za-z0-9_]*$\"\n" +
                 "AnnotatedCountry:\n" +
                 "  type: object\n" +
                 "  properties:\n" +
                 "    country:\n" +
+                "      type: string\n" +
                 "      const: United States\n" +
                 "Client:\n" +
                 "  type: object\n" +
@@ -167,16 +168,18 @@ public class ModelResolverOAS31Test extends SwaggerTestBase {
                 "  type: object\n" +
                 "  properties:\n" +
                 "    postalCode:\n" +
+                "      type: string\n" +
                 "      pattern: \"[0-9]{5}(-[0-9]{4})?\"\n" +
                 "PostalCodePattern:\n" +
                 "  type: object\n" +
                 "  properties:\n" +
                 "    postalCode:\n" +
+                "      type: string\n" +
                 "      pattern: \"[A-Z][0-9][A-Z] [0-9][A-Z][0-9]\"\n" +
                 "PropertyNamesPattern:\n" +
-                "  type: object\n" +
                 "  pattern: \"^[A-Za-z_][A-Za-z0-9_]*$\"\n");
     }
+
 
     @Test
     public void testDependentSchemasAnnotation() {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/Address.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/Address.java
@@ -70,7 +70,8 @@ public class Address {
         private Object country;
 
         @Schema(
-                _const = "United States"
+                _const = "United States",
+                type = "string"
 
         )
         public Object getCountry() {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodeNumberPattern.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodeNumberPattern.java
@@ -8,7 +8,8 @@ public class PostalCodeNumberPattern {
     private Object postalCode;
 
     @Schema(
-            pattern = "[0-9]{5}(-[0-9]{4})?"
+            pattern = "[0-9]{5}(-[0-9]{4})?",
+            type = "string"
     )
     public Object getPostalCode() {
         return postalCode;

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodePattern.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodePattern.java
@@ -7,7 +7,8 @@ public class PostalCodePattern {
     private Object postalCode;
 
     @Schema(
-            pattern = "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]"
+            pattern = "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]",
+            type = "string"
     )
     public Object getPostalCode() {
         return postalCode;

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -89,6 +89,7 @@ import io.swagger.v3.jaxrs2.resources.Ticket4804CustomClass;
 import io.swagger.v3.jaxrs2.resources.Ticket4804ProcessorResource;
 import io.swagger.v3.jaxrs2.resources.Ticket4804Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket4859Resource;
+import io.swagger.v3.jaxrs2.resources.Ticket4879Resource;
 import io.swagger.v3.jaxrs2.resources.UploadResource;
 import io.swagger.v3.jaxrs2.resources.UrlEncodedResourceWithEncodings;
 import io.swagger.v3.jaxrs2.resources.UserAnnotationResource;
@@ -3623,8 +3624,7 @@ public class ReaderTest {
                 "          properties:\n" +
                 "            foo:\n" +
                 "              $ref: \"#/components/schemas/Foo\"\n" +
-                "    SimpleCategory:\n" +
-                "      type: object\n" ;
+                "    SimpleCategory: {}\n";
         SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
     }
 
@@ -3698,7 +3698,6 @@ public class ReaderTest {
                 "components:\n" +
                 "  schemas:\n" +
                 "    PetSimple:\n" +
-                "      type: object\n" +
                 "      description: Pet\n";
         SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
     }
@@ -3747,7 +3746,6 @@ public class ReaderTest {
                 "components:\n" +
                 "  schemas:\n" +
                 "    PetSimple:\n" +
-                "      type: object\n" +
                 "      description: Pet\n";
         SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
     }
@@ -3793,7 +3791,6 @@ public class ReaderTest {
                 "components:\n" +
                 "  schemas:\n" +
                 "    PetSimple:\n" +
-                "      type: object\n" +
                 "      description: Pet\n";
         SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
     }
@@ -3870,7 +3867,6 @@ public class ReaderTest {
                 "components:\n" +
                 "  schemas:\n" +
                 "    PetSimple:\n" +
-                "      type: object\n" +
                 "      description: Pet\n";
         SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
     }
@@ -4080,7 +4076,7 @@ public class ReaderTest {
                 "          - United States of America\n" +
                 "          - Canada\n" +
                 "      propertyNames:\n" +
-                "        $ref: \"#/components/schemas/PropertyNamesPattern\"\n" +
+                "        pattern: \"^[A-Za-z_][A-Za-z0-9_]*$\"\n" +
                 "    AnnotatedCountry:\n" +
                 "      type: object\n" +
                 "      properties:\n" +
@@ -4102,7 +4098,6 @@ public class ReaderTest {
                 "        postalCode:\n" +
                 "          pattern: \"[A-Z][0-9][A-Z] [0-9][A-Z][0-9]\"\n" +
                 "    PropertyNamesPattern:\n" +
-                "      type: object\n" +
                 "      pattern: \"^[A-Za-z_][A-Za-z0-9_]*$\"\n";
         SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
     }
@@ -5161,6 +5156,77 @@ public class ReaderTest {
                 "          type: string\n" +
                 "          example: \"4242424242424242\"\n";
         SerializationMatchers.assertEqualsToYaml(openAPI, yaml);
+        ModelConverters.reset();
+    }
+
+    @Test(description = "test default value type")
+    public void testTicket4879() {
+        ModelConverters.reset();
+        SwaggerConfiguration config = new SwaggerConfiguration().openAPI31(true);
+        Reader reader = new Reader(config);
+
+        OpenAPI openAPI = reader.read(Ticket4879Resource.class);
+        String yaml = "openapi: 3.1.0\n" +
+                "paths:\n" +
+                "  /test/test:\n" +
+                "    put:\n" +
+                "      operationId: test\n" +
+                "      requestBody:\n" +
+                "        content:\n" +
+                "          '*/*':\n" +
+                "            schema:\n" +
+                "              $ref: \"#/components/schemas/DefaultClass\"\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            '*/*': {}\n" +
+                "  /test/testDefaultValueAnnotation:\n" +
+                "    get:\n" +
+                "      operationId: testDefault\n" +
+                "      parameters:\n" +
+                "      - name: myBool\n" +
+                "        in: query\n" +
+                "        schema:\n" +
+                "          type: boolean\n" +
+                "          default: true\n" +
+                "      - name: myInt\n" +
+                "        in: query\n" +
+                "        schema:\n" +
+                "          type: integer\n" +
+                "          format: int32\n" +
+                "          default: 1\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            '*/*': {}\n" +
+                "  /test/testsize:\n" +
+                "    get:\n" +
+                "      operationId: testSize\n" +
+                "      requestBody:\n" +
+                "        content:\n" +
+                "          '*/*':\n" +
+                "            schema:\n" +
+                "              type: array\n" +
+                "              items:\n" +
+                "                type: string\n" +
+                "              maxItems: 100\n" +
+                "              minItems: 1\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            '*/*': {}\n" +
+                "components:\n" +
+                "  schemas:\n" +
+                "    DefaultClass:\n" +
+                "      type: object\n" +
+                "      properties:\n" +
+                "        name:\n" +
+                "          type: boolean\n" +
+                "          default: true\n";
+        SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
         ModelConverters.reset();
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket4879Resource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket4879Resource.java
@@ -1,0 +1,35 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.validation.constraints.Size;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import java.util.List;
+
+@Path("/test")
+public class Ticket4879Resource {
+
+    @PUT
+    @Path("/test")
+    public void test(DefaultClass defaultClass) {}
+
+    @GET
+    @Path("/testDefaultValueAnnotation")
+    public void testDefault(
+            @DefaultValue(value = "true") @QueryParam(value = "myBool") Boolean myBool,
+            @DefaultValue(value = "1") @QueryParam(value = "myInt") Integer myInt) {
+    }
+
+    @GET
+    @Path("/testsize")
+    public void testSize(@Size(min = 1, max = 100) List<String> myList) {}
+
+    public static class DefaultClass {
+        @Schema(defaultValue = "true")
+        public Boolean name;
+    }
+}

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ArbitrarySchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/ArbitrarySchema.java
@@ -1,0 +1,59 @@
+package io.swagger.v3.oas.models.media;
+
+import java.util.Objects;
+
+/**
+ * ObjectSchema
+ */
+
+public class ArbitrarySchema extends Schema<Object> {
+
+    public ArbitrarySchema() {
+    }
+
+    @Override
+    public ArbitrarySchema type(String type) {
+        super.setType(type);
+        return this;
+    }
+
+    @Override
+    public ArbitrarySchema example(Object example) {
+        if (example != null) {
+            super.setExample(example.toString());
+        } else {
+            super.setExample(example);
+        }
+        return this;
+    }
+
+    @Override
+    protected Object cast(Object value) {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class ObjectSchema {\n");
+        sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/JsonSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/JsonSchema.java
@@ -2,14 +2,70 @@ package io.swagger.v3.oas.models.media;
 
 import io.swagger.v3.oas.models.SpecVersion;
 
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * JsonSchema
  */
 
 public class JsonSchema extends Schema<Object> {
 
+    private static final Set<String> NUMBER_TYPES = new HashSet<>(Arrays.asList("integer", "number"));
+
     public JsonSchema (){
         specVersion(SpecVersion.V31);
+    }
+
+    private String resolveType() {
+        if (this.getTypes() != null) {
+            if (this.getTypes().size() == 1) {
+                String type = this.getTypes().iterator().next();
+                if (NUMBER_TYPES.contains(type)) {
+                    return "number";
+                }
+                return type;
+            }
+            if (this.getTypes().contains("object")) {
+                return "object";
+            } else if (this.getTypes().contains("string")) {
+                return "string";
+            } else if (this.getTypes().contains("array")) {
+                return "array";
+            } else if (this.getTypes().contains("integer") || this.getTypes().contains("number")) {
+                return "number";
+            } else if (this.getTypes().contains("boolean")) {
+                return "boolean";
+            }
+            return this.getTypes().iterator().next();
+        }
+        return "null";
+    }
+
+    protected Object cast(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String) {
+            if (resolveType().equals("number")) {
+                try {
+                    Number casted = NumberFormat.getInstance().parse(value.toString());
+                    if (Integer.MIN_VALUE <= casted.longValue() && casted.longValue() <= Integer.MAX_VALUE) {
+                        return Integer.parseInt(value.toString());
+                    } else {
+                        return Long.parseLong(value.toString());
+                    }
+                } catch (Exception e) {
+                    return value;
+                }
+            } else if (resolveType().equals("boolean")) {
+                return Boolean.parseBoolean(value.toString());
+            }
+
+        }
+        return value;
     }
 
     @Override

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -47,6 +47,9 @@ public class Schema<T> {
 
     public static final String SCHEMA_RESOLUTION_PROPERTY = "schema-resolution";
     public static final String APPLY_SCHEMA_RESOLUTION_PROPERTY = "apply-schema-resolution";
+    public static final String EXPLICIT_OBJECT_SCHEMA_PROPERTY = "explicit-object-schema";
+    public static final String USE_ARBITRARY_SCHEMA_PROPERTY = "use-arbitrary-schema";
+
     public enum SchemaResolution {
         @JsonProperty("default")
         DEFAULT("default"),
@@ -539,6 +542,16 @@ public class Schema<T> {
 
     /**
      *
+     * @since 2.2.30 (OpenAPI 3.1.0)
+     */
+    @OpenAPI31
+    public Schema typesItem(String type) {
+        addType(type);
+        return this;
+    }
+
+    /**
+     *
      * @since 2.2.0 (OpenAPI 3.1.0)
      */
     @OpenAPI31
@@ -821,7 +834,7 @@ public class Schema<T> {
 
 
     /**
-     * returns the name property from a from a Schema instance. Ignored in serialization.
+     * returns the name property from a Schema instance. Ignored in serialization.
      *
      * @return String name
      **/


### PR DESCRIPTION
This PR addresses the following tickets:

* #4798
* #4625
* #4457
* #4014
* #3834
* #4792 

Changes include:

* use correct `Schema` hierarchy for 3.0 and 3.1 
* update casting for 3.1
* update `object` type resolution 
* introducing `explicit-object-schema` and `use-arbitrary-schema` sys/env props

These 2 properties allow to tweak the processing of  Schema `type`. By default

* for OAS 3.0 a `type: object` is added whenever any class (even `java.lang.Object`) is resolved into a schema and no type is defined in annotations or elsewhere. This behavior is unchanged (see below to customize) for compatibility reasons

* for OAS 3.1 `type: object` is NOT added when type is not defined and there are not Object Schema-specific properties resolved for that schema.

this behavior can be customized by explicitly setting System/Env property `explicit-object-schema` to `true` (always add `type:object` in this scenario or `false` (don't add `type: object`)

Additionally, setting `use-arbitrary-schema` to `true` allows to customize deserialization behavior (see #4014) to deserialize schemas with no type defined into a `ArbitrarySchema` with `type` not defined instead of `ObjectSchema` with `type: object`
