### PR TITLE
Preserve @ArraySchema item metadata when implementation is used

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -1787,6 +1787,25 @@ public abstract class AnnotationsUtils {
                schemaObject.setFormat(schemaAnnotation.format());
             }
             if (isArray) {
+                // When array item implementation is provided via @ArraySchema.schema(implementation=...),
+                // merge item-level annotation attributes (description, format, access mode, etc.) into a detached item schema
+                // so shared component schemas are not mutated.
+                if (arrayAnnotation != null && arrayAnnotation.schema() != null) {
+                    Schema itemSchemaObject = clone(schemaObject, openapi31);
+                    Optional<Schema> itemSchemaFromAnnotation = AnnotationsUtils.getSchemaFromAnnotation(
+                            arrayAnnotation.schema(),
+                            components,
+                            jsonViewAnnotation,
+                            openapi31,
+                            itemSchemaObject,
+                            Schema.SchemaResolution.INLINE,
+                            null
+                    );
+                    if (itemSchemaFromAnnotation.isPresent()) {
+                        itemSchemaObject = itemSchemaFromAnnotation.get();
+                    }
+                    schemaObject = itemSchemaObject;
+                }
                 Optional<Schema> arraySchema = AnnotationsUtils.getArraySchema(arrayAnnotation, components, jsonViewAnnotation, openapi31, null);
                 if (arraySchema.isPresent()) {
                     arraySchema.get().setItems(schemaObject);

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -96,6 +96,7 @@ import io.swagger.v3.jaxrs2.resources.Ticket4850Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket4859Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket4878Resource;
 import io.swagger.v3.jaxrs2.resources.Ticket4879Resource;
+import io.swagger.v3.jaxrs2.resources.Ticket5051Resource;
 import io.swagger.v3.jaxrs2.resources.UploadResource;
 import io.swagger.v3.jaxrs2.resources.UrlEncodedResourceWithEncodings;
 import io.swagger.v3.jaxrs2.resources.UserAnnotationResource;
@@ -5607,5 +5608,23 @@ public class ReaderTest {
                 "email",
                 "Items format should come from schema.format"
         );
+    }
+
+    @Test(description = "response array schema description should not leak into items")
+    public void test5051ResponseArraySchemaDescriptionLeak() {
+        Reader reader = new Reader(new OpenAPI());
+        OpenAPI openAPI = reader.read(Ticket5051Resource.class);
+
+        ApiResponse response = openAPI.getPaths().get("/ticket5051/items").getGet().getResponses().get("201");
+        assertNotNull(response, "201 response should be present");
+
+        io.swagger.v3.oas.models.media.MediaType mediaType = response.getContent().get("application/json");
+        assertNotNull(mediaType, "application/json media type should be present");
+        assertTrue(mediaType.getSchema() instanceof ArraySchema, "response schema should be an array");
+
+        ArraySchema arraySchema = (ArraySchema) mediaType.getSchema();
+        assertEquals(arraySchema.getDescription(), "Array description");
+        assertNotNull(arraySchema.getItems(), "items schema should be present");
+        assertEquals(arraySchema.getItems().getDescription(), "Item description");
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket5051Resource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/Ticket5051Resource.java
@@ -1,0 +1,37 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+@Path("/ticket5051")
+@Produces(MediaType.APPLICATION_JSON)
+public class Ticket5051Resource {
+
+    @GET
+    @Path("/items")
+    @ApiResponse(
+            responseCode = "201",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON,
+                    array = @ArraySchema(
+                            arraySchema = @Schema(description = "Array description"),
+                            schema = @Schema(description = "Item description", implementation = Item.class)
+                    )
+            )
+    )
+    public List<Item> items() {
+        return null;
+    }
+
+    public static class Item {
+        public String value;
+    }
+}


### PR DESCRIPTION
## Summary
- add a jaxrs2 regression resource/test that reproduces item-level metadata loss when using `@Content(array=@ArraySchema(...))` with `schema(implementation=...)`
- preserve item-level annotation attributes (`description`, `format`, access mode, etc.) by merging `array.schema()` into a detached item schema when implementation-based item schema is resolved
- keep array-level metadata on the array schema while correctly applying item-level metadata to `items`

## Why
- `@ArraySchema.schema(implementation=...)` produced the correct item type but dropped item-level schema annotation metadata in generated OpenAPI
- this change keeps the implementation-based item type and applies the additional item constraints/metadata as expected

## Tests
- mvn -pl modules/swagger-jaxrs2 "-Dtest=io.swagger.v3.jaxrs2.ReaderTest#test5051ResponseArraySchemaDescriptionLeak" test
- mvn test -pl modules/swagger-jaxrs2
- mvn test -pl modules/swagger-core
