### PR TITLE
chore: bump jackson versions to 2.19.2

### DIFF
--- a/modules/swagger-project-jakarta/pom.xml
+++ b/modules/swagger-project-jakarta/pom.xml
@@ -471,8 +471,8 @@
         <bnd-version>6.4.0</bnd-version>
         <servlet-api-version>5.0.0</servlet-api-version>
         <jersey2-version>3.1.10</jersey2-version>
-        <jackson-version>2.18.2</jackson-version>
-        <jackson-databind-version>2.18.2</jackson-databind-version>
+        <jackson-version>2.19.2</jackson-version>
+        <jackson-databind-version>2.19.2</jackson-databind-version>
         <logback-version>1.5.16</logback-version>
         <classgraph-version>4.8.181</classgraph-version>
         <guava-version>32.1.3-jre</guava-version>

--- a/pom.xml
+++ b/pom.xml
@@ -628,8 +628,8 @@
         <bnd-version>6.4.0</bnd-version>
         <servlet-api-version>4.0.4</servlet-api-version>
         <jersey2-version>2.46</jersey2-version>
-        <jackson-version>2.18.2</jackson-version>
-        <jackson-databind-version>2.18.2</jackson-databind-version>
+        <jackson-version>2.19.2</jackson-version>
+        <jackson-databind-version>2.19.2</jackson-databind-version>
         <logback-version>1.5.16</logback-version>
         <classgraph-version>4.8.181</classgraph-version>
         <guava-version>32.1.3-jre</guava-version>


### PR DESCRIPTION
Bump jackson libs to version 2.19.2