### PR TITLE
Fix schema property cache key collisions by parent schema identity

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/AnnotatedTypeParentCachingTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/AnnotatedTypeParentCachingTest.java
@@ -1,0 +1,56 @@
+package io.swagger.v3.core.converting;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+
+import static org.testng.Assert.assertEquals;
+
+public class AnnotatedTypeParentCachingTest {
+
+    private static class ParentAwareConverter implements ModelConverter {
+        @Override
+        public Schema resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
+            if (String.class.equals(type.getType()) && type.isSchemaProperty() && "fizz".equals(type.getPropertyName())) {
+                Schema schema = new Schema();
+                Schema parent = type.getParent();
+                if (parent != null && "ParentA".equals(parent.getName())) {
+                    schema.setDeprecated(true);
+                } else {
+                    schema.setDeprecated(false);
+                }
+                return schema;
+            }
+            return null;
+        }
+    }
+
+    @Test(description = "cache key should differ for same property under different parent schemas")
+    public void testParentAwareSchemaPropertyCaching() {
+        ModelConverterContextImpl context = new ModelConverterContextImpl(new ParentAwareConverter());
+
+        Schema parentA = new Schema().name("ParentA");
+        Schema parentB = new Schema().name("ParentB");
+
+        AnnotatedType typeInParentA = new AnnotatedType(String.class)
+                .schemaProperty(true)
+                .propertyName("fizz")
+                .parent(parentA);
+
+        AnnotatedType typeInParentB = new AnnotatedType(String.class)
+                .schemaProperty(true)
+                .propertyName("fizz")
+                .parent(parentB);
+
+        Schema schemaFromParentA = context.resolve(typeInParentA);
+        Schema schemaFromParentB = context.resolve(typeInParentB);
+
+        assertEquals(schemaFromParentA.getDeprecated(), Boolean.TRUE);
+        assertEquals(schemaFromParentB.getDeprecated(), Boolean.FALSE);
+    }
+}


### PR DESCRIPTION
## Summary
- add a focused regression test for AnnotatedType cache behavior when the same schema property type/name appears under different parent schemas
- include a stable parent discriminator (schema name/ref) in AnnotatedType equals/hashCode for primitive schema-property cache keys
- keep previous behavior for non-primitive schema-property keys to avoid inheritance/cycle regressions

## Why
- fixes metadata leakage caused by cache collisions for primitive property schemas shared across different parent models
- keeps compatibility with existing recursive and inheritance resolution behavior

## Tests
- mvn -pl modules/swagger-core "-Dtest=io.swagger.v3.core.converting.AnnotatedTypeParentCachingTest,io.swagger.v3.core.converting.AnnotatedTypeCachingTest,io.swagger.v3.core.converting.AnnotatedTypeTest,io.swagger.v3.core.converting.ArrayOfSubclassTest,io.swagger.v3.core.resolving.Ticket2740CyclicTest,io.swagger.v3.core.resolving.Ticket3624Test,io.swagger.v3.core.resolving.Ticket3703Test" test
- mvn test -pl modules/swagger-core
