### PR TITLE
Create a failing test presenting open api 3.1 - enum property schema enumAsRef error

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/EnumTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/EnumTest.java
@@ -56,6 +56,34 @@ public class EnumTest extends SwaggerTestBase {
         assertNotNull(model.getProperties().get("type"));
     }
 
+    @Test
+    public void testEnumPropertyWithSchemaAnnotation() {
+        final ModelResolver modelResolver = new ModelResolver(mapper()).openapi31(true);
+        final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        final Schema model = context.resolve(new AnnotatedType().type(ClassWithEnumAsRefProperty.class));
+        assertNotNull(model);
+        assertEquals(model.getName(), "ClassWithEnumAsRefProperty");
+        assertTrue(model.getProperties().containsKey("enumWithSchemaProperty"));
+        final Schema enumPropertySchema = (Schema) model.getProperties().get("enumWithSchemaProperty");
+        assertNotNull(enumPropertySchema.get$ref());
+    }
+
+    public static class ClassWithEnumAsRefProperty {
+
+        @io.swagger.v3.oas.annotations.media.Schema(enumAsRef = true)
+        public final EnumWithSchemaProperty enumWithSchemaProperty;
+
+        public ClassWithEnumAsRefProperty(EnumWithSchemaProperty enumWithSchemaProperty) {
+            this.enumWithSchemaProperty = enumWithSchemaProperty;
+        }
+
+        public enum EnumWithSchemaProperty {
+            VALUE1,
+            VALUE2
+        }
+    }
+
     public enum Currency {
         USA, CANADA
     }


### PR DESCRIPTION
The test from the PR fails.

However, after changing the model resolver to generate open api 3.0 with ⬇️ works as expected
```
final ModelResolver modelResolver = new ModelResolver(mapper()).openapi31(true);
```
