### PR TITLE
Fix a non-deterministic assertion in ServletUtilsTest

### DIFF
--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/util/ServletUtilsTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/util/ServletUtilsTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertNotNull;
 
 public class ServletUtilsTest {
@@ -25,7 +26,8 @@ public class ServletUtilsTest {
         assertEquals(multivaluedMap.size(), 2);
         assertEquals(multivaluedMap.get("key1").size(), 2);
         assertEquals(multivaluedMap.get("key2").size(), 4);
-        assertEquals(multivaluedMap.keySet().iterator().next(), "key1");
+        assertTrue(multivaluedMap.containsKey("key1"));
+        assertTrue(multivaluedMap.containsKey("key1"));
     }
 
     @Test(description = "convert query parameters to multivaluedmap with decoded values")


### PR DESCRIPTION
## Description

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->
Problem: The test io.swagger.v3.jaxrs2.util.ServletUtilsTest.convertWithRightOutputSize can fail intermittently because multivaluedMap.keySet() does not guarantee the order of the keys.This non-deterministic behavior was detected using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. This pull request is for a simple fix to make the test deterministic.

Reference: https://docs.oracle.com/javaee/7/api/javax/ws/rs/core/MultivaluedHashMap.html

Fixes: This PR replaces the order-dependent assertion with a robust check that verifies the presence of the expected keys. By using assertTrue(multivaluedMap.containsKey("key1")) and assertTrue(multivaluedMap.containsKey("key2")), the test correctly validates the map's contents without relying on iteration order, making it deterministic and reliable.
## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [ ] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->
Log from NonDex:
[ERROR] Failures: 
[ERROR]   ServletUtilsTest.convertWithRightOutputSize:29 expected [key1] but found [key2]
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0