### PR TITLE
feat: Support other types than string in enum schemas

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/EnumPropertyTest.java
@@ -12,6 +12,7 @@ import io.swagger.v3.core.oas.models.ModelWithEnumField;
 import io.swagger.v3.core.oas.models.ModelWithEnumProperty;
 import io.swagger.v3.core.oas.models.ModelWithEnumRefProperty;
 import io.swagger.v3.core.oas.models.ModelWithJacksonEnumField;
+import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import org.testng.annotations.AfterTest;
@@ -216,23 +217,23 @@ public class EnumPropertyTest {
         assertEquals(secondStringProperty.getEnum(), Arrays.asList("one", "two", "three"));
 
         final Schema thirdEnumProperty = (Schema) model.getProperties().get("thirdEnumValue");
-        assertTrue(thirdEnumProperty instanceof StringSchema);
-        final StringSchema thirdStringProperty = (StringSchema) thirdEnumProperty;
-        assertEquals(thirdStringProperty.getEnum(), Arrays.asList("2", "4", "6"));
+        assertTrue(thirdEnumProperty instanceof IntegerSchema);
+        final IntegerSchema thirdStringProperty = (IntegerSchema) thirdEnumProperty;
+        assertEquals(thirdStringProperty.getEnum(), Arrays.asList(2, 4, 6));
 
         final Schema fourthEnumProperty = (Schema) model.getProperties().get("fourthEnumValue");
         assertTrue(fourthEnumProperty instanceof StringSchema);
         final StringSchema fourthStringProperty = (StringSchema) fourthEnumProperty;
-        assertEquals(fourthEnumProperty.getEnum(), Arrays.asList("one", "two", "three"));
+        assertEquals(fourthStringProperty.getEnum(), Arrays.asList("one", "two", "three"));
 
         final Schema fifthEnumProperty = (Schema) model.getProperties().get("fifthEnumValue");
-        assertTrue(fifthEnumProperty instanceof StringSchema);
-        final StringSchema fifthStringProperty = (StringSchema) fifthEnumProperty;
-        assertEquals(fifthEnumProperty.getEnum(), Arrays.asList("2", "4", "6"));
+        assertTrue(fifthEnumProperty instanceof IntegerSchema);
+        final IntegerSchema fifthStringProperty = (IntegerSchema) fifthEnumProperty;
+        assertEquals(fifthStringProperty.getEnum(), Arrays.asList(2, 4, 6));
 
         final Schema sixthEnumProperty = (Schema) model.getProperties().get("sixthEnumValue");
         assertTrue(sixthEnumProperty instanceof StringSchema);
         final StringSchema sixthStringProperty = (StringSchema) sixthEnumProperty;
-        assertEquals(sixthEnumProperty.getEnum(), Arrays.asList("one", "two", "three"));
+        assertEquals(sixthStringProperty.getEnum(), Arrays.asList("one", "two", "three"));
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonIntegerValueEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonIntegerValueEnum.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 /**
  * Enum holds values different from names.  Schema model will derive Integer value from jackson annotation JsonValue on public method.
  */
-public enum JacksonNumberValueEnum {
+public enum JacksonIntegerValueEnum {
     FIRST(2),
     SECOND(4),
     THIRD(6),
@@ -14,12 +14,12 @@ public enum JacksonNumberValueEnum {
 
     private final int value;
 
-    JacksonNumberValueEnum(int value) {
+    JacksonIntegerValueEnum(int value) {
         this.value = value;
     }
 
     @JsonValue
-    public Number getValue() {
+    public Integer getValue() {
         return value;
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonIntegerValueFieldEnum.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/JacksonIntegerValueFieldEnum.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.Hidden;
 /**
  * Enum holds values different from names. Schema model will derive Integer value from jackson annotation JsonValue on private field.
  */
-public enum JacksonNumberValueFieldEnum {
+public enum JacksonIntegerValueFieldEnum {
     FIRST(2),
     SECOND(4),
     THIRD(6),
@@ -15,7 +15,7 @@ public enum JacksonNumberValueFieldEnum {
     @JsonValue
     private final int value;
 
-    JacksonNumberValueFieldEnum(int value) {
+    JacksonIntegerValueFieldEnum(int value) {
         this.value = value;
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithJacksonEnumField.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/ModelWithJacksonEnumField.java
@@ -6,8 +6,8 @@ package io.swagger.v3.core.oas.models;
 public class ModelWithJacksonEnumField {
     public JacksonPropertyEnum firstEnumValue;
     public JacksonValueEnum secondEnumValue;
-    public JacksonNumberValueEnum thirdEnumValue;
+    public JacksonIntegerValueEnum thirdEnumValue;
     public JacksonValueFieldEnum fourthEnumValue;
-    public JacksonNumberValueFieldEnum fifthEnumValue;
+    public JacksonIntegerValueFieldEnum fifthEnumValue;
     public JacksonValuePrivateEnum sixthEnumValue;
 }


### PR DESCRIPTION
Refactor the method for generating enum schemas to better handle type-specific schemas, such as IntegerSchema. This change ensures that integer-based enums are correctly represented in the generated schemas.

fixes https://github.com/swagger-api/swagger-core/issues/4768