### PR TITLE
bug fix for test - reset enumAsRef value in the test to default

### DIFF
--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -5655,6 +5655,7 @@ public class ReaderTest {
                 "      - FOO\n" +
                 "      - BAR\n";
         SerializationMatchers.assertEqualsToYaml31(openAPI, yaml);
+        ModelResolver.enumsAsRef = false;
     }
 
     static class RemoveUnusedSchemasOAS31Filter extends AbstractSpecFilter {


### PR DESCRIPTION
# Pull request

## Description

In [this PR](https://github.com/swagger-api/swagger-core/pull/5020) a test was added that sets a static value of `ModelResolver.enumAsRef` to `true`. This value is shared between tests, which lead the original change to break the build. For more context see [this comment](https://github.com/swagger-api/swagger-core/pull/5020#issuecomment-4084270951).
In this PR the value is reset back to default at the end of test.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)