### PR TITLE
Fix for #4904 - Invalid cast of JsonSchema to ComposedSchema

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -1043,7 +1043,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
         if (isComposedSchema) {
 
-            ComposedSchema composedSchema = (ComposedSchema) model;
+            Schema composedSchema = model; // Could be ComposedSchema or JsonSchema (3.1)
 
             Class<?>[] allOf = resolvedSchemaAnnotation.allOf();
             Class<?>[] anyOf = resolvedSchemaAnnotation.anyOf();

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4904Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4904Test.java
@@ -1,0 +1,40 @@
+package io.swagger.v3.core.resolving;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.testng.annotations.Test;
+
+import static io.swagger.v3.core.resolving.SwaggerTestBase.mapper;
+
+public class Ticket4904Test {
+
+    @Test
+    public void testComposedSchemaWithDiscriminator() {
+        final ModelResolver modelResolver = new ModelResolver(mapper());
+        modelResolver.setOpenapi31(true);
+        final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+        context.resolve(new AnnotatedType(ParentClass.class));
+    }
+
+    @Schema(
+            type = "object",
+            discriminatorMapping = {
+                    @DiscriminatorMapping(value = "A", schema = ChildClassA.class),
+                    @DiscriminatorMapping(value = "B", schema = ChildClassB.class)
+            },
+            oneOf = {ChildClassA.class, ChildClassB.class},
+            discriminatorProperty = "objectType"
+    )
+    public abstract static class ParentClass {
+    }
+
+    public static class ChildClassA extends ParentClass {
+    }
+
+    public static class ChildClassB extends ParentClass {
+    }
+
+}


### PR DESCRIPTION
# Description

This solves issue #4904. After introduction of JsonSchema the composed schema part stopped working.

Fixes: #4904

# Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

# Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable (not needed in this case)
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)
