### PR TITLE
chore: migrate Sonatype OSSRH to Central Portal

### DIFF
--- a/.github/workflows/maven-pulls.yml
+++ b/.github/workflows/maven-pulls.yml
@@ -10,14 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 14, 17 ]
+        java: [ 11, 17 ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
+        distribution: temurin
+        server-id: central
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
     - name: Cache local Maven repository
       uses: actions/cache@v4
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,15 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 14, 17 ]
+        java: [ 11, 17 ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
-        server-id: ossrh
+        distribution: temurin
+        server-id: central
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
     - name: Cache local Maven repository
@@ -52,5 +53,5 @@ jobs:
           echo "not building and maven publishing project as it is a release version: " ${MY_JAVA_VERSION}
         fi
       env:
-        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+        MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: tibdex/github-app-token@v1
       id: generate-token
       with:
@@ -21,10 +21,11 @@ jobs:
       with:
         python-version: '3.10'
     - name: Set up Java 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 11
-        server-id: ossrh
+        distribution: temurin
+        server-id: central
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
     - name: Cache local Maven repository
@@ -58,9 +59,8 @@ jobs:
         branch: prepare-release-${{ env.SC_VERSION }}
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS:  true
-      MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+      MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SC_VERSION:
       SC_NEXT_VERSION:
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: tibdex/github-app-token@v1
       id: generate-token
       with:
@@ -21,12 +21,15 @@ jobs:
       with:
         python-version: '3.10'
     - name: Set up Java 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 11
-        server-id: ossrh
+        distribution: temurin
+        server-id: central
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD
+        gpg-private-key: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
+        gpg-passphrase: ${{ secrets.OSSRH_GPG_PRIVATE_PASSPHRASE }}
     - name: Cache local Maven repository
       uses: actions/cache@v4
       with:
@@ -60,22 +63,17 @@ jobs:
         git config --global user.name "GitHub Action"
         git config --global hub.protocol https
         git remote set-url origin https://\${{ secrets.GITHUB_TOKEN }}:x-oauth-basic@github.com/''' + 'swagger-api/swagger-core' + '''.git
-    - name: Run maven deploy/release (action-maven-publish)
-      uses: samuelmeuli/action-maven-publish@v1
+    - name:  Run maven deploy/release
       if: env.RELEASE_OK == 'yes'
-      with:
-        gpg_private_key: ${{ secrets.OSSRH_GPG_PRIVATE_KEY }}
-        gpg_passphrase: ${{ secrets.OSSRH_GPG_PRIVATE_PASSPHRASE }}
-        nexus_username: ${{ secrets.OSSRH_USERNAME }}
-        nexus_password: ${{ secrets.OSSRH_TOKEN }}
-        maven_profiles: "release"
+      run: |
+        ./mvnw --no-transfer-progress -B -Prelease deploy
     - name: Run prepare javadocs script
       id: prepareJavadocs
       if: env.RELEASE_OK == 'yes'
       run: |
         . ./CI/prepare-javadocs.sh
     - name: Checkout gh-pages
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: "gh-pages"
         fetch-depth: 0
@@ -86,7 +84,7 @@ jobs:
         TMPDIR="$(dirname -- "${0}")"
         . $TMPDIR/publish-javadocs.sh
     - name: Checkout master
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: "master"
         fetch-depth: 0
@@ -104,7 +102,7 @@ jobs:
         title: 'bump snapshot ${{ env.SC_NEXT_VERSION }}-SNAPSHOT'
         branch: bump-snap-${{ env.SC_NEXT_VERSION }}-SNAPSHOT
     - name: Checkout 1.5
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: "1.5"
         fetch-depth: 0
@@ -123,7 +121,7 @@ jobs:
         title: 'update 1.5 Readme with new v2 version ${{ env.SC_VERSION }}'
         branch: update-v1-readme-${{ env.SC_VERSION }}
     - name: Checkout Wiki
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: swagger-api/swagger-core.wiki
         token: ${{ steps.generate-token.outputs.token }}
@@ -145,8 +143,8 @@ jobs:
 
     env:
       ACTIONS_ALLOW_UNSECURE_COMMANDS:  true
-      MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+      MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+      MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SC_VERSION:
       SC_NEXT_VERSION:

--- a/CI/CI.md
+++ b/CI/CI.md
@@ -83,7 +83,7 @@ See also [here](https://github.com/peter-evans/create-pull-request/blob/master/d
 GPG private key and passphrase defined to be used for sonatype deployments, as detailed in
 https://central.sonatype.org/pages/working-with-pgp-signatures.html (I'd say with email matching the one  of the sonatype account of point 1
 
-* `OSSRH_USERNAME` and `OSSRH_TOKEN`: sonatype user/token
+* `MAVEN_CENTRAL_USERNAME` and `MAVEN_CENTRAL_PASSWORD`: sonatype user/token
 
 * `GRADLE_PUBLISH_KEY` and `GRADLE_PUBLISH_SECRET`: credentials for https://plugins.gradle.org/
 

--- a/modules/swagger-project-jakarta/pom.xml
+++ b/modules/swagger-project-jakarta/pom.xml
@@ -13,16 +13,6 @@
         <developerConnection>scm:git:git@github.com:swagger-api/swagger-core.git</developerConnection>
         <url>https://github.com/swagger-api/swagger-core</url>
     </scm>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
     <prerequisites>
         <maven>2.2.0</maven>
     </prerequisites>
@@ -112,18 +102,14 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
-<!--                    <skipStaging>true</skipStaging>
-                    <skipRemoteStaging>true</skipRemoteStaging>
-                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>-->
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
         </plugins>
@@ -509,7 +495,6 @@
         <coverage.missed.classes>0</coverage.missed.classes>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
         <transformer-maven-plugin-version>0.5.0</transformer-maven-plugin-version>
         <maven.version>3.9.9</maven.version>
         <commons-compress-version>1.27.1</commons-compress-version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,6 @@
         <developerConnection>scm:git:git@github.com:swagger-api/swagger-core.git</developerConnection>
         <url>https://github.com/swagger-api/swagger-core</url>
     </scm>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
     <prerequisites>
         <maven>2.2.0</maven>
     </prerequisites>
@@ -208,18 +198,14 @@
                 <version>3.12.1</version>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
-<!--                    <skipStaging>true</skipStaging>
-                    <skipRemoteStaging>true</skipRemoteStaging>
-                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>-->
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
                 </configuration>
             </plugin>
         </plugins>
@@ -666,6 +652,5 @@
         <coverage.missed.classes>0</coverage.missed.classes>
         <transformer-maven-plugin-version>0.5.0</transformer-maven-plugin-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
     </properties>
 </project>


### PR DESCRIPTION
see https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/

To be merged after OSSRH repo has been manually moved by Sonatype Support to Central Portal