### PR TITLE
Consistent usage of TestNG

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -147,11 +147,6 @@
             <version>1.0.5</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <properties>
         <!-- TODO increase coverage -->

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/OpenAPI3_1DeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/OpenAPI3_1DeserializationTest.java
@@ -13,11 +13,10 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNull;
 
 public class OpenAPI3_1DeserializationTest {
 
@@ -46,7 +45,7 @@ public class OpenAPI3_1DeserializationTest {
         final String jsonString = ResourceUtils.loadClassResource(getClass(), "specFiles/petstore-3.0.yaml");
         final OpenAPI swagger = Yaml.mapper().readValue(jsonString, OpenAPI.class);
         assertNotNull(swagger);
-        assertEquals(swagger.getInfo().getLicense().getIdentifier(), null);
+        assertNull(swagger.getInfo().getLicense().getIdentifier());
     }
 
     @Test
@@ -237,13 +236,13 @@ public class OpenAPI3_1DeserializationTest {
         String json = Json31.pretty(openAPI);
         String yaml = Yaml31.pretty(openAPI);
         OpenAPI oas = Json31.mapper().readValue(json, OpenAPI.class);
-        assertTrue(Boolean.TRUE.equals(oas.getComponents().getSchemas().get("test").getBooleanSchemaValue()));
+        assertEquals(oas.getComponents().getSchemas().get("test").getBooleanSchemaValue(), Boolean.TRUE);
         Schema schema = Json31.mapper().readValue("true", Schema.class);
-        assertTrue(Boolean.TRUE.equals(schema.getBooleanSchemaValue()));
+        assertEquals(schema.getBooleanSchemaValue(), Boolean.TRUE);
         oas = Yaml31.mapper().readValue(yaml, OpenAPI.class);
-        assertTrue(Boolean.TRUE.equals(oas.getComponents().getSchemas().get("test").getBooleanSchemaValue()));
+        assertEquals(oas.getComponents().getSchemas().get("test").getBooleanSchemaValue(), Boolean.TRUE);
         schema = Yaml31.mapper().readValue("true", Schema.class);
-        assertTrue(Boolean.TRUE.equals(schema.getBooleanSchemaValue()));
+        assertEquals(schema.getBooleanSchemaValue(), Boolean.TRUE);
 
         json = Json.pretty(openAPI);
         yaml = Yaml.pretty(openAPI);

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/properties/MapPropertyDeserializerTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/properties/MapPropertyDeserializerTest.java
@@ -8,11 +8,11 @@ import io.swagger.v3.oas.models.media.MapSchema;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static io.swagger.v3.core.util.TestUtils.normalizeLineEnds;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -143,7 +143,7 @@ public class MapPropertyDeserializerTest {
         assertTrue(responseSchema instanceof ObjectSchema);
 
         assertTrue(responseSchema.getAdditionalProperties() instanceof Boolean);
-        Assert.assertFalse((Boolean)responseSchema.getAdditionalProperties());
+        assertFalse((Boolean)responseSchema.getAdditionalProperties());
 
         operation = Json.mapper().readValue(jsonAdditionalPropertiesBooleanTrue, Operation.class);
         response = operation.getResponses().get("200");
@@ -154,7 +154,7 @@ public class MapPropertyDeserializerTest {
         assertTrue(responseSchema instanceof MapSchema);
 
         assertTrue(responseSchema.getAdditionalProperties() instanceof Boolean);
-        Assert.assertTrue((Boolean)responseSchema.getAdditionalProperties());
+        assertTrue((Boolean)responseSchema.getAdditionalProperties());
     }
 
     @Test(description = "it should serialize a boolean additionalProperties")

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/AnnotationsUtilsExtensionsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/AnnotationsUtilsExtensionsTest.java
@@ -5,13 +5,14 @@ import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.extensions.Extension;
 import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
 
 public class AnnotationsUtilsExtensionsTest {
 
@@ -41,7 +42,7 @@ public class AnnotationsUtilsExtensionsTest {
         final Extension[] extensions = method.getAnnotation(Operation.class).extensions();
         final Map<String, Object> map = AnnotationsUtils.getExtensions(extensions);
 
-        Assert.assertEquals(map, expected);
+        assertEquals(map, expected);
     }
 
     @Operation(description = "method")

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/AnnotationsUtilsHeadersTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/AnnotationsUtilsHeadersTest.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.models.headers.Header.StyleEnum;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -14,6 +13,8 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
 
 public class AnnotationsUtilsHeadersTest {
 
@@ -48,7 +49,7 @@ public class AnnotationsUtilsHeadersTest {
         final Optional<Map<String, io.swagger.v3.oas.models.headers.Header>> optionalMap =
                 AnnotationsUtils.getHeaders(headers, null, null);
 
-        Assert.assertEquals(optionalMap, expected);
+        assertEquals(optionalMap, expected);
     }
 
     @Operation(description = "method")

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/BeanValidatorTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/BeanValidatorTest.java
@@ -7,11 +7,13 @@ import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class BeanValidatorTest {
 
@@ -21,33 +23,33 @@ public class BeanValidatorTest {
         final Schema model = schemas.get("BeanValidationsModel");
         final Map<String, Schema> properties = model.getProperties();
 
-        Assert.assertTrue(model.getRequired().contains("id"));
+        assertTrue(model.getRequired().contains("id"));
 
         final IntegerSchema age = (IntegerSchema) properties.get("age");
-        Assert.assertEquals(age.getMinimum(), new BigDecimal(13.0));
-        Assert.assertEquals(age.getMaximum(), new BigDecimal(99.0));
+        assertEquals(age.getMinimum(), new BigDecimal(13.0));
+        assertEquals(age.getMaximum(), new BigDecimal(99.0));
 
         final StringSchema password = (StringSchema) properties.get("password");
-        Assert.assertEquals((int) password.getMinLength(), 6);
-        Assert.assertEquals((int) password.getMaxLength(), 20);
+        assertEquals((int) password.getMinLength(), 6);
+        assertEquals((int) password.getMaxLength(), 20);
 
         final StringSchema email = (StringSchema) properties.get("email");
-        Assert.assertEquals((String) email.getPattern(), "(.+?)@(.+?)");
+        assertEquals(email.getPattern(), "(.+?)@(.+?)");
 
         final NumberSchema minBalance = (NumberSchema) properties.get("minBalance");
-        Assert.assertTrue(minBalance.getExclusiveMinimum());
+        assertTrue(minBalance.getExclusiveMinimum());
 
         final NumberSchema maxBalance = (NumberSchema) properties.get("maxBalance");
-        Assert.assertTrue(maxBalance.getExclusiveMaximum());
+        assertTrue(maxBalance.getExclusiveMaximum());
 
         final ArraySchema items = (ArraySchema) properties.get("items");
-        Assert.assertEquals((int) items.getMinItems(), 2);
-        Assert.assertEquals((int) items.getMaxItems(), 10);
-        Assert.assertEquals((int) items.getItems().getMinLength(), 3);
-        Assert.assertEquals((int) items.getItems().getMaxLength(), 4);
+        assertEquals((int) items.getMinItems(), 2);
+        assertEquals((int) items.getMaxItems(), 10);
+        assertEquals((int) items.getItems().getMinLength(), 3);
+        assertEquals((int) items.getItems().getMaxLength(), 4);
 
         final StringSchema optionalValue = (StringSchema) properties.get("optionalValue");
-        Assert.assertEquals((int) optionalValue.getMinLength(), 1);
-        Assert.assertEquals((int) optionalValue.getMaxLength(), 10);
+        assertEquals((int) optionalValue.getMinLength(), 1);
+        assertEquals((int) optionalValue.getMaxLength(), 10);
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedSchemaTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedSchemaTest.java
@@ -7,14 +7,18 @@ import io.swagger.v3.core.resolving.resources.TestObjectTicket2620Subtypes;
 import io.swagger.v3.core.resolving.resources.TestObjectTicket2900;
 import io.swagger.v3.core.resolving.resources.TestObjectTicket4247;
 import io.swagger.v3.core.util.Json;
-import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class ComposedSchemaTest {
 
@@ -23,43 +27,43 @@ public class ComposedSchemaTest {
         Map<String, Schema> schemas = ModelConverters.getInstance().readAll(TestObjectTicket2620.class);
         Schema model = schemas.get("Child2TestObject");
         Map<String, Schema> properties = model.getProperties();
-        Assert.assertNotNull(properties.get("name"));
-        Assert.assertNotNull(properties.get("childName"));
-        Assert.assertFalse(model instanceof ComposedSchema);
+        assertNotNull(properties.get("name"));
+        assertNotNull(properties.get("childName"));
+        assertFalse(model instanceof ComposedSchema);
         model = schemas.get("ChildTestObject");
         properties = model.getProperties();
-        Assert.assertNotNull(properties.get("name"));
-        Assert.assertNotNull(properties.get("childName"));
-        Assert.assertFalse(model instanceof ComposedSchema);
+        assertNotNull(properties.get("name"));
+        assertNotNull(properties.get("childName"));
+        assertFalse(model instanceof ComposedSchema);
 
         model = schemas.get("TestObjectTicket2620");
         properties = model.getProperties();
-        Assert.assertNotNull(properties.get("name"));
-        Assert.assertNull(properties.get("childName"));
-        Assert.assertTrue(model instanceof ComposedSchema);
-        Assert.assertTrue(((ComposedSchema)model).getOneOf().size() == 2);
+        assertNotNull(properties.get("name"));
+        assertNull(properties.get("childName"));
+        assertTrue(model instanceof ComposedSchema);
+        assertEquals(((ComposedSchema) model).getOneOf().size(), 2);
 
         schemas = ModelConverters.getInstance().readAll(TestObjectTicket2620Subtypes.class);
         model = schemas.get("Child2TestObject");
-        Assert.assertNull(model.getProperties());
+        assertNull(model.getProperties());
         properties = ((ComposedSchema)model).getAllOf().get(1).getProperties();
-        Assert.assertNull(properties.get("name"));
-        Assert.assertNotNull(properties.get("childName"));
-        Assert.assertTrue(model instanceof ComposedSchema);
+        assertNull(properties.get("name"));
+        assertNotNull(properties.get("childName"));
+        assertTrue(model instanceof ComposedSchema);
         model = schemas.get("ChildTestObject");
-        Assert.assertNull(model.getProperties());
+        assertNull(model.getProperties());
         properties = ((ComposedSchema)model).getAllOf().get(1).getProperties();
-        Assert.assertNull(properties.get("name"));
-        Assert.assertNotNull(properties.get("childName"));
-        Assert.assertTrue(model instanceof ComposedSchema);
-        Assert.assertTrue(((ComposedSchema)model).getAllOf().size() == 2);
+        assertNull(properties.get("name"));
+        assertNotNull(properties.get("childName"));
+        assertTrue(model instanceof ComposedSchema);
+        assertEquals(((ComposedSchema) model).getAllOf().size(), 2);
 
         model = schemas.get("TestObjectTicket2620Subtypes");
         properties = model.getProperties();
-        Assert.assertNotNull(properties.get("name"));
-        Assert.assertNull(properties.get("childName"));
-        Assert.assertTrue(model instanceof ComposedSchema);
-        Assert.assertTrue(((ComposedSchema)model).getOneOf().size() == 2);
+        assertNotNull(properties.get("name"));
+        assertNull(properties.get("childName"));
+        assertTrue(model instanceof ComposedSchema);
+        assertEquals(((ComposedSchema) model).getOneOf().size(), 2);
     }
 
     @Test(description = "read composed schem refs #2900")
@@ -67,44 +71,44 @@ public class ComposedSchemaTest {
         Json.mapper().addMixIn(TestObjectTicket2900.GsonJsonPrimitive.class, TestObjectTicket2900.GsonJsonPrimitiveMixIn.class);
         Map<String, Schema> schemas = ModelConverters.getInstance().readAll(TestObjectTicket2900.class);
         Schema model = schemas.get("SomeDTO");
-        Assert.assertNotNull(model);
+        assertNotNull(model);
         Map<String, Schema> properties = model.getProperties();
-        Assert.assertNotNull(properties.get("value"));
-        Assert.assertEquals(properties.get("value").get$ref(), "#/components/schemas/MyJsonPrimitive");
-        Assert.assertEquals(properties.get("valueWithMixIn").get$ref(), "#/components/schemas/GsonJsonPrimitive");
+        assertNotNull(properties.get("value"));
+        assertEquals(properties.get("value").get$ref(), "#/components/schemas/MyJsonPrimitive");
+        assertEquals(properties.get("valueWithMixIn").get$ref(), "#/components/schemas/GsonJsonPrimitive");
 
         model = schemas.get("MyJsonPrimitive");
-        Assert.assertNotNull(model);
-        Assert.assertTrue(((ComposedSchema)model).getOneOf().size() == 2);
-        Assert.assertEquals(((ComposedSchema)model).getOneOf().get(0).getType(), "string");
-        Assert.assertEquals(((ComposedSchema)model).getOneOf().get(1).getType(), "number");
+        assertNotNull(model);
+        assertEquals(((ComposedSchema) model).getOneOf().size(), 2);
+        assertEquals(((ComposedSchema)model).getOneOf().get(0).getType(), "string");
+        assertEquals(((ComposedSchema)model).getOneOf().get(1).getType(), "number");
 
         model = schemas.get("GsonJsonPrimitive");
-        Assert.assertNotNull(model);
-        Assert.assertTrue(((ComposedSchema)model).getOneOf().size() == 2);
-        Assert.assertEquals(((ComposedSchema)model).getOneOf().get(0).getType(), "string");
-        Assert.assertEquals(((ComposedSchema)model).getOneOf().get(1).getType(), "number");
-        Assert.assertNull(model.getProperties());
+        assertNotNull(model);
+        assertEquals(((ComposedSchema) model).getOneOf().size(), 2);
+        assertEquals(((ComposedSchema)model).getOneOf().get(0).getType(), "string");
+        assertEquals(((ComposedSchema)model).getOneOf().get(1).getType(), "number");
+        assertNull(model.getProperties());
     }
 
     @Test(description = "read composed schem refs #2616")
     public void readArrayComposedSchema_ticket2616() {
         Map<String, Schema> schemas = ModelConverters.getInstance().readAll(TestObject2616.class);
         Schema model = schemas.get("testObject");
-        Assert.assertNotNull(model);
+        assertNotNull(model);
         Map<String, Schema> properties = model.getProperties();
-        Assert.assertNotNull(properties.get("objects"));
-        Assert.assertTrue(properties.get("objects") instanceof ArraySchema);
+        assertNotNull(properties.get("objects"));
+        assertTrue(properties.get("objects") instanceof ArraySchema);
         model = schemas.get("AbstractObject");
-        Assert.assertNotNull(model);
-        Assert.assertTrue(model instanceof ComposedSchema);
-        Assert.assertTrue(((ComposedSchema)model).getOneOf().size() == 2);
+        assertNotNull(model);
+        assertTrue(model instanceof ComposedSchema);
+        assertEquals(((ComposedSchema) model).getOneOf().size(), 2);
         model = schemas.get("AObject");
-        Assert.assertNotNull(model);
+        assertNotNull(model);
         model = schemas.get("BObject");
-        Assert.assertNotNull(model);
+        assertNotNull(model);
         model = schemas.get("objects");
-        Assert.assertNull(model);
+        assertNull(model);
 
     }
 
@@ -112,31 +116,31 @@ public class ComposedSchemaTest {
     public void readComposedSchema_ticket2616() {
         Map<String, Schema> schemas = ModelConverters.getInstance().readAll(TestObject2616.TestObject2616_Schema.class);
         Schema model = schemas.get("TestObject2616_Schema");
-        Assert.assertNotNull(model);
+        assertNotNull(model);
         Map<String, Schema> properties = model.getProperties();
-        Assert.assertNotNull(properties.get("object"));
-        Assert.assertTrue(properties.get("object").get$ref().equals("#/components/schemas/AbstractObject"));
+        assertNotNull(properties.get("object"));
+        assertEquals(properties.get("object").get$ref(), "#/components/schemas/AbstractObject");
         model = schemas.get("AbstractObject");
-        Assert.assertNotNull(model);
-        Assert.assertTrue(model instanceof ComposedSchema);
-        Assert.assertTrue(((ComposedSchema)model).getOneOf().size() == 2);
+        assertNotNull(model);
+        assertTrue(model instanceof ComposedSchema);
+        assertEquals(((ComposedSchema) model).getOneOf().size(), 2);
         model = schemas.get("AObject");
-        Assert.assertNotNull(model);
+        assertNotNull(model);
         model = schemas.get("BObject");
-        Assert.assertNotNull(model);
+        assertNotNull(model);
         model = schemas.get("objects");
-        Assert.assertNull(model);
+        assertNull(model);
     }
 
     @Test(description = "read composed schem refs #4247")
     public void readComposedSchema_ticket4247() {
         Map<String, Schema> schemas = ModelConverters.getInstance().readAll(TestObjectTicket4247.class);
         Schema model = schemas.get("TestObjectTicket4247");
-        Assert.assertNotNull(model);
+        assertNotNull(model);
         Map<String, Schema> properties = model.getProperties();
-        Assert.assertNotNull(properties.get("value"));
-        Assert.assertTrue(((ComposedSchema)properties.get("value")).getOneOf().size() == 2);
-        Assert.assertEquals(((ComposedSchema)properties.get("value")).getOneOf().get(0).getType(), "string");
-        Assert.assertEquals(((ComposedSchema)properties.get("value")).getOneOf().get(1).getType(), "number");
+        assertNotNull(properties.get("value"));
+        assertEquals(((ComposedSchema) properties.get("value")).getOneOf().size(), 2);
+        assertEquals(((ComposedSchema)properties.get("value")).getOneOf().get(0).getType(), "string");
+        assertEquals(((ComposedSchema)properties.get("value")).getOneOf().get(1).getType(), "number");
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/JsonViewTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/JsonViewTest.java
@@ -8,13 +8,14 @@ import io.swagger.v3.core.converter.ModelConverterContextImpl;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.core.resolving.resources.JsonViewObject;
 import io.swagger.v3.oas.models.media.Schema;
-import org.junit.Test;
-import org.testng.Assert;
+import org.testng.annotations.Test;
 
 import java.lang.annotation.Annotation;
 import java.util.Map;
 
 import static io.swagger.v3.core.resolving.SwaggerTestBase.mapper;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 public class JsonViewTest {
 
@@ -41,11 +42,11 @@ public class JsonViewTest {
                     .getAnnotations()));
 
     Map<String, Schema> properties = model.getProperties();
-    Assert.assertEquals(properties.size(), 4);
-    Assert.assertNotNull(properties.get("id"));
-    Assert.assertNotNull(properties.get("firstName"));
-    Assert.assertNotNull(properties.get("lastName"));
-    Assert.assertNotNull(properties.get("email"));
+    assertEquals(properties.size(), 4);
+    assertNotNull(properties.get("id"));
+    assertNotNull(properties.get("firstName"));
+    assertNotNull(properties.get("lastName"));
+    assertNotNull(properties.get("email"));
   }
 
   @Test
@@ -74,9 +75,9 @@ public class JsonViewTest {
                     .getAnnotations()));
 
     Map<String, Schema> properties = model.getProperties();
-    Assert.assertEquals(properties.size(), 3);
-    Assert.assertNotNull(properties.get("id"));
-    Assert.assertNotNull(properties.get("firstName"));
-    Assert.assertNotNull(properties.get("lastName"));
+    assertEquals(properties.size(), 3);
+    assertNotNull(properties.get("id"));
+    assertNotNull(properties.get("firstName"));
+    assertNotNull(properties.get("lastName"));
   }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket2884Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket2884Test.java
@@ -9,8 +9,10 @@ import io.swagger.v3.core.matchers.SerializationMatchers;
 import io.swagger.v3.core.resolving.resources.Ticket2884Model;
 import io.swagger.v3.core.resolving.resources.Ticket2884ModelClass;
 import io.swagger.v3.oas.models.media.Schema;
-import org.junit.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class Ticket2884Test extends SwaggerTestBase {
 
@@ -53,8 +55,8 @@ public class Ticket2884Test extends SwaggerTestBase {
     public void test2884_null() {
         ResolvedSchema schema = ModelConverters.getInstance().readAllAsResolvedSchema(new AnnotatedType(Ticket2884ModelClass.class).resolveAsRef(true));
         Schema o = (Schema)schema.schema.getProperties().get(Ticket2884ModelClass.class.getSimpleName());
-        Assert.assertNotNull(o);
-        Assert.assertTrue(o.get$ref().contains(Ticket2884ModelClass.class.getSimpleName()));
+        assertNotNull(o);
+        assertTrue(o.get$ref().contains(Ticket2884ModelClass.class.getSimpleName()));
         SerializationMatchers.assertEqualsToYaml(schema.schema.getProperties(), "Ticket2884ModelClass:\n" +
                 "  $ref: \"#/components/schemas/Ticket2884ModelClass\"");
 

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/SecurityDefinitionTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/SecurityDefinitionTest.java
@@ -24,15 +24,13 @@ import io.swagger.v3.oas.models.security.Scopes;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import org.testng.Assert;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
 
 public class SecurityDefinitionTest {
 

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/util/AnnotationsUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/util/AnnotationsUtilsTest.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.Schema;
-import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -20,6 +19,9 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class AnnotationsUtilsTest {
 
@@ -52,9 +54,9 @@ public class AnnotationsUtilsTest {
     public void resolveSchemaFromType(Class<?> aClass, Map<String, Object> expected) {
         Schema schema = AnnotationsUtils.resolveSchemaFromType(aClass, new Components(), null);
 
-        Assert.assertEquals(schema.getType(), expected.get("type"));
-        Assert.assertEquals(schema.getFormat(), expected.get("format"));
-        Assert.assertEquals(schema.get$ref(), expected.get("$ref"));
+       assertEquals(schema.getType(), expected.get("type"));
+       assertEquals(schema.getFormat(), expected.get("format"));
+       assertEquals(schema.get$ref(), expected.get("$ref"));
     }
 
     @DataProvider
@@ -73,10 +75,10 @@ public class AnnotationsUtilsTest {
         Content annotationContent = method.getAnnotation(ApiResponse.class).content()[0];
         Optional<? extends Schema> schema = AnnotationsUtils.getSchema(annotationContent, new Components(), null, false);
 
-        Assert.assertTrue(schema.isPresent());
-        Assert.assertEquals(schema.get().getType(), expected.get("type"));
-        Assert.assertEquals(schema.get().getFormat(), expected.get("format"));
-        Assert.assertEquals(schema.get().get$ref(), expected.get("$ref"));
+       assertTrue(schema.isPresent());
+       assertEquals(schema.get().getType(), expected.get("type"));
+       assertEquals(schema.get().getFormat(), expected.get("format"));
+       assertEquals(schema.get().get$ref(), expected.get("$ref"));
     }
 
     @ApiResponse(content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Byte.class)))

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/util/ReferenceTypeUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/util/ReferenceTypeUtilsTest.java
@@ -3,14 +3,14 @@ package io.swagger.v3.core.util;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.swagger.v3.core.converter.AnnotatedType;
-import org.checkerframework.checker.units.qual.A;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Unit test cases for {@link ReferenceTypeUtils}
@@ -25,7 +25,7 @@ public class ReferenceTypeUtilsTest {
 
         final boolean actualIsReferenceType = ReferenceTypeUtils._isReferenceType(atomicReferenceType);
 
-        Assert.assertEquals(actualIsReferenceType, true, rawType.getCanonicalName() + " should be reference type but was not.");
+        assertTrue(actualIsReferenceType, rawType.getCanonicalName() + " should be reference type but was not.");
     }
 
     @Test(description = "AtomicReference JavaType should be unwrapped")
@@ -37,7 +37,7 @@ public class ReferenceTypeUtilsTest {
 
         final AnnotatedType actualUnwrappedType = ReferenceTypeUtils.unwrapReference(new AnnotatedType(atomicReferenceType));
 
-        Assert.assertEquals(actualUnwrappedType.getType(), expectedReferredType, rawType.getCanonicalName() + "Reference type not correctly unwrapped");
+       assertEquals(actualUnwrappedType.getType(), expectedReferredType, rawType.getCanonicalName() + "Reference type not correctly unwrapped");
     }
 
     @Test(description = "AtomicReference should be unwrapped when read from Java bean")
@@ -47,7 +47,7 @@ public class ReferenceTypeUtilsTest {
         final Type genericType = TypeWithAtomicReferenceMember.class.getDeclaredField("member").getGenericType();
         final AnnotatedType actualUnwrappedType = ReferenceTypeUtils.unwrapReference(new AnnotatedType(genericType));
 
-        Assert.assertEquals(actualUnwrappedType.getType(), expectedReferredType, genericType.getTypeName() + "Reference type not correctly unwrapped");
+       assertEquals(actualUnwrappedType.getType(), expectedReferredType, genericType.getTypeName() + "Reference type not correctly unwrapped");
     }
 
     @SuppressWarnings("unused")

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/util/reflection/ReflectionUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/util/reflection/ReflectionUtilsTest.java
@@ -8,7 +8,6 @@ import io.swagger.v3.core.util.reflection.resources.Parent;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.Path;
@@ -25,18 +24,23 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import static java.lang.annotation.ElementType.PARAMETER;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class ReflectionUtilsTest {
 
     @Test
     public void typeFromStringTest() {
-        Assert.assertEquals(ReflectionUtils.typeFromString("int"), (Type) Integer.class);
-        Assert.assertEquals(ReflectionUtils.typeFromString("java.lang.String"), (Type) String.class);
-        Assert.assertNull(ReflectionUtils.typeFromString("FakeType"));
-        Assert.assertNull(ReflectionUtils.typeFromString(null));
+        assertEquals(ReflectionUtils.typeFromString("int"), (Type) Integer.class);
+        assertEquals(ReflectionUtils.typeFromString("java.lang.String"), (Type) String.class);
+        assertNull(ReflectionUtils.typeFromString("FakeType"));
+        assertNull(ReflectionUtils.typeFromString(null));
     }
 
     @Test
@@ -46,28 +50,28 @@ public class ReflectionUtilsTest {
                 final boolean result = ReflectionUtils.isOverriddenMethod(method, Child.class);
                 final Class<?> first = method.getParameterTypes()[0];
                 if (Number.class.equals(first)) {
-                    Assert.assertTrue(result);
+                    assertTrue(result);
                 } else if (Integer.class.equals(first)) {
-                    Assert.assertFalse(result);
+                    assertFalse(result);
                 }
             } else if ("parametrizedMethod3".equals(method.getName())) {
-                Assert.assertFalse(ReflectionUtils.isOverriddenMethod(method, Child.class));
+                assertFalse(ReflectionUtils.isOverriddenMethod(method, Child.class));
             }
         }
 
         for (Method method : Object.class.getMethods()) {
             if ("equals".equals(method.getName())) {
-                Assert.assertFalse(ReflectionUtils.isOverriddenMethod(method, Object.class));
+                assertFalse(ReflectionUtils.isOverriddenMethod(method, Object.class));
             }
         }
 
         for (Method method : IParent.class.getMethods()) {
             if ("parametrizedMethod5".equals(method.getName())) {
-                Assert.assertFalse(ReflectionUtils.isOverriddenMethod(method, IParent.class));
+                assertFalse(ReflectionUtils.isOverriddenMethod(method, IParent.class));
             } else if ("parametrizedMethod2".equals(method.getName())) {
-                Assert.assertFalse(ReflectionUtils.isOverriddenMethod(method, IParent.class));
+                assertFalse(ReflectionUtils.isOverriddenMethod(method, IParent.class));
             } else {
-                Assert.fail("Method not expected");
+                fail("Method not expected");
             }
         }
     }
@@ -76,81 +80,81 @@ public class ReflectionUtilsTest {
     public void getOverriddenMethodTest() throws NoSuchMethodException {
         final Method method1 = ReflectionUtils.getOverriddenMethod(
                 Child.class.getMethod("parametrizedMethod1", Integer.class));
-        Assert.assertNotNull(method1);
-        Assert.assertEquals(method1.getParameterTypes()[0], Number.class);
+        assertNotNull(method1);
+        assertEquals(method1.getParameterTypes()[0], Number.class);
 
         final Method method2 = ReflectionUtils.getOverriddenMethod(
                 Child.class.getMethod("parametrizedMethod2", Long.class));
-        Assert.assertNotNull(method2);
-        Assert.assertEquals(method2.getParameterTypes()[0], Number.class);
+        assertNotNull(method2);
+        assertEquals(method2.getParameterTypes()[0], Number.class);
 
         final Method method3 = ReflectionUtils.getOverriddenMethod(
                 Child.class.getMethod("parametrizedMethod3", Long.class));
-        Assert.assertNull(method3);
+        assertNull(method3);
 
-        Assert.assertNull(ReflectionUtils.getOverriddenMethod(Object.class.getMethod("equals", Object.class)));
+        assertNull(ReflectionUtils.getOverriddenMethod(Object.class.getMethod("equals", Object.class)));
     }
 
     @Test
     public void findMethodTest() throws NoSuchMethodException {
         final Method methodToFind1 = Child.class.getMethod("parametrizedMethod1", Integer.class);
         final Method method1 = ReflectionUtils.findMethod(methodToFind1, Parent.class);
-        Assert.assertNotNull(method1);
-        Assert.assertEquals(method1.getParameterTypes()[0], Number.class);
+        assertNotNull(method1);
+        assertEquals(method1.getParameterTypes()[0], Number.class);
 
         final Method methodToFind2 = Child.class.getMethod("parametrizedMethod4", Long.class);
         final Method method2 = ReflectionUtils.findMethod(methodToFind2, Parent.class);
-        Assert.assertNull(method2);
+        assertNull(method2);
     }
 
     @Test
     public void isInjectTest() throws NoSuchMethodException {
         final Method injectableMethod = Child.class.getMethod("injectableMethod");
-        Assert.assertTrue(ReflectionUtils.isInject(Arrays.asList(injectableMethod.getDeclaredAnnotations())));
+        assertTrue(ReflectionUtils.isInject(Arrays.asList(injectableMethod.getDeclaredAnnotations())));
 
         final Method methodToFind = Child.class.getMethod("parametrizedMethod1", Integer.class);
-        Assert.assertFalse(ReflectionUtils.isInject(Arrays.asList(methodToFind.getDeclaredAnnotations())));
+        assertFalse(ReflectionUtils.isInject(Arrays.asList(methodToFind.getDeclaredAnnotations())));
     }
 
     @Test
     public void isConstructorCompatibleTest() throws NoSuchMethodException {
-        Assert.assertFalse(ReflectionUtils.isConstructorCompatible(Child.class.getDeclaredConstructor()));
-        Assert.assertTrue(ReflectionUtils.isConstructorCompatible(Child.class.getDeclaredConstructor(String.class)));
+        assertFalse(ReflectionUtils.isConstructorCompatible(Child.class.getDeclaredConstructor()));
+        assertTrue(ReflectionUtils.isConstructorCompatible(Child.class.getDeclaredConstructor(String.class)));
     }
 
     @Test
     public void getAnnotationTest() throws NoSuchMethodException {
         final Method method = Child.class.getMethod("annotationHolder");
-        Assert.assertNotNull(ReflectionUtils.getAnnotation(method, Schema.class));
-        Assert.assertNull(ReflectionUtils.getAnnotation(method, ApiResponse.class));
+        assertNotNull(ReflectionUtils.getAnnotation(method, Schema.class));
+        assertNull(ReflectionUtils.getAnnotation(method, ApiResponse.class));
     }
 
     @Test
     public void isVoidTest() {
-        Assert.assertTrue(ReflectionUtils.isVoid(Void.class));
-        Assert.assertTrue(ReflectionUtils.isVoid(Void.TYPE));
-        Assert.assertFalse(ReflectionUtils.isVoid(String.class));
+        assertTrue(ReflectionUtils.isVoid(Void.class));
+        assertTrue(ReflectionUtils.isVoid(Void.TYPE));
+        assertFalse(ReflectionUtils.isVoid(String.class));
     }
 
     @Test
     public void testDerivedAnnotation() {
         final Path annotation = ReflectionUtils.getAnnotation(Child.class, javax.ws.rs.Path.class);
-        Assert.assertNotNull(annotation);
-        Assert.assertEquals(annotation.value(), "parentInterfacePath");
+        assertNotNull(annotation);
+        assertEquals(annotation.value(), "parentInterfacePath");
     }
 
     @Test
     public void getDeclaredFieldsFromInterfaceTest() throws NoSuchMethodException {
         final Class cls = IParent.class;
-        Assert.assertEquals(Collections.emptyList(), ReflectionUtils.getDeclaredFields(cls));
+        assertEquals(Collections.emptyList(), ReflectionUtils.getDeclaredFields(cls));
     }
 
     @Test
     public void declaredFieldsShouldBeSorted() {
         final Class cls = ObjectWithManyFields.class;
         final List<Field> declaredFields = ReflectionUtils.getDeclaredFields(cls);
-        Assert.assertEquals(4, declaredFields.size());
-        Assert.assertEquals(Arrays.asList("a", "b", "c", "d"), declaredFields.stream().map(Field::getName).collect(Collectors.toList()));
+        assertEquals(declaredFields.size(), 4);
+        assertEquals(Arrays.asList("a", "b", "c", "d"), declaredFields.stream().map(Field::getName).collect(Collectors.toList()));
     }
 
     @Test
@@ -162,30 +166,30 @@ public class ReflectionUtilsTest {
     @Test
     public void getRepeatableAnnotationsArrayTest() {
         Tag[] annotations = ReflectionUtils.getRepeatableAnnotationsArray(InheritingClass.class, Tag.class);
-        Assert.assertNotNull(annotations);
-        Assert.assertTrue(annotations.length == 1);
-        Assert.assertNotNull(annotations[0]);
-        Assert.assertEquals("inherited tag", annotations[0].name());
+        assertNotNull(annotations);
+        assertEquals(annotations.length, 1);
+        assertNotNull(annotations[0]);
+        assertEquals(annotations[0].name(), "inherited tag");
     }
 
     @Test
     public void getParameterAnnotationsTest() throws NoSuchMethodException {
         Method method = SecondLevelSubClass.class.getMethod("method", String.class);
         Annotation[][] parameterAnnotations = ReflectionUtils.getParameterAnnotations(method);
-        Assert.assertEquals(1, parameterAnnotations.length);
-        Assert.assertEquals(1, parameterAnnotations[0].length);
-        Assert.assertTrue(parameterAnnotations[0][0] instanceof AnnotationInterface);
-        Assert.assertEquals("level1", ((AnnotationInterface)parameterAnnotations[0][0]).value());
+        assertEquals(parameterAnnotations.length, 1);
+        assertEquals(parameterAnnotations[0].length, 1);
+        assertTrue(parameterAnnotations[0][0] instanceof AnnotationInterface);
+        assertEquals(((AnnotationInterface)parameterAnnotations[0][0]).value(), "level1");
     }
 
     @Test
     public void getParameterAnnotationsForOverriddenAnnotationTest() throws NoSuchMethodException {
         Method method = ThirdLevelSubClass.class.getMethod("method", String.class);
         Annotation[][] parameterAnnotations = ReflectionUtils.getParameterAnnotations(method);
-        Assert.assertEquals(1, parameterAnnotations.length);
-        Assert.assertEquals(1, parameterAnnotations[0].length);
-        Assert.assertTrue(parameterAnnotations[0][0] instanceof AnnotationInterface);
-        Assert.assertEquals("level4", ((AnnotationInterface)parameterAnnotations[0][0]).value());
+        assertEquals(parameterAnnotations.length, 1);
+        assertEquals(parameterAnnotations[0].length, 1);
+        assertTrue(parameterAnnotations[0][0] instanceof AnnotationInterface);
+        assertEquals(((AnnotationInterface)parameterAnnotations[0][0]).value(), "level4");
     }
 
     @Tag(name = "inherited tag")

--- a/modules/swagger-eclipse-transformer-maven-plugin/pom.xml
+++ b/modules/swagger-eclipse-transformer-maven-plugin/pom.xml
@@ -17,8 +17,6 @@
         <eclipse.transformer.version>0.20</eclipse.transformer.version>
         <maven-test-harness.version>3.3.0</maven-test-harness.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
-        <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <junit-platform.version>1.7.0</junit-platform.version>
         <assertj.version>3.18.1</assertj.version>
     </properties>
     <build>

--- a/modules/swagger-gradle-plugin/build.gradle
+++ b/modules/swagger-gradle-plugin/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation 'com.google.guava:guava:32.1.3-jre'
     testImplementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
     testImplementation "io.swagger.core.v3:swagger-jaxrs2:${project.version}"
-    testImplementation 'junit:junit:4+'
+    testImplementation 'org.testng:testng:7.10.2'
     testImplementation "org.eclipse.jetty:jetty-server:${project.jettyVersion}"
     testImplementation "org.eclipse.jetty:jetty-servlet:${project.jettyVersion}"
     testImplementation "org.eclipse.jetty:jetty-servlets:${project.jettyVersion}"
@@ -99,6 +99,10 @@ pluginBundle {
             id          = project.pluginId
         }
     }
+}
+
+test {
+    useTestNG()
 }
 
 publishing {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/BeanParamTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/BeanParamTest.java
@@ -6,7 +6,6 @@ import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import io.swagger.v3.jaxrs2.resources.model.ListOfStringsBeanParam;
@@ -14,6 +13,8 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+
+import static org.testng.Assert.assertEquals;
 
 public class BeanParamTest {
 
@@ -29,13 +30,13 @@ public class BeanParamTest {
     public void shouldSerializeTypeParameter() {
         OpenAPI openApi = new Reader(new OpenAPI()).read(MyBeanParamResource.class);
         List<Parameter> getOperationParams = openApi.getPaths().get("/").getGet().getParameters();
-        Assert.assertEquals(getOperationParams.size(), 1);
+        assertEquals(getOperationParams.size(), 1);
         Parameter param = getOperationParams.get(0);
-        Assert.assertEquals(param.getName(), "listOfStrings");
+        assertEquals(param.getName(), "listOfStrings");
         Schema<?> schema = param.getSchema();
         // These are the important checks:
-        Assert.assertEquals(schema.getClass(), ArraySchema.class);
-        Assert.assertEquals(((ArraySchema) schema).getItems().getType(), "string");   
+        assertEquals(schema.getClass(), ArraySchema.class);
+        assertEquals(schema.getItems().getType(), "string");
     }
 
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/DecoratorExtensionTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/DecoratorExtensionTest.java
@@ -7,13 +7,16 @@ import io.swagger.v3.jaxrs2.resources.SimpleResourceWithVendorAnnotation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.responses.ApiResponse;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 import java.util.Iterator;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 public class DecoratorExtensionTest {
 
@@ -65,15 +68,15 @@ public class DecoratorExtensionTest {
     public void scanSimpleResourceWithDecorator() {
         final OpenAPI openAPI = getOpenAPI(SimpleResourceWithVendorAnnotation.class);
 
-        Assert.assertEquals(openAPI.getPaths().size(), 2);
+        assertEquals(openAPI.getPaths().size(), 2);
 
         final Operation get = getGet(openAPI, "/{id}");
-        Assert.assertNotNull(get);
-        Assert.assertEquals(get.getParameters().size(), 2);
+        assertNotNull(get);
+        assertEquals(get.getParameters().size(), 2);
 
         final ApiResponse response = get.getResponses().get(RESPONSE_STATUS_401);
-        Assert.assertNotNull(response);
-        Assert.assertEquals(response.getDescription(), RESPONSE_DESCRIPTION);
+        assertNotNull(response);
+        assertEquals(response.getDescription(), RESPONSE_DESCRIPTION);
     }
 
     /**
@@ -83,12 +86,12 @@ public class DecoratorExtensionTest {
     public void scanSimpleResourceWithoutDecorator() {
         final OpenAPI openAPI = getOpenAPI(SimpleResourceWithVendorAnnotation.class);
 
-        Assert.assertEquals(openAPI.getPaths().size(), 2);
+        assertEquals(openAPI.getPaths().size(), 2);
 
         final Operation get = getGet(openAPI, "/{id}/value");
-        Assert.assertNotNull(get);
+        assertNotNull(get);
 
         final ApiResponse response = get.getResponses().get(RESPONSE_STATUS_401);
-        Assert.assertNull(response);
+        assertNull(response);
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/FormParamBeanTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/FormParamBeanTest.java
@@ -5,10 +5,12 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.RequestBody;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.*;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 public class FormParamBeanTest {
 
@@ -49,13 +51,13 @@ public class FormParamBeanTest {
     public void shouldSerializeTypeParameter() {
         OpenAPI openApi = new Reader(new OpenAPI()).read(MyFormBeanParamResource.class);
         RequestBody requestBody = openApi.getPaths().get("/").getGet().getRequestBody();
-        Assert.assertNotNull(requestBody);
+        assertNotNull(requestBody);
         MediaType mediaType = requestBody.getContent().get("application/x-www-form-urlencoded");
-        Assert.assertNotNull(mediaType);
+        assertNotNull(mediaType);
         Schema schema = mediaType.getSchema();
-        Assert.assertEquals(schema.getProperties().size(), 2);
-        Assert.assertEquals(schema.getProperties().get("param1"), new StringSchema());
-        Assert.assertEquals(schema.getProperties().get("param2"), new StringSchema());
+        assertEquals(schema.getProperties().size(), 2);
+        assertEquals(schema.getProperties().get("param1"), new StringSchema());
+        assertEquals(schema.getProperties().get("param2"), new StringSchema());
     }
 
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/JsonViewTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/JsonViewTest.java
@@ -12,8 +12,6 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.MediaType;
 
-import org.testng.Assert;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -28,6 +26,9 @@ import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class JsonViewTest {
 
@@ -162,12 +163,12 @@ public class JsonViewTest {
 
         OpenAPI openAPI = reader.read(CarSummaryApi.class);
         String openApiJson = Json.mapper().writeValueAsString(openAPI);
-        Assert.assertTrue(openApiJson.contains("manufacture"));
-        Assert.assertTrue(openApiJson.contains("model"));
-        Assert.assertTrue(openApiJson.contains("color"));
-        Assert.assertFalse(openApiJson.contains("tires"));
-        Assert.assertFalse(openApiJson.contains("made"));
-        Assert.assertFalse(openApiJson.contains("condition"));
+        assertTrue(openApiJson.contains("manufacture"));
+        assertTrue(openApiJson.contains("model"));
+        assertTrue(openApiJson.contains("color"));
+        assertFalse(openApiJson.contains("tires"));
+        assertFalse(openApiJson.contains("made"));
+        assertFalse(openApiJson.contains("condition"));
 
         reader = new Reader(new OpenAPI());
         openAPI = reader.read(CarSummaryUpdateApi.class);
@@ -190,59 +191,59 @@ public class JsonViewTest {
             .orElse(new MediaType())
             .getSchema()
             .get$ref();
-        Assert.assertTrue(carSummarySchemaProperties.contains("manufacture"));
-        Assert.assertTrue(carSummarySchemaProperties.contains("model"));
-        Assert.assertTrue(carSummarySchemaProperties.contains("color"));
-        Assert.assertFalse(carSummarySchemaProperties.contains("price"));
-        Assert.assertFalse(carSummarySchemaProperties.contains("tires"));
-        Assert.assertFalse(carSummarySchemaProperties.contains("made"));
-        Assert.assertFalse(carSummarySchemaProperties.contains("condition"));
-        Assert.assertTrue(carSummaryUpdateApiRequestBodySchemaRef.contains("Car_Summary"));
+        assertTrue(carSummarySchemaProperties.contains("manufacture"));
+        assertTrue(carSummarySchemaProperties.contains("model"));
+        assertTrue(carSummarySchemaProperties.contains("color"));
+        assertFalse(carSummarySchemaProperties.contains("price"));
+        assertFalse(carSummarySchemaProperties.contains("tires"));
+        assertFalse(carSummarySchemaProperties.contains("made"));
+        assertFalse(carSummarySchemaProperties.contains("condition"));
+        assertTrue(carSummaryUpdateApiRequestBodySchemaRef.contains("Car_Summary"));
 
         reader = new Reader(new OpenAPI());
         openAPI = reader.read(CarDetailApi.class);
         openApiJson = Json.mapper().writeValueAsString(openAPI);
-        Assert.assertTrue(openApiJson.contains("manufacture"));
-        Assert.assertTrue(openApiJson.contains("model"));
-        Assert.assertTrue(openApiJson.contains("color"));
-        Assert.assertTrue(openApiJson.contains("tires"));
-        Assert.assertTrue(openApiJson.contains("brand"));
-        Assert.assertTrue(openApiJson.contains("condition"));
-        Assert.assertTrue(openApiJson.contains("Car_Detail"));
+        assertTrue(openApiJson.contains("manufacture"));
+        assertTrue(openApiJson.contains("model"));
+        assertTrue(openApiJson.contains("color"));
+        assertTrue(openApiJson.contains("tires"));
+        assertTrue(openApiJson.contains("brand"));
+        assertTrue(openApiJson.contains("condition"));
+        assertTrue(openApiJson.contains("Car_Detail"));
 
         reader = new Reader(new OpenAPI());
         openAPI = reader.read(CarSaleSummaryApi.class);
         openApiJson = Json.mapper().writeValueAsString(openAPI);
         Yaml.prettyPrint(openAPI);
-        Assert.assertTrue(openApiJson.contains("manufacture"));
-        Assert.assertTrue(openApiJson.contains("model"));
-        Assert.assertTrue(openApiJson.contains("color"));
-        Assert.assertTrue(openApiJson.contains("price"));
-        Assert.assertFalse(openApiJson.contains("tires"));
-        Assert.assertFalse(openApiJson.contains("made"));
-        Assert.assertFalse(openApiJson.contains("condition"));
+        assertTrue(openApiJson.contains("manufacture"));
+        assertTrue(openApiJson.contains("model"));
+        assertTrue(openApiJson.contains("color"));
+        assertTrue(openApiJson.contains("price"));
+        assertFalse(openApiJson.contains("tires"));
+        assertFalse(openApiJson.contains("made"));
+        assertFalse(openApiJson.contains("condition"));
 
         reader = new Reader(new OpenAPI());
         openAPI = reader.read(CarApi.class);
         openApiJson = Json.mapper().writeValueAsString(openAPI);
-        Assert.assertTrue(openApiJson.contains("manufacture"));
-        Assert.assertTrue(openApiJson.contains("model"));
-        Assert.assertTrue(openApiJson.contains("color"));
-        Assert.assertTrue(openApiJson.contains("price"));
-        Assert.assertTrue(openApiJson.contains("tires"));
-        Assert.assertFalse(openApiJson.contains("made"));
-        Assert.assertTrue(openApiJson.contains("condition"));
+        assertTrue(openApiJson.contains("manufacture"));
+        assertTrue(openApiJson.contains("model"));
+        assertTrue(openApiJson.contains("color"));
+        assertTrue(openApiJson.contains("price"));
+        assertTrue(openApiJson.contains("tires"));
+        assertFalse(openApiJson.contains("made"));
+        assertTrue(openApiJson.contains("condition"));
 
         reader = new Reader(new OpenAPI());
         openAPI = reader.read(CarIgnoreApi.class);
         openApiJson = Json.mapper().writeValueAsString(openAPI);
-        Assert.assertTrue(openApiJson.contains("manufacture"));
-        Assert.assertTrue(openApiJson.contains("model"));
-        Assert.assertTrue(openApiJson.contains("color"));
-        Assert.assertTrue(openApiJson.contains("price"));
-        Assert.assertTrue(openApiJson.contains("tires"));
-        Assert.assertFalse(openApiJson.contains("made"));
-        Assert.assertTrue(openApiJson.contains("condition"));
+        assertTrue(openApiJson.contains("manufacture"));
+        assertTrue(openApiJson.contains("model"));
+        assertTrue(openApiJson.contains("color"));
+        assertTrue(openApiJson.contains("price"));
+        assertTrue(openApiJson.contains("tires"));
+        assertFalse(openApiJson.contains("made"));
+        assertTrue(openApiJson.contains("condition"));
     }
 
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/OpenApiResourceIT.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/it/OpenApiResourceIT.java
@@ -6,7 +6,6 @@ import io.restassured.http.ContentType;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.jaxrs2.annotations.AbstractAnnotationTest;
-import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -14,6 +13,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 
 import static io.restassured.RestAssured.given;
+import static org.testng.Assert.assertTrue;
 
 /**
  * <p>
@@ -664,7 +664,7 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
                 .contentType("application/yaml")
                 .extract().response().body().asString();
 
-        Assert.assertTrue(actualBody.contains("openapi: 3.1.0"));
+        assertTrue(actualBody.contains("openapi: 3.1.0"));
     }
 
     @Test
@@ -681,7 +681,7 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
                 .contentType("application/yaml")
                 .extract().response().body().asString();
 
-        Assert.assertTrue(actualBody.contains("openapi: 3.1.0"));
+        assertTrue(actualBody.contains("openapi: 3.1.0"));
     }
 
     @Test
@@ -696,7 +696,7 @@ public class OpenApiResourceIT extends AbstractAnnotationTest {
                 .assertThat()
                 .statusCode(200)
                 .extract().response().body().asString();
-        Assert.assertTrue(actualBody.contains("openapi: 3.1.0"));
+        assertTrue(actualBody.contains("openapi: 3.1.0"));
     }
 
     private String formatYaml(String source) throws IOException {

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/util/ServletUtilsTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/util/ServletUtilsTest.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.jaxrs2.util;
 
-import org.hamcrest.collection.IsMapContaining;
 import org.testng.annotations.Test;
 
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -10,8 +9,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 public class ServletUtilsTest {
 
@@ -35,11 +34,11 @@ public class ServletUtilsTest {
         Map<String, String[]> params = new HashMap<>();
         params.put(URLEncoder.encode("key1&", UTF_8.name()), new String[]{"value1", URLEncoder.encode("value2?", UTF_8.name())});
         params.put("key2", new String[]{URLEncoder.encode("value2", UTF_8.name()), "value3", "value4", "value4"});
-        assertThat(params, IsMapContaining.hasEntry("key1%26", new String[]{"value1", "value2%3F"}));
+        assertEquals(params.get("key1%26"), new String[]{"value1", "value2%3F"});
 
         MultivaluedHashMap<String, String> multivaluedHashMap = ServletUtils.getQueryParams(params);
         assertEquals(multivaluedHashMap.size(), 2);
-        assertThat(multivaluedHashMap, IsMapContaining.hasKey("key1&"));
+        assertNotNull(multivaluedHashMap.get("key1&"));
         assertEquals(multivaluedHashMap.get("key1&").size(), 2);
         assertEquals(multivaluedHashMap.get("key1&"), Arrays.asList("value1", "value2?"));
         assertEquals(multivaluedHashMap.get("key2"), Arrays.asList("value2", "value3", "value4", "value4"));

--- a/modules/swagger-models/src/test/java/io/swagger/test/SchemaTests.java
+++ b/modules/swagger-models/src/test/java/io/swagger/test/SchemaTests.java
@@ -3,12 +3,13 @@ package io.swagger.test;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.testng.Assert.fail;
 
 public class SchemaTests {
 
@@ -48,9 +49,9 @@ public class SchemaTests {
                     .minimum(new BigDecimal(6))
                     .additionalProperties("ok")
             );
-            Assert.fail("Should have thrown an exception");
+            fail("Should have thrown an exception");
         }catch (Exception exception){
-            
+
         }
     }
 }

--- a/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/PathsTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/PathsTest.java
@@ -2,25 +2,28 @@ package io.swagger.v3.oas.models;
 
 import java.util.HashMap;
 
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
 
 public class PathsTest {
 
     @Test
     public void testAddPathItem() {
         Paths paths = new Paths();
-        Assert.assertEquals(paths.addPathItem("foo", null), paths);
+        assertEquals(paths.addPathItem("foo", null), paths);
     }
 
     @Test
     public void testEquals() {
         Paths paths = new Paths();
-        Assert.assertTrue(paths.equals(paths));
-        Assert.assertTrue(paths.equals(new Paths()));
+        assertEquals(paths, paths);
+        assertEquals(paths, new Paths());
 
-        Assert.assertFalse(paths.equals(null));
-        Assert.assertFalse(paths.equals(new String()));
+        assertNotEquals(paths, null);
+        assertNotEquals(paths, new String());
     }
 
     @Test
@@ -30,7 +33,7 @@ public class PathsTest {
         paths.addExtension("y-", null);
         paths.addExtension(null, null);
 
-        Assert.assertNull(paths.getExtensions());
+        assertNull(paths.getExtensions());
     }
 
     @Test
@@ -40,7 +43,7 @@ public class PathsTest {
         paths.addExtension("x-", "bar");
         paths.addExtension("x-", "baz");
 
-        Assert.assertEquals(paths.getExtensions(),
+        assertEquals(paths.getExtensions(),
                 new HashMap<String, Object>() {{
                     put("x-", "baz");
                 }});
@@ -55,7 +58,7 @@ public class PathsTest {
         hashMap.put("x-", "baz");
         paths.setExtensions(hashMap);
 
-        Assert.assertEquals(paths.getExtensions(),
+        assertEquals(paths.getExtensions(),
                 new HashMap<String, Object>() {{
                     put("x-", "baz");
                 }});
@@ -69,14 +72,14 @@ public class PathsTest {
         hashMap.put("x-", "bar");
         hashMap.put("x-", "baz");
 
-        Assert.assertEquals(paths.extensions(hashMap), paths);
+        assertEquals(paths.extensions(hashMap), paths);
     }
 
     @Test
     public void testToString() {
         Paths paths = new Paths();
         paths.addPathItem("foo", null);
-        Assert.assertEquals(paths.toString(),
+        assertEquals(paths.toString(),
                 "class Paths {\n    {foo=null}\n}");
     }
 }

--- a/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/links/LinkParameterTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/links/LinkParameterTest.java
@@ -2,8 +2,11 @@ package io.swagger.v3.oas.models.links;
 
 import java.util.HashMap;
 
-import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
 
 public class LinkParameterTest {
 
@@ -14,18 +17,18 @@ public class LinkParameterTest {
         linkParameter.setValue("bar");
         linkParameter.setValue("baz");
 
-        Assert.assertEquals(linkParameter.value("bar"), linkParameter);
-        Assert.assertEquals(linkParameter.getValue(), "bar");
+        assertEquals(linkParameter.value("bar"), linkParameter);
+        assertEquals(linkParameter.getValue(), "bar");
     }
 
     @Test
     public void testEquals() {
         LinkParameter linkParameter = new LinkParameter();
-        Assert.assertFalse(linkParameter.equals(null));
-        Assert.assertFalse(linkParameter.equals(new String()));
+        assertNotEquals(linkParameter, null);
+        assertNotEquals(linkParameter, new String());
 
-        Assert.assertTrue(linkParameter.equals(linkParameter));
-        Assert.assertTrue(linkParameter.equals(new LinkParameter()));
+        assertEquals(linkParameter, linkParameter);
+        assertEquals(linkParameter, new LinkParameter());
     }
 
     @Test
@@ -35,7 +38,7 @@ public class LinkParameterTest {
         linkParameter.addExtension("y-", null);
         linkParameter.addExtension(null, null);
 
-        Assert.assertNull(linkParameter.getExtensions());
+        assertNull(linkParameter.getExtensions());
     }
 
     @Test
@@ -45,7 +48,7 @@ public class LinkParameterTest {
         linkParameter.addExtension("x-", "bar");
         linkParameter.addExtension("x-", "baz");
 
-        Assert.assertEquals(linkParameter.getExtensions(),
+        assertEquals(linkParameter.getExtensions(),
                 new HashMap<String, Object>() {{
                     put("x-", "baz");
                 }});
@@ -60,7 +63,7 @@ public class LinkParameterTest {
         hashMap.put("x-", "baz");
         linkParameter.setExtensions(hashMap);
 
-        Assert.assertEquals(linkParameter.getExtensions(),
+        assertEquals(linkParameter.getExtensions(),
                 new HashMap<String, Object>() {{
                     put("x-", "baz");
                 }});
@@ -74,14 +77,14 @@ public class LinkParameterTest {
         hashMap.put("x-", "bar");
         hashMap.put("x-", "baz");
 
-        Assert.assertEquals(linkParameter.extensions(hashMap), linkParameter);
+        assertEquals(linkParameter.extensions(hashMap), linkParameter);
     }
 
     @Test
     public void testToString() {
         LinkParameter linkParameter = new LinkParameter();
         linkParameter.setValue("foo");
-        Assert.assertEquals(linkParameter.toString(),
+        assertEquals(linkParameter.toString(),
                 "class LinkParameter {\n}");
     }
 }

--- a/modules/swagger-project-jakarta/pom.xml
+++ b/modules/swagger-project-jakarta/pom.xml
@@ -484,7 +484,6 @@
         <bnd-version>6.4.0</bnd-version>
         <servlet-api-version>5.0.0</servlet-api-version>
         <jersey2-version>3.1.10</jersey2-version>
-        <junit-version>4.13.2</junit-version>
         <jackson-version>2.18.2</jackson-version>
         <jackson-databind-version>2.18.2</jackson-databind-version>
         <logback-version>1.5.16</logback-version>

--- a/pom.xml
+++ b/pom.xml
@@ -611,12 +611,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit-version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.ant</groupId>
                 <artifactId>ant</artifactId>
                 <version>${ant-version}</version>
@@ -647,7 +641,6 @@
         <bnd-version>6.4.0</bnd-version>
         <servlet-api-version>4.0.4</servlet-api-version>
         <jersey2-version>2.46</jersey2-version>
-        <junit-version>4.13.2</junit-version>
         <jackson-version>2.18.2</jackson-version>
         <jackson-databind-version>2.18.2</jackson-databind-version>
         <logback-version>1.5.16</logback-version>


### PR DESCRIPTION
This PR aims to _remove_ usage of JUnit and consistently use TestNG across the modules instead.

Changes include:

* Use TestNG annotations over JUnit counterparts
* Use TestNG assertions over JUnit counterparts (also simplify some assertions in the process)
* Consistently use static imports for TestNG assertions
* Remove JUnit depencency if not required
* Add TestNG dependency if required

There is one exception in `swagger-maven-plugin` where JUnit is still required by the underlying maven test suite and thus tests can not be migrated.