### PR TITLE
migrate Sonatype OSSRH to Central Portal

### DIFF
--- a/.github/workflows/maven-v1-pulls.yml
+++ b/.github/workflows/maven-v1-pulls.yml
@@ -13,13 +13,15 @@ jobs:
         java: [ 11, 17 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: temurin
+          server-id: central
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven-v1.yml
+++ b/.github/workflows/maven-v1.yml
@@ -13,16 +13,17 @@ jobs:
         java: [ 11, 17 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          server-id: sonatype-nexus-snapshots
+          distribution: temurin
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Cache local Maven repository
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -47,5 +48,5 @@ jobs:
             echo "not deploying on java version: " ${MY_JAVA_VERSION}
           fi
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Javadocs for annotations with the current release are [available online](http://
 
 The goal of Swagger™ is to define a standard, language-agnostic interface to REST APIs which allows both humans and computers to discover and understand the capabilities of the service without access to source code, documentation, or through network traffic inspection. When properly defined via Swagger, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interfaces have done for lower-level programming, Swagger removes the guesswork in calling the service.
 
-Swagger Core is the Java implementation of Swagger. Current version supports *JAX-RS* and plain servlets.  Integration with the Play! framework has been moved to [Swagger-Play](https://github.com/swagger-api/swagger-play).
+Swagger Core is the Java implementation of Swagger. Current version supports *JAX-RS* and plain servlets. Integration with the Play! framework has been moved to [Swagger-Play](https://github.com/swagger-api/swagger-play).
 
 Check out [Swagger-Spec](https://github.com/OAI/OpenAPI-Specification) for additional information about the Swagger project, including additional libraries with support for SpringMVC, other languages and more.
 
@@ -29,100 +29,104 @@ See the guide on [getting started with swagger](https://github.com/swagger-api/s
 For 2.X see [getting started with swagger 2.X](https://github.com/frantuma/swagger-core/wiki/Swagger-2.X---Getting-started).
 
 ## Compatibility
-The OpenAPI Specification has undergone several revisions since initial creation in 2010.  The Swagger Core project has the following compatibilities with the OpenAPI Specification:
+The OpenAPI Specification has undergone several revisions since initial creation in 2010. The Swagger Core project has the following compatibilities with the OpenAPI Specification:
 
-Swagger core Version      | Release Date | OpenAPI Spec compatibility | Notes                                                                                                             | Status
-------------------------- |--------------| -------------------------- |-------------------------------------------------------------------------------------------------------------------| ----
-2.2.28 (**current stable**)| 2025-01-16   | 3.x           | [tag v2.2.28](https://github.com/swagger-api/swagger-core/tree/v2.2.28)                                           | Supported
-2.2.27                     | 2024-12-11   | 3.x           | [tag v2.2.27](https://github.com/swagger-api/swagger-core/tree/v2.2.27)                                           | Supported
-2.2.26                     | 2024-11-18   | 3.x           | [tag v2.2.26](https://github.com/swagger-api/swagger-core/tree/v2.2.26)                                           | Supported
-2.2.25                     | 2024-10-02   | 3.x           | [tag v2.2.25](https://github.com/swagger-api/swagger-core/tree/v2.2.25)                                           | Supported
-2.2.24                     | 2024-09-23   | 3.x           | [tag v2.2.24](https://github.com/swagger-api/swagger-core/tree/v2.2.24)                                           | Supported
-2.2.23                     | 2024-08-28   | 3.x           | [tag v2.2.23](https://github.com/swagger-api/swagger-core/tree/v2.2.23)                                           | Supported
-2.2.22                     | 2024-05-15   | 3.x           | [tag v2.2.22](https://github.com/swagger-api/swagger-core/tree/v2.2.22)                                           | Supported
-2.2.21                     | 2024-03-20   | 3.x           | [tag v2.2.21](https://github.com/swagger-api/swagger-core/tree/v2.2.21)                                           | Supported
-2.2.20                     | 2023-12-19   | 3.x           | [tag v2.2.20](https://github.com/swagger-api/swagger-core/tree/v2.2.20)                                           | Supported
-2.2.19                     | 2023-11-10   | 3.x           | [tag v2.2.19](https://github.com/swagger-api/swagger-core/tree/v2.2.19)                                           | Supported
-2.2.18                     | 2023-10-25   | 3.x           | [tag v2.2.18](https://github.com/swagger-api/swagger-core/tree/v2.2.18)                                           | Supported
-2.2.17                     | 2023-10-12   | 3.x           | [tag v2.2.17](https://github.com/swagger-api/swagger-core/tree/v2.2.17)                                           | Supported
-2.2.16                     | 2023-09-18   | 3.x           | [tag v2.2.16](https://github.com/swagger-api/swagger-core/tree/v2.2.16)                                           | Supported
-2.2.15                     | 2023-07-08   | 3.x           | [tag v2.2.15](https://github.com/swagger-api/swagger-core/tree/v2.2.15)                                           | Supported
-2.2.14                     | 2023-06-26   | 3.x           | [tag v2.2.14](https://github.com/swagger-api/swagger-core/tree/v2.2.14)                                           | Supported
-2.2.13                     | 2023-06-24   | 3.x           | [tag v2.2.13](https://github.com/swagger-api/swagger-core/tree/v2.2.13)                                           | Supported
-2.2.12                     | 2023-06-13   | 3.x           | [tag v2.2.12](https://github.com/swagger-api/swagger-core/tree/v2.2.12)                                           | Supported
-2.2.11                     | 2023-06-01   | 3.x           | [tag v2.2.11](https://github.com/swagger-api/swagger-core/tree/v2.2.11)                                           | Supported
-2.2.10                     | 2023-05-15   | 3.x           | [tag v2.2.10](https://github.com/swagger-api/swagger-core/tree/v2.2.10)                                           | Supported
-2.2.9                     | 2023-03-20   | 3.x           | [tag v2.2.9](https://github.com/swagger-api/swagger-core/tree/v2.2.9)                                             | Supported
-2.2.8                     | 2023-01-06   | 3.x           | [tag v2.2.8](https://github.com/swagger-api/swagger-core/tree/v2.2.8)                                             | Supported
-2.2.7                     | 2022-11-15   | 3.0           | [tag v2.2.7](https://github.com/swagger-api/swagger-core/tree/v2.2.7)                                             | Supported
-2.2.6                     | 2022-11-02   | 3.0           | [tag v2.2.6](https://github.com/swagger-api/swagger-core/tree/v2.2.6)                                             | Supported
-2.2.5                     | 2022-11-02   | 3.0           | [tag v2.2.5](https://github.com/swagger-api/swagger-core/tree/v2.2.5)                                             | Supported
-2.2.4                     | 2022-10-16   | 3.0           | [tag v2.2.4](https://github.com/swagger-api/swagger-core/tree/v2.2.4)                                             | Supported
-2.2.3                     | 2022-09-27   | 3.0           | [tag v2.2.3](https://github.com/swagger-api/swagger-core/tree/v2.2.3)                                             | Supported
-2.2.2                     | 2022-07-20   | 3.0           | [tag v2.2.2](https://github.com/swagger-api/swagger-core/tree/v2.2.2)                                             | Supported
-2.2.1                     | 2022-06-15   | 3.0           | [tag v2.2.1](https://github.com/swagger-api/swagger-core/tree/v2.2.1)                                             | Supported
-2.2.0                     | 2022-04-04   | 3.0           | [tag v2.2.0](https://github.com/swagger-api/swagger-core/tree/v2.2.0)                                             | Supported
-2.1.13                     | 2022-02-07   | 3.0           | [tag v2.1.13](https://github.com/swagger-api/swagger-core/tree/v2.1.13)                                           | Supported
-2.1.12                     | 2021-12-23   | 3.0           | [tag v2.1.12](https://github.com/swagger-api/swagger-core/tree/v2.1.12)                                           | Supported
-2.1.11                     | 2021-09-29   | 3.0           | [tag v2.1.11](https://github.com/swagger-api/swagger-core/tree/v2.1.11)                                           | Supported
-2.1.10                     | 2021-06-28   | 3.0           | [tag v2.1.10](https://github.com/swagger-api/swagger-core/tree/v2.1.10)                                           | Supported
-2.1.9                     | 2021-04-20   | 3.0           | [tag v2.1.9](https://github.com/swagger-api/swagger-core/tree/v2.1.9)                                             | Supported
-2.1.8                     | 2021-04-18   | 3.0           | [tag v2.1.8](https://github.com/swagger-api/swagger-core/tree/v2.1.8)                                             | Supported
-2.1.7                     | 2021-02-18   | 3.0           | [tag v2.1.7](https://github.com/swagger-api/swagger-core/tree/v2.1.7)                                             | Supported
-2.1.6                     | 2020-12-04   | 3.0           | [tag v2.1.6](https://github.com/swagger-api/swagger-core/tree/v2.1.6)                                             | Supported
-2.1.5                     | 2020-10-01   | 3.0           | [tag v2.1.5](https://github.com/swagger-api/swagger-core/tree/v2.1.5)                                             | Supported
-2.1.4                     | 2020-07-24   | 3.0           | [tag v2.1.4](https://github.com/swagger-api/swagger-core/tree/v2.1.4)                                             | Supported
-2.1.3                     | 2020-06-27   | 3.0           | [tag v2.1.3](https://github.com/swagger-api/swagger-core/tree/v2.1.3)                                             | Supported
-2.1.2                     | 2020-04-01   | 3.0           | [tag v2.1.2](https://github.com/swagger-api/swagger-core/tree/v2.1.2)                                             | Supported
-2.1.1                     | 2020-01-02   | 3.0           | [tag v2.1.1](https://github.com/swagger-api/swagger-core/tree/v2.1.1)                                             | Supported
-2.1.0                     | 2019-11-16   | 3.0           | [tag v2.1.0](https://github.com/swagger-api/swagger-core/tree/v2.1.0)                                             | Supported
-2.0.10                    | 2019-10-11   | 3.0           | [tag v2.0.10](https://github.com/swagger-api/swagger-core/tree/v2.0.10)                                           | Supported
-2.0.9                     | 2019-08-22   | 3.0           | [tag v2.0.9](https://github.com/swagger-api/swagger-core/tree/v2.0.9)                                             | Supported
-2.0.8                     | 2019-04-24   | 3.0           | [tag v2.0.8](https://github.com/swagger-api/swagger-core/tree/v2.0.8)                                             | Supported
-2.0.7                     | 2019-02-18   | 3.0           | [tag v2.0.7](https://github.com/swagger-api/swagger-core/tree/v2.0.7)                                             | Supported
-2.0.6                     | 2018-11-27   | 3.0           | [tag v2.0.6](https://github.com/swagger-api/swagger-core/tree/v2.0.6)                                             | Supported
-2.0.5                     | 2018-09-19   | 3.0           | [tag v2.0.5](https://github.com/swagger-api/swagger-core/tree/v2.0.5)                                             | Supported
-2.0.4                     | 2018-09-05   | 3.0           | [tag v2.0.4](https://github.com/swagger-api/swagger-core/tree/v2.0.4)                                             | Supported
-2.0.3                     | 2018-08-09   | 3.0           | [tag v2.0.3](https://github.com/swagger-api/swagger-core/tree/v2.0.3)                                             | Supported
-1.6.15 (**current stable**)| 2025-01-15   | 2.0           | [tag v1.6.15](https://github.com/swagger-api/swagger-core/tree/v1.6.15)                                           | Supported
-1.6.14                    | 2024-03-19   | 2.0           | [tag v1.6.14](https://github.com/swagger-api/swagger-core/tree/v1.6.14)                                           | Supported
-1.6.13                    | 2024-01-26   | 2.0           | [tag v1.6.13](https://github.com/swagger-api/swagger-core/tree/v1.6.13)                                           | Supported
-1.6.12                    | 2023-10-14   | 2.0           | [tag v1.6.12](https://github.com/swagger-api/swagger-core/tree/v1.6.12)                                           | Supported
-1.6.11                    | 2023-05-15   | 2.0           | [tag v1.6.11](https://github.com/swagger-api/swagger-core/tree/v1.6.11)                                           | Supported
-1.6.10                    | 2023-03-21   | 2.0           | [tag v1.6.10](https://github.com/swagger-api/swagger-core/tree/v1.6.10)                                           | Supported
-1.6.9                     | 2022-11-15   | 2.0           | [tag v1.6.9](https://github.com/swagger-api/swagger-core/tree/v1.6.9)                                             | Supported
-1.6.8                     | 2022-10-16   | 2.0           | [tag v1.6.8](https://github.com/swagger-api/swagger-core/tree/v1.6.8)                                             | Supported
-1.6.7                     | 2022-09-27   | 2.0           | [tag v1.6.7](https://github.com/swagger-api/swagger-core/tree/v1.6.7)                                             | Supported
-1.6.6                     | 2022-04-04   | 2.0           | [tag v1.6.6](https://github.com/swagger-api/swagger-core/tree/v1.6.6)                                             | Supported
-1.6.5                     | 2022-02-07   | 2.0           | [tag v1.6.5](https://github.com/swagger-api/swagger-core/tree/v1.6.5)                                             | Supported
-1.6.4                     | 2021-12-23   | 2.0           | [tag v1.6.4](https://github.com/swagger-api/swagger-core/tree/v1.6.4)                                             | Supported
-1.6.3                     | 2021-09-29   | 2.0           | [tag v1.6.3](https://github.com/swagger-api/swagger-core/tree/v1.6.3)                                             | Supported
-1.6.2                     | 2020-07-01   | 2.0           | [tag v1.6.2](https://github.com/swagger-api/swagger-core/tree/v1.6.2)                                             | Supported
-1.6.1                     | 2020-04-01   | 2.0           | [tag v1.6.1](https://github.com/swagger-api/swagger-core/tree/v1.6.1)                                             | Supported
-1.6.0                     | 2019-11-16   | 2.0           | [tag v1.6.0](https://github.com/swagger-api/swagger-core/tree/v1.6.0)                                             | Supported
-1.5.24                    | 2019-10-11   | 2.0           | [tag v1.5.24](https://github.com/swagger-api/swagger-core/tree/v1.5.24)                                           | Supported
-1.5.23                    | 2019-08-22   | 2.0           | [tag v1.5.23](https://github.com/swagger-api/swagger-core/tree/v1.5.23)                                           | Supported
-1.5.22                    | 2019-02-18   | 2.0           | [tag v1.5.22](https://github.com/swagger-api/swagger-core/tree/v1.5.22)                                           | Supported
-1.5.21                    | 2018-08-09   | 2.0           | [tag v1.5.21](https://github.com/swagger-api/swagger-core/tree/v1.5.21)                                           | Supported
-1.5.20                    | 2018-05-23   | 2.0           | [tag v1.5.20](https://github.com/swagger-api/swagger-core/tree/v1.5.20)                                           | Supported
-2.0.2                     | 2018-05-23   | 3.0           | [tag v2.0.2](https://github.com/swagger-api/swagger-core/tree/v2.0.2)                                             | Supported
-2.0.1                     | 2018-04-16   | 3.0           | [tag v2.0.1](https://github.com/swagger-api/swagger-core/tree/v2.0.1)                                             | Supported
-1.5.19                    | 2018-04-16   | 2.0           | [tag v1.5.19](https://github.com/swagger-api/swagger-core/tree/v1.5.19)                                           | Supported
-2.0.0                     | 2018-03-20   | 3.0           | [tag v2.0.0](https://github.com/swagger-api/swagger-core/tree/v2.0.0)                                             | Supported
-2.0.0-rc4                 | 2018-01-22   | 3.0           | [tag v2.0.0-rc4](https://github.com/swagger-api/swagger-core/tree/v2.0.0-rc4)                                     | Supported
-2.0.0-rc3                 | 2017-11-21   | 3.0           | [tag v2.0.0-rc3](https://github.com/swagger-api/swagger-core/tree/v2.0.0-rc3)                                     | Supported
-2.0.0-rc2                 | 2017-09-29   | 3.0           | [tag v2.0.0-rc2](https://github.com/swagger-api/swagger-core/tree/v2.0.0-rc2)                                     | Supported
-2.0.0-rc1                 | 2017-08-17   | 3.0           | [tag v2.0.0-rc1](https://github.com/swagger-api/swagger-core/tree/v2.0.0-rc1)                                     | Supported
-1.5.18                    | 2018-01-22   | 2.0           | [tag v1.5.18](https://github.com/swagger-api/swagger-core/tree/v1.5.18)                                           | Supported
-1.5.17                    | 2017-11-21   | 2.0           | [tag v1.5.17](https://github.com/swagger-api/swagger-core/tree/v1.5.17)                                           | Supported
-1.5.16                    | 2017-07-15   | 2.0           | [tag v1.5.16](https://github.com/swagger-api/swagger-core/tree/v1.5.16)                                           | Supported
-1.3.12                    | 2014-12-23   | 1.2           | [tag v1.3.12](https://github.com/swagger-api/swagger-core/tree/v1.3.12)                                           | Supported
-1.2.4                     | 2013-06-19   | 1.1           | [tag swagger-project_2.10.0-1.2.4](https://github.com/swagger-api/swagger-core/tree/swagger-project_2.10.0-1.2.4) | Deprecated
-1.0.0                     | 2011-10-16   | 1.0           | [tag v1.0](https://github.com/swagger-api/swagger-core/tree/v1.0)                                                 | Deprecated
+Swagger core Version | Release Date | OpenAPI Spec compatibility | Notes | Status
+------------------------- | ------------ | -------------------------- | ----- | ----
+2.2.32 (**current stable**)| 2025-05-14 | 3.x | [tag v2.2.32](https://github.com/swagger-api/swagger-core/tree/v2.2.32) | Supported
+2.2.31 | 2025-05-13 | 3.x | [tag v2.2.31](https://github.com/swagger-api/swagger-core/tree/v2.2.31) | Supported
+2.2.30 | 2025-04-07 | 3.x | [tag v2.2.30](https://github.com/swagger-api/swagger-core/tree/v2.2.30) | Supported
+2.2.29 | 2025-03-10 | 3.x | [tag v2.2.29](https://github.com/swagger-api/swagger-core/tree/v2.2.29) | Supported
+2.2.28 | 2025-01-16 | 3.x | [tag v2.2.28](https://github.com/swagger-api/swagger-core/tree/v2.2.28) | Supported
+2.2.27 | 2024-12-11 | 3.x | [tag v2.2.27](https://github.com/swagger-api/swagger-core/tree/v2.2.27) | Supported
+2.2.26 | 2024-11-18 | 3.x | [tag v2.2.26](https://github.com/swagger-api/swagger-core/tree/v2.2.26) | Supported
+2.2.25 | 2024-10-02 | 3.x | [tag v2.2.25](https://github.com/swagger-api/swagger-core/tree/v2.2.25) | Supported
+2.2.24 | 2024-09-23 | 3.x | [tag v2.2.24](https://github.com/swagger-api/swagger-core/tree/v2.2.24) | Supported
+2.2.23 | 2024-08-28 | 3.x | [tag v2.2.23](https://github.com/swagger-api/swagger-core/tree/v2.2.23) | Supported
+2.2.22 | 2024-05-15 | 3.x | [tag v2.2.22](https://github.com/swagger-api/swagger-core/tree/v2.2.22) | Supported
+2.2.21 | 2024-03-20 | 3.x | [tag v2.2.21](https://github.com/swagger-api/swagger-core/tree/v2.2.21) | Supported
+2.2.20 | 2023-12-19 | 3.x | [tag v2.2.20](https://github.com/swagger-api/swagger-core/tree/v2.2.20) | Supported
+2.2.19 | 2023-11-10 | 3.x | [tag v2.2.19](https://github.com/swagger-api/swagger-core/tree/v2.2.19) | Supported
+2.2.18 | 2023-10-25 | 3.x | [tag v2.2.18](https://github.com/swagger-api/swagger-core/tree/v2.2.18) | Supported
+2.2.17 | 2023-10-12 | 3.x | [tag v2.2.17](https://github.com/swagger-api/swagger-core/tree/v2.2.17) | Supported
+2.2.16 | 2023-09-18 | 3.x | [tag v2.2.16](https://github.com/swagger-api/swagger-core/tree/v2.2.16) | Supported
+2.2.15 | 2023-07-08 | 3.x | [tag v2.2.15](https://github.com/swagger-api/swagger-core/tree/v2.2.15) | Supported
+2.2.14 | 2023-06-26 | 3.x | [tag v2.2.14](https://github.com/swagger-api/swagger-core/tree/v2.2.14) | Supported
+2.2.13 | 2023-06-24 | 3.x | [tag v2.2.13](https://github.com/swagger-api/swagger-core/tree/v2.2.13) | Supported
+2.2.12 | 2023-06-13 | 3.x | [tag v2.2.12](https://github.com/swagger-api/swagger-core/tree/v2.2.12) | Supported
+2.2.11 | 2023-06-01 | 3.x | [tag v2.2.11](https://github.com/swagger-api/swagger-core/tree/v2.2.11) | Supported
+2.2.10 | 2023-05-15 | 3.x | [tag v2.2.10](https://github.com/swagger-api/swagger-core/tree/v2.2.10) | Supported
+2.2.9 | 2023-03-20 | 3.x | [tag v2.2.9](https://github.com/swagger-api/swagger-core/tree/v2.2.9) | Supported
+2.2.8 | 2023-01-06 | 3.x | [tag v2.2.8](https://github.com/swagger-api/swagger-core/tree/v2.2.8) | Supported
+2.2.7 | 2022-11-15 | 3.0 | [tag v2.2.7](https://github.com/swagger-api/swagger-core/tree/v2.2.7) | Supported
+2.2.6 | 2022-11-02 | 3.0 | [tag v2.2.6](https://github.com/swagger-api/swagger-core/tree/v2.2.6) | Supported
+2.2.5 | 2022-11-02 | 3.0 | [tag v2.2.5](https://github.com/swagger-api/swagger-core/tree/v2.2.5) | Supported
+2.2.4 | 2022-10-16 | 3.0 | [tag v2.2.4](https://github.com/swagger-api/swagger-core/tree/v2.2.4) | Supported
+2.2.3 | 2022-09-27 | 3.0 | [tag v2.2.3](https://github.com/swagger-api/swagger-core/tree/v2.2.3) | Supported
+2.2.2 | 2022-07-20 | 3.0 | [tag v2.2.2](https://github.com/swagger-api/swagger-core/tree/v2.2.2) | Supported
+2.2.1 | 2022-06-15 | 3.0 | [tag v2.2.1](https://github.com/swagger-api/swagger-core/tree/v2.2.1) | Supported
+2.2.0 | 2022-04-04 | 3.0 | [tag v2.2.0](https://github.com/swagger-api/swagger-core/tree/v2.2.0) | Supported
+2.1.13 | 2022-02-07 | 3.0 | [tag v2.1.13](https://github.com/swagger-api/swagger-core/tree/v2.1.13) | Supported
+2.1.12 | 2021-12-23 | 3.0 | [tag v2.1.12](https://github.com/swagger-api/swagger-core/tree/v2.1.12) | Supported
+2.1.11 | 2021-09-29 | 3.0 | [tag v2.1.11](https://github.com/swagger-api/swagger-core/tree/v2.1.11) | Supported
+2.1.10 | 2021-06-28 | 3.0 | [tag v2.1.10](https://github.com/swagger-api/swagger-core/tree/v2.1.10) | Supported
+2.1.9 | 2021-04-20 | 3.0 | [tag v2.1.9](https://github.com/swagger-api/swagger-core/tree/v2.1.9) | Supported
+2.1.8 | 2021-04-18 | 3.0 | [tag v2.1.8](https://github.com/swagger-api/swagger-core/tree/v2.1.8) | Supported
+2.1.7 | 2021-02-18 | 3.0 | [tag v2.1.7](https://github.com/swagger-api/swagger-core/tree/v2.1.7) | Supported
+2.1.6 | 2020-12-04 | 3.0 | [tag v2.1.6](https://github.com/swagger-api/swagger-core/tree/v2.1.6) | Supported
+2.1.5 | 2020-10-01 | 3.0 | [tag v2.1.5](https://github.com/swagger-api/swagger-core/tree/v2.1.5) | Supported
+2.1.4 | 2020-07-24 | 3.0 | [tag v2.1.4](https://github.com/swagger-api/swagger-core/tree/v2.1.4) | Supported
+2.1.3 | 2020-06-27 | 3.0 | [tag v2.1.3](https://github.com/swagger-api/swagger-core/tree/v2.1.3) | Supported
+2.1.2 | 2020-04-01 | 3.0 | [tag v2.1.2](https://github.com/swagger-api/swagger-core/tree/v2.1.2) | Supported
+2.1.1 | 2020-01-02 | 3.0 | [tag v2.1.1](https://github.com/swagger-api/swagger-core/tree/v2.1.1) | Supported
+2.1.0 | 2019-11-16 | 3.0 | [tag v2.1.0](https://github.com/swagger-api/swagger-core/tree/v2.1.0) | Supported
+2.0.10 | 2019-10-11 | 3.0 | [tag v2.0.10](https://github.com/swagger-api/swagger-core/tree/v2.0.10) | Supported
+2.0.9 | 2019-08-22 | 3.0 | [tag v2.0.9](https://github.com/swagger-api/swagger-core/tree/v2.0.9) | Supported
+2.0.8 | 2019-04-24 | 3.0 | [tag v2.0.8](https://github.com/swagger-api/swagger-core/tree/v2.0.8) | Supported
+2.0.7 | 2019-02-18 | 3.0 | [tag v2.0.7](https://github.com/swagger-api/swagger-core/tree/v2.0.7) | Supported
+2.0.6 | 2018-11-27 | 3.0 | [tag v2.0.6](https://github.com/swagger-api/swagger-core/tree/v2.0.6) | Supported
+2.0.5 | 2018-09-19 | 3.0 | [tag v2.0.5](https://github.com/swagger-api/swagger-core/tree/v2.0.5) | Supported
+2.0.4 | 2018-09-05 | 3.0 | [tag v2.0.4](https://github.com/swagger-api/swagger-core/tree/v2.0.4) | Supported
+2.0.3 | 2018-08-09 | 3.0 | [tag v2.0.3](https://github.com/swagger-api/swagger-core/tree/v2.0.3) | Supported
+1.6.15 (**current stable**)| 2025-01-15 | 2.0 | [tag v1.6.15](https://github.com/swagger-api/swagger-core/tree/v1.6.15) | Supported
+1.6.14 | 2024-03-19 | 2.0 | [tag v1.6.14](https://github.com/swagger-api/swagger-core/tree/v1.6.14) | Supported
+1.6.13 | 2024-01-26 | 2.0 | [tag v1.6.13](https://github.com/swagger-api/swagger-core/tree/v1.6.13) | Supported
+1.6.12 | 2023-10-14 | 2.0 | [tag v1.6.12](https://github.com/swagger-api/swagger-core/tree/v1.6.12) | Supported
+1.6.11 | 2023-05-15 | 2.0 | [tag v1.6.11](https://github.com/swagger-api/swagger-core/tree/v1.6.11) | Supported
+1.6.10 | 2023-03-21 | 2.0 | [tag v1.6.10](https://github.com/swagger-api/swagger-core/tree/v1.6.10) | Supported
+1.6.9 | 2022-11-15 | 2.0 | [tag v1.6.9](https://github.com/swagger-api/swagger-core/tree/v1.6.9) | Supported
+1.6.8 | 2022-10-16 | 2.0 | [tag v1.6.8](https://github.com/swagger-api/swagger-core/tree/v1.6.8) | Supported
+1.6.7 | 2022-09-27 | 2.0 | [tag v1.6.7](https://github.com/swagger-api/swagger-core/tree/v1.6.7) | Supported
+1.6.6 | 2022-04-04 | 2.0 | [tag v1.6.6](https://github.com/swagger-api/swagger-core/tree/v1.6.6) | Supported
+1.6.5 | 2022-02-07 | 2.0 | [tag v1.6.5](https://github.com/swagger-api/swagger-core/tree/v1.6.5) | Supported
+1.6.4 | 2021-12-23 | 2.0 | [tag v1.6.4](https://github.com/swagger-api/swagger-core/tree/v1.6.4) | Supported
+1.6.3 | 2021-09-29 | 2.0 | [tag v1.6.3](https://github.com/swagger-api/swagger-core/tree/v1.6.3) | Supported
+1.6.2 | 2020-07-01 | 2.0 | [tag v1.6.2](https://github.com/swagger-api/swagger-core/tree/v1.6.2) | Supported
+1.6.1 | 2020-04-01 | 2.0 | [tag v1.6.1](https://github.com/swagger-api/swagger-core/tree/v1.6.1) | Supported
+1.6.0 | 2019-11-16 | 2.0 | [tag v1.6.0](https://github.com/swagger-api/swagger-core/tree/v1.6.0) | Supported
+1.5.24 | 2019-10-11 | 2.0 | [tag v1.5.24](https://github.com/swagger-api/swagger-core/tree/v1.5.24) | Supported
+1.5.23 | 2019-08-22 | 2.0 | [tag v1.5.23](https://github.com/swagger-api/swagger-core/tree/v1.5.23) | Supported
+1.5.22 | 2019-02-18 | 2.0 | [tag v1.5.22](https://github.com/swagger-api/swagger-core/tree/v1.5.22) | Supported
+1.5.21 | 2018-08-09 | 2.0 | [tag v1.5.21](https://github.com/swagger-api/swagger-core/tree/v1.5.21) | Supported
+1.5.20 | 2018-05-23 | 2.0 | [tag v1.5.20](https://github.com/swagger-api/swagger-core/tree/v1.5.20) | Supported
+2.0.2 | 2018-05-23 | 3.0 | [tag v2.0.2](https://github.com/swagger-api/swagger-core/tree/v2.0.2) | Supported
+2.0.1 | 2018-04-16 | 3.0 | [tag v2.0.1](https://github.com/swagger-api/swagger-core/tree/v2.0.1) | Supported
+1.5.19 | 2018-04-16 | 2.0 | [tag v1.5.19](https://github.com/swagger-api/swagger-core/tree/v1.5.19) | Supported
+2.0.0 | 2018-03-20 | 3.0 | [tag v2.0.0](https://github.com/swagger-api/swagger-core/tree/v2.0.0) | Supported
+2.0.0-rc4 | 2018-01-22 | 3.0 | [tag v2.0.0-rc4](https://github.com/swagger-api/swagger-core/tree/v2.0.0-rc4) | Supported
+2.0.0-rc3 | 2017-11-21 | 3.0 | [tag v2.0.0-rc3](https://github.com/swagger-api/swagger-core/tree/v2.0.0-rc3) | Supported
+2.0.0-rc2 | 2017-09-29 | 3.0 | [tag v2.0.0-rc2](https://github.com/swagger-api/swagger-core/tree/v2.0.0-rc2) | Supported
+2.0.0-rc1 | 2017-08-17 | 3.0 | [tag v2.0.0-rc1](https://github.com/swagger-api/swagger-core/tree/v2.0.0-rc1) | Supported
+1.5.18 | 2018-01-22 | 2.0 | [tag v1.5.18](https://github.com/swagger-api/swagger-core/tree/v1.5.18) | Supported
+1.5.17 | 2017-11-21 | 2.0 | [tag v1.5.17](https://github.com/swagger-api/swagger-core/tree/v1.5.17) | Supported
+1.5.16 | 2017-07-15 | 2.0 | [tag v1.5.16](https://github.com/swagger-api/swagger-core/tree/v1.5.16) | Supported
+1.3.12 | 2014-12-23 | 1.2 | [tag v1.3.12](https://github.com/swagger-api/swagger-core/tree/v1.3.12) | Supported
+1.2.4 | 2013-06-19 | 1.1 | [tag swagger-project_2.10.0-1.2.4](https://github.com/swagger-api/swagger-core/tree/swagger-project_2.10.0-1.2.4) | Deprecated
+1.0.0 | 2011-10-16 | 1.0 | [tag v1.0](https://github.com/swagger-api/swagger-core/tree/v1.0) | Deprecated
 
 
 ## Where is Scala support?
-To allow independent development, scala support has been moved into a separate project.  See the [swagger-scala-module](https://github.com/swagger-api/swagger-scala-module) for details.  Play! framework support has moved to [swagger-play](https://github.com/swagger-api/swagger-play).
+To allow independent development, scala support has been moved into a separate project. See the [swagger-scala-module](https://github.com/swagger-api/swagger-scala-module) for details. Play! framework support has moved to [swagger-play](https://github.com/swagger-api/swagger-play).
 
 ## Overview
 This is a project to build the swagger-core library, which is required for the Swagger implementation of the OpenAPI Spec.

--- a/pom.xml
+++ b/pom.xml
@@ -575,23 +575,23 @@
     <properties>
         <maven.compiler.release>7</maven.compiler.release>
         <joda-version>2.2.4</joda-version>
-        <joda-time-version>2.13.0</joda-time-version>
+        <joda-time-version>2.14.0</joda-time-version>
 
         <bnd-version>6.4.0</bnd-version>
         <servlet-api-version>2.5</servlet-api-version>
         <jersey-version>1.19.4</jersey-version>
         <jersey2-version>2.46</jersey2-version>
-        <jackson-version>2.18.2</jackson-version>
-        <jackson-databind-version>2.18.2</jackson-databind-version>
-        <snakeyaml-version>2.3</snakeyaml-version>
-        <logback-version>1.5.16</logback-version>
+        <jackson-version>2.19.0</jackson-version>
+        <jackson-databind-version>2.19.0</jackson-databind-version>
+        <snakeyaml-version>2.4</snakeyaml-version>
+        <logback-version>1.5.18</logback-version>
         <reflections-version>0.10.2</reflections-version>
         <guava-version>32.1.3-android</guava-version>
         <javassist-version>3.30.2-GA</javassist-version>
 
-        <testng-version>7.10.2</testng-version>
+        <testng-version>7.11.0</testng-version>
         <mockito-version>2.28.2</mockito-version>
-        <rest-assured-version>5.5.0</rest-assured-version>
+        <rest-assured-version>5.5.2</rest-assured-version>
         <surefire-version>2.22.2</surefire-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
         <commons-lang-version>3.17.0</commons-lang-version>

--- a/pom.xml
+++ b/pom.xml
@@ -175,9 +175,16 @@
                 <version>3.12.1</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
+                    <waitMaxTime>3600</waitMaxTime>
+                </configuration>
             </plugin>
         </plugins>
         <pluginManagement>


### PR DESCRIPTION
[fix: fix README](https://github.com/swagger-api/swagger-core/commit/244adc2c626a67283ef3c4dd44a404741e7f3aa6)

[update dependencies](https://github.com/swagger-api/swagger-core/commit/60ad4cc4da651d8153471135c1a5ee399c3bc8aa)

[chore: migrate Sonatype OSSRH to Central Portal](https://github.com/swagger-api/swagger-core/commit/bcfbbb00f204a93928007764bab625e42663a003)

