### PR TITLE
feat: Infer discriminator mapping

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -16,8 +16,10 @@ import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyMetadata;
+import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.introspect.Annotated;
@@ -28,6 +30,8 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMethod;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.fasterxml.jackson.databind.introspect.POJOPropertyBuilder;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import com.fasterxml.jackson.databind.util.Annotations;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
@@ -967,7 +971,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             model.setDiscriminator(null);
         }
 
-        Discriminator discriminator = resolveDiscriminator(type, context);
+        Discriminator discriminator = resolveDiscriminator(model, beanDesc, context, annotatedType.getJsonViewAnnotation());
         if (discriminator != null) {
             model.setDiscriminator(discriminator);
         }
@@ -2668,22 +2672,63 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         return null;
     }
 
+    protected TypeSerializer getTypeSerializer(JavaType type) {
+        SerializationConfig config = _mapper.getSerializationConfig();
+
+        try {
+            return _mapper.getSerializerFactory().createTypeSerializer(
+                    config, type
+            );
+        } catch (JsonMappingException e) {
+            LOGGER.error("Unable to create type serializer", e);
+        }
+
+        return null;
+    }
+
+    protected TypeSerializer getTypeSerializerForDiscriminatorInference(JavaType type) {
+        // longer method would involve AnnotationIntrospector.findTypeResolver(...) but:
+        JsonTypeInfo typeInfo = type.getRawClass().getDeclaredAnnotation(JsonTypeInfo.class);
+        if (typeInfo == null || typeInfo.use() == JsonTypeInfo.Id.NONE) {
+            return null;
+        }
+
+        TypeSerializer serializer = getTypeSerializer(type);
+        if (serializer == null) {
+            return null;
+        }
+
+        JsonTypeInfo.As include = serializer.getTypeInclusion();
+        if (
+                !(
+                        include == JsonTypeInfo.As.PROPERTY
+                                || include == JsonTypeInfo.As.EXISTING_PROPERTY
+                                || include == JsonTypeInfo.As.WRAPPER_OBJECT
+                )
+        ) {
+            return null;
+        }
+
+        return serializer;
+    }
+
     protected void resolveDiscriminatorProperty(JavaType type, ModelConverterContext context, Schema model) {
         // add JsonTypeInfo.property if not member of bean
-        JsonTypeInfo typeInfo = type.getRawClass().getDeclaredAnnotation(JsonTypeInfo.class);
-        if (typeInfo != null) {
-            String typeInfoProp = typeInfo.property();
-            if (StringUtils.isNotBlank(typeInfoProp)) {
-                Schema modelToUpdate = model;
-                if (StringUtils.isNotBlank(model.get$ref())) {
-                    modelToUpdate = context.getDefinedModels().get(model.get$ref().substring(SCHEMA_COMPONENT_PREFIX));
-                }
-                if (modelToUpdate.getProperties() == null || !modelToUpdate.getProperties().keySet().contains(typeInfoProp)) {
-                    Schema discriminatorSchema = openapi31 ? new JsonSchema().typesItem("string").name(typeInfoProp) : new StringSchema().name(typeInfoProp);
-                    modelToUpdate.addProperties(typeInfoProp, discriminatorSchema);
-                    if (modelToUpdate.getRequired() == null || !modelToUpdate.getRequired().contains(typeInfoProp)) {
-                        modelToUpdate.addRequiredItem(typeInfoProp);
-                    }
+        TypeSerializer serializer = getTypeSerializerForDiscriminatorInference(type);
+        if (serializer == null) {
+            return;
+        }
+        String propertyName = serializer.getPropertyName();
+        if (StringUtils.isNotBlank(propertyName)) {
+            Schema modelToUpdate = model;
+            if (StringUtils.isNotBlank(model.get$ref())) {
+                modelToUpdate = context.getDefinedModels().get(model.get$ref().substring(SCHEMA_COMPONENT_PREFIX));
+            }
+            if (modelToUpdate.getProperties() == null || !modelToUpdate.getProperties().keySet().contains(propertyName)) {
+                Schema discriminatorSchema = openapi31 ? new JsonSchema().typesItem("string").name(propertyName) : new StringSchema().name(propertyName);
+                modelToUpdate.addProperties(propertyName, discriminatorSchema);
+                if (modelToUpdate.getRequired() == null || !modelToUpdate.getRequired().contains(propertyName)) {
+                    modelToUpdate.addRequiredItem(propertyName);
                 }
             }
         }
@@ -2722,23 +2767,23 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         return model;
     }
 
-    protected Discriminator resolveDiscriminator(JavaType type, ModelConverterContext context) {
+    protected Discriminator resolveDiscriminator(Schema model, BeanDescription bean, ModelConverterContext context, JsonView jsonViewAnnotation) {
+        io.swagger.v3.oas.annotations.media.Schema declaredSchemaAnnotation = AnnotationsUtils.getSchemaDeclaredAnnotation(bean.getType().getRawClass());
 
-        io.swagger.v3.oas.annotations.media.Schema declaredSchemaAnnotation = AnnotationsUtils.getSchemaDeclaredAnnotation(type.getRawClass());
+        if (declaredSchemaAnnotation != null) {
+            String propertyName = declaredSchemaAnnotation.discriminatorProperty();
 
-        String disc = (declaredSchemaAnnotation == null) ? "" : declaredSchemaAnnotation.discriminatorProperty();
-
-        if (disc.isEmpty()) {
-            // longer method would involve AnnotationIntrospector.findTypeResolver(...) but:
-            JsonTypeInfo typeInfo = type.getRawClass().getDeclaredAnnotation(JsonTypeInfo.class);
-            if (typeInfo != null) {
-                disc = typeInfo.property();
+            if (StringUtils.isBlank(propertyName)) {
+                TypeSerializer serializer = getTypeSerializerForDiscriminatorInference(bean.getType());
+                if (serializer == null) {
+                    return null;
+                }
+                propertyName = serializer.getPropertyName();
             }
-        }
-        if (!disc.isEmpty()) {
-            Discriminator discriminator = new Discriminator()
-                    .propertyName(disc);
-            if (declaredSchemaAnnotation != null) {
+
+            if (StringUtils.isNotBlank(propertyName)) {
+                Discriminator discriminator = new Discriminator().propertyName(propertyName);
+
                 DiscriminatorMapping[] mappings = declaredSchemaAnnotation.discriminatorMapping();
                 if (mappings != null && mappings.length > 0) {
                     for (DiscriminatorMapping mapping : mappings) {
@@ -2747,11 +2792,62 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                         }
                     }
                 }
-            }
 
-            return discriminator;
+                return discriminator;
+            }
         }
-        return null;
+
+        TypeSerializer serializer = getTypeSerializerForDiscriminatorInference(bean.getType());
+        if (serializer == null) {
+            return null;
+        }
+        String propertyName = serializer.getPropertyName();
+        if (StringUtils.isBlank(propertyName)) {
+            return null;
+        }
+
+        Discriminator discriminator = new Discriminator().propertyName(propertyName);
+
+        // Use same approach to finding subtypes as resolveSubtypes, mimicking
+        final List<NamedType> subTypes = _intr().findSubtypes(bean.getClassInfo());
+        if (subTypes == null) {
+            return null;
+        }
+
+        removeSuperClassAndInterfaceSubTypes(subTypes, bean);
+
+        final Class<?> beanClass = bean.getClassInfo().getAnnotated();
+        if (!subTypes.isEmpty()) {
+            TypeIdResolver resolver = serializer.getTypeIdResolver();
+
+            for (NamedType subType : subTypes) {
+                final Class<?> subtypeType = subType.getType();
+                if (!beanClass.isAssignableFrom(subtypeType)) {
+                    continue;
+                }
+
+                String subTypeName = resolver.idFromValueAndType(null, subType.getType());
+
+                final Schema subtypeModel = context.resolve(new AnnotatedType()
+                        .type(subtypeType)
+                        .jsonViewAnnotation(jsonViewAnnotation)
+                        .subtype(true));
+
+                if (StringUtils.isBlank(subtypeModel.getName()) ||
+                        subtypeModel.getName().equals(model.getName())) {
+                    subtypeModel.setName(_typeNameResolver.nameForType(_mapper.constructType(subtypeType),
+                            TypeNameResolver.Options.SKIP_API_MODEL));
+                }
+
+                // Per the specification, there is an implicit map to schemas with the same name
+                // We skip writing the mappings that are implied to keep the schema minimal
+                if (!subTypeName.equals(subtypeModel.getName())) {
+                    discriminator.mapping(subTypeName, RefUtils.constructRef(subtypeModel.getName()));
+                }
+            }
+        }
+
+        return discriminator;
     }
 
     protected XML resolveXml(Annotated a, Annotation[] annotations, io.swagger.v3.oas.annotations.media.Schema schema) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/CompositionTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/CompositionTest.java
@@ -2,12 +2,11 @@ package io.swagger.v3.core.converting;
 
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.matchers.SerializationMatchers;
-import io.swagger.v3.core.oas.models.composition.AbstractBaseModelWithoutFields;
-import io.swagger.v3.core.oas.models.composition.Animal;
-import io.swagger.v3.core.oas.models.composition.AnimalClass;
-import io.swagger.v3.core.oas.models.composition.AnimalWithSchemaSubtypes;
-import io.swagger.v3.core.oas.models.composition.Human;
-import io.swagger.v3.core.oas.models.composition.ModelWithFieldWithSubTypes;
+import io.swagger.v3.core.oas.models.composition.*;
+import io.swagger.v3.core.oas.models.composition.discriminator.ModelWithDefaultPropertyName;
+import io.swagger.v3.core.oas.models.composition.discriminator.ModelWithDiscriminatorMapping;
+import io.swagger.v3.core.oas.models.composition.discriminator.ModelWithProvidedDiscriminatorMapping;
+import io.swagger.v3.core.oas.models.composition.discriminator.ModelWithoutTypeInfo;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.ResourceUtils;
 import io.swagger.v3.oas.models.media.Schema;
@@ -46,6 +45,26 @@ public class CompositionTest {
     @Test(description = "create a ModelWithFieldWithSubTypes")
     public void createModelWithFieldWithSubTypes() throws IOException {
         compareAsJson(ModelWithFieldWithSubTypes.class, "ModelWithFieldWithSubTypes.json");
+    }
+
+    @Test(description = "create a ModelWithDiscriminatorMapping")
+    public void createModelWithDiscriminatorMapping() throws IOException {
+        compareAsJson(ModelWithDiscriminatorMapping.class, "ModelWithDiscriminatorMapping.json");
+    }
+
+    @Test(description = "create a ModelWithDefaultProperty")
+    public void createModelWithDefaultProperty() throws IOException {
+        compareAsJson(ModelWithDefaultPropertyName.class, "ModelWithDefaultProperty.json");
+    }
+
+    @Test(description = "create a ModelWithoutTypeInfo")
+    public void createModelWithoutTypeInfo() throws IOException {
+        compareAsJson(ModelWithoutTypeInfo.class, "ModelWithoutTypeInfo.json");
+    }
+
+    @Test(description = "create a createModelWithProvidedDiscriminatorMapping")
+    public void createModelWithProvidedDiscriminatorMapping() throws IOException {
+        compareAsJson(ModelWithProvidedDiscriminatorMapping.class, "ModelWithProvidedDiscriminatorMapping.json");
     }
 
     private void compareAsJson(Class<?> cls, String fileName) throws IOException {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/composition/discriminator/ModelWithDefaultPropertyName.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/composition/discriminator/ModelWithDefaultPropertyName.java
@@ -1,0 +1,29 @@
+package io.swagger.v3.core.oas.models.composition.discriminator;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeInfo(use= JsonTypeInfo.Id.SIMPLE_NAME, include = JsonTypeInfo.As.PROPERTY)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ModelWithDefaultPropertyName.First.class),
+        @JsonSubTypes.Type(value = ModelWithDefaultPropertyName.Second.class, name = "SecondType"),
+})
+public class ModelWithDefaultPropertyName {
+
+    public static class First extends ModelWithDefaultPropertyName {
+        private String name;
+
+        public String getName() { return name; }
+
+        public void setName(String name) { this.name = name; }
+    }
+
+    public static class Second extends ModelWithDefaultPropertyName {
+        private String value;
+
+        public String getValue() { return value; }
+
+        public void setValue(String value) { this.value = value; }
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/composition/discriminator/ModelWithDiscriminatorMapping.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/composition/discriminator/ModelWithDiscriminatorMapping.java
@@ -1,0 +1,39 @@
+package io.swagger.v3.core.oas.models.composition.discriminator;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeInfo(use= JsonTypeInfo.Id.SIMPLE_NAME, include = JsonTypeInfo.As.PROPERTY, property="kind")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ModelWithDiscriminatorMapping.First.class),
+        @JsonSubTypes.Type(value = ModelWithDiscriminatorMapping.Second.class, name = "SecondType"),
+        @JsonSubTypes.Type(value = ModelWithDiscriminatorMapping.Third.class)
+})
+public class ModelWithDiscriminatorMapping {
+
+    public static class First extends ModelWithDiscriminatorMapping {
+        private String name;
+
+        public String getName() { return name; }
+
+        public void setName(String name) { this.name = name; }
+    }
+
+    public static class Second extends ModelWithDiscriminatorMapping {
+        private String value;
+
+        public String getValue() { return value; }
+
+        public void setValue(String value) { this.value = value; }
+    }
+
+    @JsonTypeName("ThirdType")
+    public static class Third extends ModelWithDiscriminatorMapping {
+        private String value;
+
+        public String getValue() { return value; }
+
+        public void setValue(String value) { this.value = value; }
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/composition/discriminator/ModelWithProvidedDiscriminatorMapping.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/composition/discriminator/ModelWithProvidedDiscriminatorMapping.java
@@ -1,0 +1,36 @@
+package io.swagger.v3.core.oas.models.composition.discriminator;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonTypeInfo(use= JsonTypeInfo.Id.SIMPLE_NAME, include = JsonTypeInfo.As.PROPERTY, property="kind")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ModelWithProvidedDiscriminatorMapping.First.class),
+    @JsonSubTypes.Type(value = ModelWithProvidedDiscriminatorMapping.Second.class),
+})
+@Schema(
+    discriminatorMapping = {
+        @DiscriminatorMapping(schema = ModelWithProvidedDiscriminatorMapping.First.class, value = "FirstOne"),
+        @DiscriminatorMapping(schema = ModelWithProvidedDiscriminatorMapping.Second.class, value = "SecondOne"),
+    }
+)
+public class ModelWithProvidedDiscriminatorMapping {
+
+    public static class First extends ModelWithProvidedDiscriminatorMapping {
+        private String name;
+
+        public String getName() { return name; }
+
+        public void setName(String name) { this.name = name; }
+    }
+
+    public static class Second extends ModelWithProvidedDiscriminatorMapping {
+        private String value;
+
+        public String getValue() { return value; }
+
+        public void setValue(String value) { this.value = value; }
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/composition/discriminator/ModelWithoutTypeInfo.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/composition/discriminator/ModelWithoutTypeInfo.java
@@ -1,0 +1,28 @@
+package io.swagger.v3.core.oas.models.composition.discriminator;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use= JsonTypeInfo.Id.NONE)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ModelWithoutTypeInfo.First.class),
+        @JsonSubTypes.Type(value = ModelWithoutTypeInfo.Second.class, name = "SecondType"),
+})
+public class ModelWithoutTypeInfo {
+
+    public static class First extends ModelWithoutTypeInfo {
+        private String name;
+
+        public String getName() { return name; }
+
+        public void setName(String name) { this.name = name; }
+    }
+
+    public static class Second extends ModelWithoutTypeInfo {
+        private String value;
+
+        public String getValue() { return value; }
+
+        public void setValue(String value) { this.value = value; }
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket2189Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket2189Test.java
@@ -31,12 +31,18 @@ public class Ticket2189Test extends SwaggerTestBase {
         final Schema model = context.resolve(new AnnotatedType(BaseClass.class));
         assertNotNull(model);
         String yaml = "BaseClass:\n" +
+                      "  required:\n" +
+                      "  - '@type'\n" +
                       "  type: object\n" +
                       "  properties:\n" +
                       "    property:\n" +
                       "      type: string\n" +
                       "    type:\n" +
                       "      type: string\n" +
+                      "    '@type':\n" +
+                      "      type: string\n" +
+                      "  discriminator:\n" +
+                      "    propertyName: '@type'\n" +
                       "SubClass:\n" +
                       "  type: object\n" +
                       "  allOf:\n" +

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3853Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket3853Test.java
@@ -31,12 +31,21 @@ public class Ticket3853Test extends SwaggerTestBase {
 
         assertNotNull(model);
         String yaml = "io.swagger.v3.core.resolving.Ticket3853Test$BaseClass:\n" +
+                "  required:\n" +
+                "  - '@type'\n" +
                 "  type: object\n" +
                 "  properties:\n" +
                 "    property:\n" +
                 "      type: string\n" +
                 "    type:\n" +
                 "      type: string\n" +
+                "    '@type':\n" +
+                "      type: string\n" +
+                "  discriminator:\n" +
+                "    propertyName: '@type'\n" +
+                "    mapping:\n" +
+                "      SubClass: \"#/components/schemas/io.swagger.v3.core.resolving.Ticket3853Test$SubClass\"\n" +
+                "      BaseClass: \"#/components/schemas/io.swagger.v3.core.resolving.Ticket3853Test$BaseClass\"\n" +
                 "io.swagger.v3.core.resolving.Ticket3853Test$SubClass:\n" +
                 "  type: object\n" +
                 "  allOf:\n" +

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4239Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4239Test.java
@@ -66,10 +66,17 @@ public class Ticket4239Test extends SwaggerTestBase {
             "      a1_out:\n" +
             "        type: string\n" +
             "A_Output:\n" +
+            "  required:\n" +
+            "  - '@type'\n" +
             "  type: object\n" +
             "  properties:\n" +
             "    a_out:\n" +
-            "      type: string\n");
-
+            "      type: string\n" +
+            "    '@type':\n" +
+            "      type: string\n" +
+            "  discriminator:\n" +
+            "    propertyName: '@type'\n" +
+            "    mapping:\n" +
+            "      Ticket4239Test$A1: \"#/components/schemas/A1_Output\"\n");
     }
 }

--- a/modules/swagger-core/src/test/resources/Animal.json
+++ b/modules/swagger-core/src/test/resources/Animal.json
@@ -9,8 +9,12 @@
                 "type": "string"
             }
         },
