### PR TITLE
refactor: add an overloaded method for resolving required so that the field type can be utilized

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -749,7 +749,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                                         (io.swagger.v3.oas.annotations.media.Schema) propSchemaOrArray;
 
                 io.swagger.v3.oas.annotations.media.Schema.AccessMode accessMode = resolveAccessMode(propDef, type, propResolvedSchemaAnnotation);
-                io.swagger.v3.oas.annotations.media.Schema.RequiredMode requiredMode = resolveRequiredMode(propResolvedSchemaAnnotation);
+                io.swagger.v3.oas.annotations.media.Schema.RequiredMode requiredMode = resolveRequiredMode(propResolvedSchemaAnnotation, propType);
 
                 Annotation[] ctxAnnotation31 = null;
                 Schema.SchemaResolution resolvedSchemaResolution = AnnotationsUtils.resolveSchemaResolution(this.schemaResolution, ctxSchema);
@@ -2458,6 +2458,12 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         return null;
     }
 
+    /**
+     * Resolve the required mode for a schema based upon the schema annotation.
+     *
+     * @param schema A schema annotation
+     * @return The resolved required mode for the schema
+     */
     protected io.swagger.v3.oas.annotations.media.Schema.RequiredMode resolveRequiredMode(io.swagger.v3.oas.annotations.media.Schema schema) {
         if (schema != null && !schema.requiredMode().equals(io.swagger.v3.oas.annotations.media.Schema.RequiredMode.AUTO)) {
             return schema.requiredMode();
@@ -2465,6 +2471,22 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             return io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
         }
         return io.swagger.v3.oas.annotations.media.Schema.RequiredMode.AUTO;
+    }
+
+    /**
+     * Resolve the required mode for a schema.
+     * <p>
+     * This method is provided as an extension point for subclasses.
+     * The default implementation ignores the {@link JavaType} parameter
+     * and delegates to {@link #resolveRequiredMode(io.swagger.v3.oas.annotations.media.Schema)}.
+     *
+     * @param schema A schema annotation
+     * @param type The JavaType of the field property that the annotation is tied to
+     * @return The resolved required mode for the schema
+     */
+    protected io.swagger.v3.oas.annotations.media.Schema.RequiredMode resolveRequiredMode(
+            io.swagger.v3.oas.annotations.media.Schema schema, JavaType type) {
+        return resolveRequiredMode(schema);
     }
 
     protected io.swagger.v3.oas.annotations.media.Schema.AccessMode resolveAccessMode(BeanPropertyDefinition propDef, JavaType type, io.swagger.v3.oas.annotations.media.Schema schema) {


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->

TL;DR:
Makes it possible to easily determine the required mode for a property based upon the class type. This is done by introducing an overloaded method `resolveRequiredMode` that also takes a `JavaType`, and then making the default behavior that the application passes the already accessible `propType` to the method.

----

This is a subject I have been asked about before both in [swagger-core](https://github.com/swagger-api/swagger-core/issues/5041) but also in [springdoc-openapi](https://github.com/springdoc/springdoc-openapi/issues/2926#issuecomment-2692842442).

There exists good documentation for how to achieve the change for the default for all (define a new `ModelResolver` and override the  `resolveRequiredMode` metod). But if we wanted to control it based upon the field/property type, we would have to override the entire `ModelResolver` and its 1000+ lines `resolve`-method. 

With this change we can rather go back to only overriding a small, clearly defined, part of the class to achieve the behavior. I have illustrated how this can be achieved in a test.

## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->