### PR TITLE
Fixed lack of `booleanSchemaValue` in `Schema` hashing and comparison

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -2155,7 +2155,8 @@ public class Schema<T> {
                 Objects.equals(this.$comment, schema.$comment) &&
                 Objects.equals(this.examples, schema.examples) &&
                 Objects.equals(this.prefixItems, schema.prefixItems) &&
-                Objects.equals(this.items, schema.items)
+                Objects.equals(this.items, schema.items) &&
+                Objects.equals(this.booleanSchemaValue, schema.booleanSchemaValue)
 
                 ;
     }
@@ -2169,7 +2170,8 @@ public class Schema<T> {
                 discriminator, _enum, _default, patternProperties, $id, $anchor, $schema, $vocabulary, $dynamicAnchor,
                 $dynamicRef, types, allOf, anyOf, oneOf, _const, contentEncoding, contentMediaType, contentSchema,
                 propertyNames, unevaluatedProperties, maxContains, minContains, additionalItems, unevaluatedItems,
-                _if, _else, then, dependentRequired, dependentSchemas, $comment, examples, prefixItems, items);
+                _if, _else, then, dependentRequired, dependentSchemas, $comment, examples, prefixItems, items,
+                booleanSchemaValue);
     }
 
     public java.util.Map<String, Object> getExtensions() {


### PR DESCRIPTION
## Description

This fixes the problem when a v3.1 schema that has `booleanSchemaValue` set to `false` gets mapped to `true` during the `resolveSchemaRef` method, since the `visitedMap` lookup returns the first insertion it got.

## Type of Change

<!-- Check all that apply: -->

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [X] I have added/updated tests as needed
- [X] I have added/updated documentation where applicable
- [X] The PR title is descriptive
- [X] The code builds and passes tests locally
- [X] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->