### PR TITLE
Revert temp workarounds for sonatype 502

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
     - name:  Run maven deploy/release
       if: env.RELEASE_OK == 'yes'
       run: |
-        ./mvnw --no-transfer-progress -B -Prelease install
+        ./mvnw --no-transfer-progress -B -Prelease deploy
     - name: Run prepare javadocs script
       id: prepareJavadocs
       if: env.RELEASE_OK == 'yes'

--- a/modules/swagger-annotations/pom.xml
+++ b/modules/swagger-annotations/pom.xml
@@ -66,7 +66,7 @@
                         <executions>
                             <execution>
                                 <id>copy-resources</id>
-                                <phase>install</phase>
+                                <phase>deploy</phase>
                                 <goals>
                                     <goal>copy-resources</goal>
                                 </goals>


### PR DESCRIPTION
Revert "temporary workaround for sonatype 502 response pt.2 - provide pipeline with javadocs without actual mvn deploy"

Revert "temporary workaround for sonatype 502 response"

This reverts commit 22b289bf8709eec82ec74c788ebc35c9bf579f1a and 778f577a80b794ce36de77c4d24b443efa0a2a2e.