### PR TITLE
feat: add support for Positive, PositiveOrZero, Negative, and NegativeOrZero constraints in model validation

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -65,7 +65,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.media.UUIDSchema;
 import io.swagger.v3.oas.models.media.XML;
-import javax.validation.constraints.Email;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
@@ -80,6 +80,11 @@ import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Negative;
+import javax.validation.constraints.NegativeOrZero;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -1901,6 +1906,40 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 modified = true;
             }
         }
+        if (annos.containsKey("javax.validation.constraints.Positive")) {
+            Positive anno = (Positive) annos.get("javax.validation.constraints.Positive");
+            boolean apply = checkGroupValidation(anno.groups(), invocationGroups, acceptNoGroups);
+            if (apply && isNumberSchema(property)) {
+                property.setMinimum(BigDecimal.ZERO);
+                property.setExclusiveMinimum(true);
+                modified = true;
+            }
+        }
+        if (annos.containsKey("javax.validation.constraints.PositiveOrZero")) {
+            PositiveOrZero anno = (PositiveOrZero) annos.get("javax.validation.constraints.PositiveOrZero");
+            boolean apply = checkGroupValidation(anno.groups(), invocationGroups, acceptNoGroups);
+            if (apply && isNumberSchema(property)) {
+                property.setMinimum(BigDecimal.ZERO);
+                modified = true;
+            }
+        }
+        if (annos.containsKey("javax.validation.constraints.Negative")) {
+            Negative anno = (Negative) annos.get("javax.validation.constraints.Negative");
+            boolean apply = checkGroupValidation(anno.groups(), invocationGroups, acceptNoGroups);
+            if (apply && isNumberSchema(property)) {
+                property.setMaximum(BigDecimal.ZERO);
+                property.setExclusiveMaximum(true);
+                modified = true;
+            }
+        }
+        if (annos.containsKey("javax.validation.constraints.NegativeOrZero")) {
+            NegativeOrZero anno = (NegativeOrZero) annos.get("javax.validation.constraints.NegativeOrZero");
+            boolean apply = checkGroupValidation(anno.groups(), invocationGroups, acceptNoGroups);
+            if (apply && isNumberSchema(property)) {
+                property.setMaximum(BigDecimal.ZERO);
+                modified = true;
+            }
+        }
         if (annos.containsKey("javax.validation.constraints.Size")) {
             Size anno = (Size) annos.get("javax.validation.constraints.Size");
             boolean apply = checkGroupValidation(anno.groups(), invocationGroups, acceptNoGroups);
@@ -2014,6 +2053,32 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             if (isNumberSchema(property)) {
                 Max max = (Max) annos.get("javax.validation.constraints.Max");
                 property.setMaximum(new BigDecimal(max.value()));
+                modified = true;
+            }
+        }
+        if (annos.containsKey("javax.validation.constraints.Positive")) {
+            if (isNumberSchema(property)) {
+                property.setMinimum(BigDecimal.ZERO);
+                property.setExclusiveMinimum(true);
+                modified = true;
+            }
+        }
+        if (annos.containsKey("javax.validation.constraints.PositiveOrZero")) {
+            if (isNumberSchema(property)) {
+                property.setMinimum(BigDecimal.ZERO);
+                modified = true;
+            }
+        }
+        if (annos.containsKey("javax.validation.constraints.Negative")) {
+            if (isNumberSchema(property)) {
+                property.setMaximum(BigDecimal.ZERO);
+                property.setExclusiveMaximum(true);
+                modified = true;
+            }
+        }
+        if (annos.containsKey("javax.validation.constraints.NegativeOrZero")) {
+            if (isNumberSchema(property)) {
+                property.setMaximum(BigDecimal.ZERO);
                 modified = true;
             }
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/BeanValidationsModel.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/oas/models/BeanValidationsModel.java
@@ -9,6 +9,10 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Negative;
+import javax.validation.constraints.NegativeOrZero;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,6 +23,18 @@ public class BeanValidationsModel {
     @Min(13)
     @Max(99)
     protected Integer age;
+
+    @Positive
+    private Double positiveValue;
+
+    @PositiveOrZero
+    private Double positiveOrZeroValue;
+
+    @Negative
+    private Double negativeValue;
+
+    @NegativeOrZero
+    private Double negativeOrZeroValue;
 
     @Pattern(regexp = "(?![-._])[-._a-zA-Z0-9]{3,32}")
     @Nonnull
@@ -133,4 +149,35 @@ public class BeanValidationsModel {
         this.optionalValue = optionalValue;
     }
 
+    public Double getPositiveValue() {
+        return positiveValue;
+    }
+
+    public void setPositiveValue(Double positiveValue) {
+        this.positiveValue = positiveValue;
+    }
+
+    public Double getPositiveOrZeroValue() {
+        return positiveOrZeroValue;
+    }
+
+    public void setPositiveOrZeroValue(Double positiveOrZeroValue) {
+        this.positiveOrZeroValue = positiveOrZeroValue;
+    }
+
+    public Double getNegativeValue() {
+        return negativeValue;
+    }
+
+    public void setNegativeValue(Double negativeValue) {
+        this.negativeValue = negativeValue;
+    }
+
+    public Double getNegativeOrZeroValue() {
+        return negativeOrZeroValue;
+    }
+
+    public void setNegativeOrZeroValue(Double negativeOrZeroValue) {
+        this.negativeOrZeroValue = negativeOrZeroValue;
+    }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/BeanValidatorTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/BeanValidatorTest.java
@@ -56,5 +56,20 @@ public class BeanValidatorTest {
         final StringSchema optionalValue = (StringSchema) properties.get("optionalValue");
         assertEquals((int) optionalValue.getMinLength(), 1);
         assertEquals((int) optionalValue.getMaxLength(), 10);
+
+        final NumberSchema positiveValue = (NumberSchema) properties.get("positiveValue");
+        assertEquals(positiveValue.getMinimum(), BigDecimal.ZERO);
+        assertTrue(positiveValue.getExclusiveMinimum());
+
+        final NumberSchema positiveOrZeroValue = (NumberSchema) properties.get("positiveOrZeroValue");
+        assertEquals(positiveOrZeroValue.getMinimum(), BigDecimal.ZERO);
+
+        final NumberSchema negativeValue = (NumberSchema) properties.get("negativeValue");
+        assertEquals(negativeValue.getMaximum(), BigDecimal.ZERO);
+        assertTrue(negativeValue.getExclusiveMaximum());
+
+        final NumberSchema negativeOrZeroValue = (NumberSchema) properties.get("negativeOrZeroValue");
+        assertEquals(negativeOrZeroValue.getMaximum(), BigDecimal.ZERO);
+
     }
 }


### PR DESCRIPTION
## Description

- Add support for Bean Validation sign constraints: @Positive, @PositiveOrZero, @Negative, @NegativeOrZero.
- Map them to OpenAPI schema bounds (minimum/maximum + exclusive*).

Fixes: #5035 

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->