### PR TITLE
Issue 4993

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -819,7 +819,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 });
 
                 boolean areSiblingsAllowed = AnnotationsUtils.areSiblingsAllowed(resolvedSchemaResolution, openapi31);
-                aType = AnnotationsUtils.addTypeWhenSiblingsAllowed(aType, ctxSchema, areSiblingsAllowed);
+                aType = AnnotationsUtils.addTypeWhenSiblingsAllowed(aType, ctxArraySchema, ctxSchema, areSiblingsAllowed);
                 property = context.resolve(aType);
                 property = clone(property);
                 Schema ctxProperty = null;

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -2930,14 +2930,33 @@ public abstract class AnnotationsUtils {
         return Schema.SchemaResolution.ALL_OF.equals(resolvedSchemaResolution) || Schema.SchemaResolution.ALL_OF_REF.equals(resolvedSchemaResolution) || openapi31;
     }
 
-    public static AnnotatedType addTypeWhenSiblingsAllowed(AnnotatedType aType, io.swagger.v3.oas.annotations.media.Schema ctxSchema, boolean areSiblingsAllowed) {
-        if (areSiblingsAllowed && ctxSchema != null) {
-            if (!Void.class.equals(ctxSchema.implementation())) {
-                aType.setType(ctxSchema.implementation());
-            } else if (StringUtils.isNotBlank(ctxSchema.type())) {
-                aType.setType(ctxSchema.type().getClass());
-            }
+    public static AnnotatedType addTypeWhenSiblingsAllowed(AnnotatedType aType, io.swagger.v3.oas.annotations.media.ArraySchema ctxArraySchema, io.swagger.v3.oas.annotations.media.Schema ctxSchema, boolean areSiblingsAllowed) {
+        if (!areSiblingsAllowed) {
+            return aType;
+        }
+
+        io.swagger.v3.oas.annotations.media.Schema schema = getEffectiveSchema(ctxArraySchema, ctxSchema);
+        if (schema != null) {
+            setTypeFromSchema(aType, schema);
         }
         return aType;
+    }
+
+    private static io.swagger.v3.oas.annotations.media.Schema getEffectiveSchema(io.swagger.v3.oas.annotations.media.ArraySchema ctxArraySchema, io.swagger.v3.oas.annotations.media.Schema ctxSchema) {
+        if (ctxSchema != null) {
+            return ctxSchema;
+        }
+        if (ctxArraySchema != null) {
+            return ctxArraySchema.schema();
+        }
+        return null;
+    }
+
+    private static void setTypeFromSchema(AnnotatedType aType, io.swagger.v3.oas.annotations.media.Schema schema) {
+        if (!Void.class.equals(schema.implementation())) {
+            aType.setType(schema.implementation());
+        } else if (StringUtils.isNotBlank(schema.type())) {
+            aType.setType(schema.type().getClass());
+        }
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/Ticket4993Test.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/Ticket4993Test.java
@@ -1,0 +1,154 @@
+package io.swagger.v3.jaxrs2;
+
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+
+public class Ticket4993Test {
+
+    @Schema(description = "User resource")
+    static class User {
+        private List<Thing> things;
+
+        @ArraySchema(
+                arraySchema = @Schema(
+                        description = "List of Things assigned to the user",
+                        requiredMode = RequiredMode.REQUIRED
+                ),
+                schema = @Schema(implementation = Thing.ThingAssignment.class)
+        )
+        public List<Thing> getThings() {
+            return things;
+        }
+    }
+
+    @Schema(description = "Thing resource")
+    static class Thing {
+        @Schema(description = "Thing to be assigned to user")
+        static class ThingAssignment extends Thing {
+        }
+    }
+
+    @Schema(description = "User resource (no override)")
+    static class UserNoOverride {
+        private List<Thing> things;
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "List of Things assigned to the user",
+                        requiredMode = RequiredMode.REQUIRED)
+        )
+        public List<Thing> getThings() {
+            return things;
+        }
+    }
+
+    @Test
+    void arrayItems_useOverrideClass_andOverrideIsPresentInComponents_oas30() {
+        ResolvedSchema rs = ModelConverters.getInstance()
+                .resolveAsResolvedSchema(new AnnotatedType(User.class).resolveAsRef(true));
+
+        assertNotNull(rs.schema, "User schema should be resolved");
+
+        @SuppressWarnings("rawtypes")
+        Map<String, io.swagger.v3.oas.models.media.Schema> refs = rs.referencedSchemas;
+        assertNotNull(refs, "referencedSchemas map must be present");
+        assertTrue(refs.containsKey("User"), "User schema should be in referencedSchemas");
+
+        io.swagger.v3.oas.models.media.Schema<?> userSchema = refs.get("User");
+
+        io.swagger.v3.oas.models.media.Schema<?> thingsProp =
+            (io.swagger.v3.oas.models.media.Schema<?>) userSchema.getProperties().get("things");
+        assertNotNull(thingsProp, "'things' property should exist on User");
+        io.swagger.v3.oas.models.media.Schema<?> items = thingsProp.getItems();
+        assertNotNull(items, "Array items must be present");
+        assertEquals(items.get$ref(), "#/components/schemas/ThingAssignment",
+                "Items $ref must point to the override class (ThingAssignment)");
+
+        assertTrue(refs.containsKey("ThingAssignment"),
+                "ThingAssignment must be included in components/schemas");
+    }
+
+    @Test
+    void arrayItems_useOverrideClass_andOverrideIsPresentInComponents_oas31() {
+        ResolvedSchema rs = ModelConverters.getInstance(true)
+                .resolveAsResolvedSchema(new AnnotatedType(User.class).resolveAsRef(true));
+
+        assertNotNull(rs.schema, "User schema should be resolved");
+
+        @SuppressWarnings("rawtypes")
+        Map<String, io.swagger.v3.oas.models.media.Schema> refs = rs.referencedSchemas;
+        assertNotNull(refs, "referencedSchemas map must be present");
+        assertTrue(refs.containsKey("User"), "User schema should be in referencedSchemas");
+
+        io.swagger.v3.oas.models.media.Schema<?> userSchema = refs.get("User");
+
+        io.swagger.v3.oas.models.media.Schema<?> thingsProp =
+            (io.swagger.v3.oas.models.media.Schema<?>) userSchema.getProperties().get("things");
+        assertNotNull(thingsProp, "'things' property should exist on User");
+
+        io.swagger.v3.oas.models.media.Schema<?> items = thingsProp.getItems();
+        assertNotNull(items, "Array items must be present");
+        assertEquals(items.get$ref(), "#/components/schemas/ThingAssignment",
+                "Items $ref must point to the override class (ThingAssignment)");
+
+        assertTrue(refs.containsKey("ThingAssignment"),
+                "ThingAssignment must be included in components/schemas");
+    }
+
+    @Test
+    void arrayItems_withoutOverride_fallBackToDeclaredGenericType_oas30() {
+        ResolvedSchema rs = ModelConverters.getInstance()
+                .resolveAsResolvedSchema(new AnnotatedType(UserNoOverride.class).resolveAsRef(true));
+
+        // then
+        @SuppressWarnings("rawtypes")
+        Map<String, io.swagger.v3.oas.models.media.Schema> refs = rs.referencedSchemas;
+        assertNotNull(refs, "referencedSchemas map must be present");
+        assertTrue(refs.containsKey("UserNoOverride"), "UserNoOverride schema should be in referencedSchemas");
+
+        io.swagger.v3.oas.models.media.Schema<?> userSchema = refs.get("UserNoOverride");
+
+        io.swagger.v3.oas.models.media.Schema<?> thingsProp =
+            (io.swagger.v3.oas.models.media.Schema<?>) userSchema.getProperties().get("things");
+
+        io.swagger.v3.oas.models.media.Schema<?> items = thingsProp.getItems();
+        assertEquals(items.get$ref(), "#/components/schemas/Thing",
+                "Without override, items $ref should resolve to the declared generic type (Thing)");
+        assertTrue(rs.referencedSchemas.containsKey("Thing"),
+                "'Thing' should be included in components/schemas");
+    }
+
+    @Test
+    void arrayItems_withoutOverride_fallBackToDeclaredGenericType_oas31() {
+        // when
+        ResolvedSchema rs = ModelConverters.getInstance(true)
+                .resolveAsResolvedSchema(new AnnotatedType(UserNoOverride.class).resolveAsRef(true));
+
+        // then
+        @SuppressWarnings("rawtypes")
+        Map<String, io.swagger.v3.oas.models.media.Schema> refs = rs.referencedSchemas;
+        assertNotNull(refs, "referencedSchemas map must be present");
+        assertTrue(refs.containsKey("UserNoOverride"), "UserNoOverride schema should be in referencedSchemas");
+
+        io.swagger.v3.oas.models.media.Schema<?> userSchema = refs.get("UserNoOverride");
+
+        io.swagger.v3.oas.models.media.Schema<?> thingsProp =
+            (io.swagger.v3.oas.models.media.Schema<?>) userSchema.getProperties().get("things");
+
+        io.swagger.v3.oas.models.media.Schema<?> items = thingsProp.getItems();
+        assertEquals(items.get$ref(), "#/components/schemas/Thing",
+                "Without override, items $ref should resolve to the declared generic type (Thing)");
+        assertTrue(rs.referencedSchemas.containsKey("Thing"),
+                "'Thing' should be included in components/schemas");
+    }
+}


### PR DESCRIPTION
Fixes: #4993 

The gap in resolving types of arraySchema implementation was caused in fix for prevent leaking properties to enum schema when Schema#implementation is set. (Issue #4800). To prevent leaking properties to enum schema the logic which copies the ctxAnnotations when type is overriden with implementation was deleted. Instead a more narrow solution of assigning type from schema had been implemented. However, this solution did not address assigning type from implementation for ArraySchema. 