### PR TITLE
fix: Java Byte to OAS integer data type

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -173,6 +173,13 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             type = _mapper.constructType(annotatedType.getType());
         }
 
+        // EARLY special handling for OpenAPI 3.1 and byte[]: treat as array of primitive items
+        if (openapi31 && type.getRawClass().isArray() && type.getRawClass().getComponentType() == byte.class) {
+            ArraySchema arraySchema = new ArraySchema().items(PrimitiveType.BYTE.createProperty31());
+            arraySchema.specVersion(SpecVersion.V31);
+            return arraySchema;
+        }
+
         final Annotation resolvedSchemaOrArrayAnnotation = AnnotationsUtils.mergeSchemaAnnotations(annotatedType.getCtxAnnotations(), type);
         final io.swagger.v3.oas.annotations.media.Schema resolvedSchemaAnnotation =
                 resolvedSchemaOrArrayAnnotation == null ?

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
@@ -63,7 +63,7 @@ public enum PrimitiveType {
         }
         @Override
         public Schema createProperty31() {
-            return new JsonSchema().typesItem("string").format("byte");
+            return new JsonSchema().typesItem("integer").format("int8");
         }
     },
     BINARY(Byte.class, "binary") {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/PrimitiveType.java
@@ -63,7 +63,7 @@ public enum PrimitiveType {
         }
         @Override
         public Schema createProperty31() {
-            return new JsonSchema().typesItem("integer").format("int8");
+            return new JsonSchema().typesItem("integer");
         }
     },
     BINARY(Byte.class, "binary") {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ByteObjectOAS31Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ByteObjectOAS31Test.java
@@ -5,6 +5,7 @@ import io.swagger.v3.core.converter.ModelConverterContextImpl;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.core.matchers.SerializationMatchers;
 import io.swagger.v3.core.resolving.SwaggerTestBase;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.testng.annotations.Test;
 
@@ -26,16 +27,24 @@ public class ByteObjectOAS31Test extends SwaggerTestBase {
                 "  properties:\n" +
                 "    primitiveWithoutSchema:\n" +
                 "      type: integer\n" +
-                "      format: int8\n" +
                 "      writeOnly: true\n" +
                 "    primitiveWithSchema:\n" +
                 "      type: integer\n" +
-                "      format: int8\n" +
                 "      writeOnly: true\n" +
                 "    primitiveWithSchemaTypeAndFormat:\n" +
                 "      type: integer\n" +
-                "      format: int8\n" +
-                "      writeOnly: true");
+                "      writeOnly: true\n" +
+                "    primitiveArrayWithoutSchema:\n" +
+                "      type: array\n" +
+                "      items:\n" +
+                "        type: integer\n" +
+                "      writeOnly: true\n" +
+                "    primitiveArrayWithSchema:\n" +
+                "      type: array\n" +
+                "      items:\n" +
+                "        type: integer\n" +
+                "      writeOnly: true"
+        );
     }
 
     public static class ByteObject {
@@ -50,6 +59,16 @@ public class ByteObjectOAS31Test extends SwaggerTestBase {
                 format = "byte"
         )
         private byte primitiveWithSchemaTypeAndFormat;
+
+        private byte[] primitiveArrayWithoutSchema;
+
+        @ArraySchema(
+                schema = @Schema(
+                        type = "string",
+                        format = "byte"
+                )
+        )
+        private byte[] primitiveArrayWithSchema;
 
         public byte primitiveWithoutSchema() {
             return primitiveWithoutSchema;
@@ -73,6 +92,22 @@ public class ByteObjectOAS31Test extends SwaggerTestBase {
 
         public void setPrimitiveWithSchemaTypeAndFormat(byte primitiveWithSchemaTypeAndFormat) {
             this.primitiveWithSchemaTypeAndFormat = primitiveWithSchemaTypeAndFormat;
+        }
+
+        public byte[] primitiveArrayWithoutSchema() {
+            return primitiveArrayWithoutSchema;
+        }
+
+        public void setPrimitiveArrayWithoutSchema(byte[] primitiveArrayWithoutSchema) {
+            this.primitiveArrayWithoutSchema = primitiveArrayWithoutSchema;
+        }
+
+        public byte[] primitiveArrayWithSchema() {
+            return primitiveArrayWithSchema;
+        }
+
+        public void setPrimitiveArrayWithSchema(byte[] primitiveArrayWithSchema) {
+            this.primitiveArrayWithSchema = primitiveArrayWithSchema;
         }
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ByteObjectOAS31Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ByteObjectOAS31Test.java
@@ -1,0 +1,78 @@
+package io.swagger.v3.core.resolving.v31;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.core.resolving.SwaggerTestBase;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class ByteObjectOAS31Test extends SwaggerTestBase {
+
+    @Test(description = "Test ByteObject schema generation with OAS 3.1")
+    public void testByteObjectSchemaOAS31() {
+        final ModelResolver modelResolver = new ModelResolver(mapper()).openapi31(true);
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        io.swagger.v3.oas.models.media.Schema model = context.resolve(new AnnotatedType(ByteObject.class));
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> definedModels = context.getDefinedModels();
+
+        SerializationMatchers.assertEqualsToYaml31(definedModels, "ByteObject:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    primitiveWithoutSchema:\n" +
+                "      type: integer\n" +
+                "      format: int8\n" +
+                "      writeOnly: true\n" +
+                "    primitiveWithSchema:\n" +
+                "      type: integer\n" +
+                "      format: int8\n" +
+                "      writeOnly: true\n" +
+                "    primitiveWithSchemaTypeAndFormat:\n" +
+                "      type: integer\n" +
+                "      format: int8\n" +
+                "      writeOnly: true");
+    }
+
+    public static class ByteObject {
+
+        private byte primitiveWithoutSchema;
+
+        @Schema
+        private byte primitiveWithSchema;
+
+        @Schema(
+                type = "string",
+                format = "byte"
+        )
+        private byte primitiveWithSchemaTypeAndFormat;
+
+        public byte primitiveWithoutSchema() {
+            return primitiveWithoutSchema;
+        }
+
+        public byte primitiveWithSchema() {
+            return primitiveWithSchema;
+        }
+
+        public byte primitiveWithSchemaTypeAndFormat() {
+            return primitiveWithSchemaTypeAndFormat;
+        }
+
+        public void setPrimitiveWithoutSchema(byte primitiveWithoutSchema) {
+            this.primitiveWithoutSchema = primitiveWithoutSchema;
+        }
+
+        public void setPrimitiveWithSchema(byte primitiveWithSchema) {
+            this.primitiveWithSchema = primitiveWithSchema;
+        }
+
+        public void setPrimitiveWithSchemaTypeAndFormat(byte primitiveWithSchemaTypeAndFormat) {
+            this.primitiveWithSchemaTypeAndFormat = primitiveWithSchemaTypeAndFormat;
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes: https://github.com/springdoc/springdoc-openapi/issues/3052

This PR fixes an incorrect type mapping for Byte class in OpenAPI 3.1 schema generation.

**Problem**: The createProperty31() method in the BYTE enum was incorrectly returning a JsonSchema with type "string" and format "byte", which is not compliant with OpenAPI 3.1 specification.

**Solution**: Changed the type from "string" to "integer" for proper byte representation in OpenAPI 3.1. The byte type in OpenAPI 3.1 should be represented as an integer type, not a string with byte format.


## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [ ] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->

<img width="1519" height="171" alt="image" src="https://github.com/user-attachments/assets/909b4d63-9b18-4c08-a186-801c287a86e6" />

The image above is the image referenced by [Micronut Docs](https://micronaut-projects.github.io/micronaut-openapi/latest/guide/#:~:text=Byte%20(type%3A%20integer%2C%20x%2Dformat%3A%20int8)%2C).