### PR TITLE
Fix for model resolution of the global path parameter with openapi 3.1

### DIFF
--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -287,8 +287,9 @@ public class Reader implements OpenApiReader {
         Hidden hidden = cls.getAnnotation(Hidden.class);
         // class path
         final javax.ws.rs.Path apiPath = ReflectionUtils.getAnnotation(cls, javax.ws.rs.Path.class);
+        final boolean openapi31 = Boolean.TRUE.equals(config.isOpenAPI31());
 
-        if (Boolean.TRUE.equals(config.isOpenAPI31())) {
+        if (openapi31) {
             openAPI.setOpenapi("3.1.0");
         }
 
@@ -342,7 +343,7 @@ public class Reader implements OpenApiReader {
             // OpenApiDefinition extensions
             if (openAPIDefinition.extensions().length > 0) {
                 openAPI.setExtensions(AnnotationsUtils
-                        .getExtensions(config.isOpenAPI31(), openAPIDefinition.extensions()));
+                        .getExtensions(openapi31, openAPIDefinition.extensions()));
             }
 
         }
@@ -407,7 +408,7 @@ public class Reader implements OpenApiReader {
 
         JavaType classType = TypeFactory.defaultInstance().constructType(cls);
         BeanDescription bd;
-        if (Boolean.TRUE.equals(config.isOpenAPI31())) {
+        if (openapi31) {
             bd = Json31.mapper().getSerializationConfig().introspect(classType);
         } else {
             bd = Json.mapper().getSerializationConfig().introspect(classType);
@@ -416,7 +417,7 @@ public class Reader implements OpenApiReader {
         final List<Parameter> globalParameters = new ArrayList<>();
 
         // look for constructor-level annotated properties
-        globalParameters.addAll(ReaderUtils.collectConstructorParameters(cls, components, classConsumes, null, config.getSchemaResolution()));
+        globalParameters.addAll(ReaderUtils.collectConstructorParameters(cls, components, classConsumes, null, config.getSchemaResolution(), openapi31));
 
         // look for field-level annotated properties
         globalParameters.addAll(ReaderUtils.collectFieldParameters(cls, components, classConsumes, null));

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/util/ReaderUtils.java
@@ -36,9 +36,6 @@ public class ReaderUtils {
     private static final String OPTIONS_METHOD = "options";
     private static final String PATH_DELIMITER = "/";
 
-    public static List<Parameter> collectConstructorParameters(Class<?> cls, Components components, javax.ws.rs.Consumes classConsumes, JsonView jsonViewAnnotation) {
-        return collectConstructorParameters(cls, components, classConsumes, jsonViewAnnotation, null);
-    }
     /**
      * Collects constructor-level parameters from class.
      *
@@ -46,7 +43,7 @@ public class ReaderUtils {
      * @param components
      * @return the collection of supported parameters
      */
-    public static List<Parameter> collectConstructorParameters(Class<?> cls, Components components, javax.ws.rs.Consumes classConsumes, JsonView jsonViewAnnotation, Schema.SchemaResolution schemaResolution) {
+    public static List<Parameter> collectConstructorParameters(Class<?> cls, Components components, javax.ws.rs.Consumes classConsumes, JsonView jsonViewAnnotation, Schema.SchemaResolution schemaResolution, boolean openapi31) {
         if (cls.isLocalClass() || (cls.isMemberClass() && !Modifier.isStatic(cls.getModifiers()))) {
             return Collections.emptyList();
         }
@@ -81,7 +78,9 @@ public class ReaderUtils {
                                     components,
                                     classConsumes == null ? new String[0] : classConsumes.value(),
                                     null,
-                                    jsonViewAnnotation, false, schemaResolution);
+                                    jsonViewAnnotation,
+                                    openapi31,
+                                    schemaResolution);
                             if (processedParameter != null) {
                                 parameters.add(processedParameter);
                             }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -91,6 +91,7 @@ import io.swagger.v3.jaxrs2.resources.Ticket4804NotBlankResource;
 import io.swagger.v3.jaxrs2.resources.Ticket4804ProcessorResource;
 import io.swagger.v3.jaxrs2.resources.Ticket4804Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket4859Resource;
+import io.swagger.v3.jaxrs2.resources.Ticket4878Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket4879Resource;
 import io.swagger.v3.jaxrs2.resources.UploadResource;
 import io.swagger.v3.jaxrs2.resources.UrlEncodedResourceWithEncodings;
@@ -5339,6 +5340,40 @@ public class ReaderTest {
                 "          description: default response\n" +
                 "          content:\n" +
                 "            application/json: {}\n";
+        SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
+        ModelConverters.reset();
+    }
+
+    @Test(description = "Test model resolution for global path parameters with openAPI 3.1")
+    public void testTicket4878() {
+        ModelConverters.reset();
+        SwaggerConfiguration config = new SwaggerConfiguration().openAPI31(true);
+        Reader reader = new Reader(config);
+
+        OpenAPI openAPI = reader.read(Ticket4878Resource.class);
+        String yaml = "openapi: 3.1.0\n" +
+                "paths:\n" +
+                "  /{globalPathParam}/{localPathParam}:\n" +
+                "    get:\n" +
+                "      operationId: getMethod\n" +
+                "      parameters:\n" +
+                "      - name: globalPathParam\n" +
+                "        in: path\n" +
+                "        required: true\n" +
+                "        schema:\n" +
+                "          type: string\n" +
+                "          $comment: 3.1 property for global path param\n" +
+                "      - name: localPathParam\n" +
+                "        in: path\n" +
+                "        required: true\n" +
+                "        schema:\n" +
+                "          type: string\n" +
+                "          $comment: 3.1 property for local path param\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            '*/*': {}\n";
         SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
         ModelConverters.reset();
     }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket4878Resource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket4878Resource.java
@@ -1,0 +1,17 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@Path("{globalPathParam}")
+public class Ticket4878Resource {
+
+    public Ticket4878Resource(@PathParam("globalPathParam") @Schema($comment="3.1 property for global path param") String globalPathParam) {}
+
+    @GET
+    @Path("{localPathParam}")
+    public void getMethod(@PathParam("localPathParam") @Schema($comment="3.1 property for local path param") String localPathParam) {}
+}


### PR DESCRIPTION
Fix for model resolution for global path params ignoring 3.1 setting - #4878 

Changes:
- Propagating openapi31 value from swagger configuration to `collectConstructorParameters` from the Reader
- Removed the other `collectConstructorParameters` method since I could see no usages
- Test to make sure a 3.1-only property for global path params is correctly represented in the spec

