### PR TITLE
bug fix propertyNames schema is not removed as unreferenced by SpecFilter #5017

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
@@ -330,6 +330,10 @@ public class SpecFilter {
             }
         }
 
+        if (schema.getPropertyNames() != null) {
+            addSchemaRef(schema.getPropertyNames(), referencedDefinitions);
+        }
+
         if (schema instanceof ArraySchema &&
                 ((ArraySchema) schema).getItems() != null) {
             addSchemaRef(((ArraySchema) schema).getItems(), referencedDefinitions);

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -96,6 +96,7 @@ import io.swagger.v3.jaxrs2.resources.Ticket4850Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket4859Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket4878Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket4879Resource;
+import io.swagger.v3.jaxrs2.resources.Ticket5017Resource;
 import io.swagger.v3.jaxrs2.resources.UploadResource;
 import io.swagger.v3.jaxrs2.resources.UrlEncodedResourceWithEncodings;
 import io.swagger.v3.jaxrs2.resources.UserAnnotationResource;
@@ -5609,5 +5610,62 @@ public class ReaderTest {
                 "email",
                 "Items format should come from schema.format"
         );
+    }
+
+    @Test
+    void testTicket5017() {
+        ModelResolver.enumsAsRef = true;
+        SwaggerConfiguration config = new SwaggerConfiguration().openAPI31(true);
+        Reader reader = new Reader(config);
+        OpenAPI openAPI = reader.read(Ticket5017Resource.class);
+
+        OpenAPISpecFilter filterImpl = new RemoveUnusedSchemasOAS31Filter();
+        SpecFilter f = new SpecFilter();
+        openAPI = f.filter(openAPI, filterImpl, null, null, null);
+
+        String yaml = "openapi: 3.1.0\n" +
+                "paths:\n" +
+                "  /test:\n" +
+                "    get:\n" +
+                "      operationId: myMethod\n" +
+                "      requestBody:\n" +
+                "        content:\n" +
+                "          '*/*':\n" +
+                "            schema:\n" +
+                "              $ref: \"#/components/schemas/Example\"\n" +
+                "      responses:\n" +
+                "        default:\n" +
+                "          description: default response\n" +
+                "          content:\n" +
+                "            '*/*': {}\n" +
+                "components:\n" +
+                "  schemas:\n" +
+                "    Example:\n" +
+                "      type: object\n" +
+                "      properties:\n" +
+                "        myMap:\n" +
+                "          type: object\n" +
+                "          additionalProperties:\n" +
+                "            type: string\n" +
+                "          propertyNames:\n" +
+                "            $ref: \"#/components/schemas/MyEnum\"\n" +
+                "    MyEnum:\n" +
+                "      type: string\n" +
+                "      enum:\n" +
+                "      - FOO\n" +
+                "      - BAR\n";
+        SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
+    }
+
+    static class RemoveUnusedSchemasOAS31Filter extends AbstractSpecFilter {
+        @Override
+        public boolean isRemovingUnreferencedDefinitions() {
+            return true;
+        }
+
+        @Override
+        public boolean isOpenAPI31Filter() {
+            return true;
+        }
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket5017Resource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket5017Resource.java
@@ -1,0 +1,30 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import java.util.Map;
+
+@Path("/test")
+public class Ticket5017Resource {
+    @GET
+    public void myMethod(Example request) {}
+
+    public static class Example {
+        @Schema(propertyNames = MyEnum.class)
+        private Map<MyEnum, String> myMap;
+
+        public Map<MyEnum, String> getMyMap() {
+            return myMap;
+        }
+
+        public void setMyMap(Map<MyEnum, String> myMap) {
+            this.myMap = myMap;
+        }
+    }
+
+    public enum MyEnum {
+        FOO, BAR
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Fixes: #5017 

Adding a check in specfilter to validate `Schema#propertyNames` is not empty and adding it to referenced schemas.

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)