### PR TITLE
fix: move env under deploy step from under integration tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -62,8 +62,8 @@ jobs:
         else
           echo "not building and maven publishing project as it is a release version: " ${MY_JAVA_VERSION}
         fi
-    - name: Verify BOM integration test
-      run: ./mvnw --no-transfer-progress -B validate -Pbom-it
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+    - name: Verify BOM integration test
+      run: ./mvnw --no-transfer-progress -B validate -Pbom-it


### PR DESCRIPTION
In the https://github.com/swagger-api/swagger-core/pull/5119 a new "Verify BOM integration test" step was inserted immediately before the env: block. In YAML env: is scoped to the step it's nested under so it silently migrated from the deploy step to the new BOM step. ./mvnw clean deploy then ran without MAVEN_USERNAME/MAVEN_PASSWORD, causing the 401. 
 
 This should be fixed with this PR.