-        "discriminator" : {
-            "propertyName" : "type"
+        "discriminator": {
+            "propertyName": "type",
+            "mapping": {
+                "human": "#/components/schemas/Human",
+                "pet": "#/components/schemas/Pet"
+            }
         }
     },
     "Human": {

--- a/modules/swagger-core/src/test/resources/AnimalClass.json
+++ b/modules/swagger-core/src/test/resources/AnimalClass.json
@@ -9,8 +9,12 @@
                 "type": "string"
             }
         },
-        "discriminator" : {
-            "propertyName" : "type"
+        "discriminator": {
+            "propertyName": "type",
+            "mapping": {
+                "human": "#/components/schemas/HumanClass",
+                "pet": "#/components/schemas/PetClass"
+            }
         }
     },
     "HumanClass": {

--- a/modules/swagger-core/src/test/resources/AnimalWithSchemaSubtypes.json
+++ b/modules/swagger-core/src/test/resources/AnimalWithSchemaSubtypes.json
@@ -9,8 +9,8 @@
                 "type": "string"
             }
         },
-        "discriminator" : {
-            "propertyName" : "type"
+        "discriminator": {
+            "propertyName": "type"
         }
     },
     "HumanWithSchemaSubtypes": {

--- a/modules/swagger-core/src/test/resources/ModelWithDefaultProperty.json
+++ b/modules/swagger-core/src/test/resources/ModelWithDefaultProperty.json
@@ -1,0 +1,46 @@
+{
+  "First" : {
+    "type" : "object",
+    "allOf" : [ {
+      "$ref" : "#/components/schemas/ModelWithDefaultPropertyName"
+    }, {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        }
+      }
+    } ]
+  },
+  "ModelWithDefaultPropertyName" : {
+    "required" : [ "@type" ],
+    "type" : "object",
+    "properties" : {
+      "@type" : {
+        "type" : "string"
+      }
+    },
+    "discriminator" : {
+      "propertyName" : "@type",
+      "mapping" : {
+        "SecondType" : "#/components/schemas/Second"
+      }
+    }
+  },
+  "Second" : {
+    "type": "object",
+    "allOf": [
+      {
+        "$ref": "#/components/schemas/ModelWithDefaultPropertyName"
+      },
+      {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/modules/swagger-core/src/test/resources/ModelWithDiscriminatorMapping.json
+++ b/modules/swagger-core/src/test/resources/ModelWithDiscriminatorMapping.json
@@ -1,0 +1,60 @@
+{
+  "First" : {
+    "type" : "object",
+    "allOf" : [ {
+      "$ref" : "#/components/schemas/ModelWithDiscriminatorMapping"
+    }, {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        }
+      }
+    } ]
+  },
+  "ModelWithDiscriminatorMapping" : {
+    "required" : [ "kind" ],
+    "type" : "object",
+    "properties" : {
+      "kind" : {
+        "type" : "string"
+      }
+    },
+    "discriminator" : {
+      "propertyName" : "kind",
+      "mapping" : {
+        "SecondType" : "#/components/schemas/Second",
+        "ThirdType" : "#/components/schemas/Third"
+      }
+    }
+  },
+  "Second" : {
+    "type": "object",
+    "allOf": [
+      {
+        "$ref": "#/components/schemas/ModelWithDiscriminatorMapping"
+      },
+      {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    ]
+  },
+  "Third" : {
+    "type" : "object",
+    "allOf" : [ {
+      "$ref" : "#/components/schemas/ModelWithDiscriminatorMapping"
+    }, {
+      "type" : "object",
+      "properties" : {
+        "value" : {
+          "type" : "string"
+        }
+      }
+    } ]
+  }
+}

--- a/modules/swagger-core/src/test/resources/ModelWithProvidedDiscriminatorMapping.json
+++ b/modules/swagger-core/src/test/resources/ModelWithProvidedDiscriminatorMapping.json
@@ -1,0 +1,47 @@
+{
+  "First" : {
+    "type" : "object",
+    "allOf" : [ {
+      "$ref" : "#/components/schemas/ModelWithProvidedDiscriminatorMapping"
+    }, {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        }
+      }
+    } ]
+  },
+  "ModelWithProvidedDiscriminatorMapping" : {
+    "required" : [ "kind" ],
+    "type" : "object",
+    "properties" : {
+      "kind" : {
+        "type" : "string"
+      }
+    },
+    "discriminator" : {
+      "propertyName" : "kind",
+      "mapping" : {
+        "FirstOne" : "#/components/schemas/First",
+        "SecondOne" : "#/components/schemas/Second"
+      }
+    }
+  },
+  "Second" : {
+    "type": "object",
+    "allOf": [
+      {
+        "$ref": "#/components/schemas/ModelWithProvidedDiscriminatorMapping"
+      },
+      {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/modules/swagger-core/src/test/resources/ModelWithoutTypeInfo.json
+++ b/modules/swagger-core/src/test/resources/ModelWithoutTypeInfo.json
@@ -1,0 +1,34 @@
+{
+  "First" : {
+    "type" : "object",
+    "allOf" : [ {
+      "$ref" : "#/components/schemas/ModelWithoutTypeInfo"
+    }, {
+      "type" : "object",
+      "properties" : {
+        "name" : {
+          "type" : "string"
+        }
+      }
+    } ]
+  },
+  "ModelWithoutTypeInfo" : {
+    "type" : "object"
+  },
+  "Second" : {
+    "type": "object",
+    "allOf": [
+      {
+        "$ref": "#/components/schemas/ModelWithoutTypeInfo"
+      },
+      {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

This PR adds inference of discriminator mappings when an explicit mapping is not present, which should greatly reduce the need for explicit `@DiscriminatorMapping` annotations and make it easier to keep the mapping in sync.

The basic theme of the approach is to leave as much resolving to Jackson as possible. This is done by instantiating a type serializer for the class, and letting Jackson compute the ids used in the mapping. This means that type ids from all the following sources are supported

 - name field in `@JsonSubTypes.Type` annotations
 - `@JsonTypeName` annotations
 - Mechanisms given by `JsonTypeInfo.Id` in `@JsonTypeInfo` annotations

It also means we support things such as default property names when no property value is set on the `@JsonTypeInfo` annotation (`@type`) and the fallback to `JsonTypeInfo.As.PROPERTY` when `JsonTypeInfo.As.EXTERNAL_PROPERTY` is used on a class.

It tries to be conservative and add only a discriminator mapping when it is applicable, e.g. not for `JsonTypeInfo.As.WRAPPER_ARRAY`. It keeps the old behaviour of using an explicit discriminator mapping if present.

The main `resolveDiscriminator` do have a new signature, which is a breaking change for those subclassing and overriding. The new signature should be sensible as it matches that of `resolveSubtypes`, and resolving subtypes is similar to determining the discriminator mappings. It is tricky to keep this backwards compatible while still making it handle the more general cases, but migration path is super easy and hopefully most overriding is not needed any more. The beanDesc can be recomputed, but getting the jsonViewAnnotation is trickier.

I've also tested that it works on the Jackson 2.8 version. Despite the readme mentioning support from 2.4 and newer, the model resolver uses functionality in Jackson only available from 2.8, so I assumed that sufficed.

Closes: https://github.com/swagger-api/swagger-core/issues/3411

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->