### PR TITLE
fix: Avoid locale-dependent NumberFormat in IntegerSchema

### DIFF
--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/IntegerSchema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/IntegerSchema.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.oas.models.media;
 
-import java.text.NumberFormat;
 import java.util.Objects;
 
 /**
@@ -34,13 +33,14 @@ public class IntegerSchema extends Schema<Number> {
     protected Number cast(Object value) {
         if (value != null) {
             try {
-                Number casted = NumberFormat.getInstance().parse(value.toString());
-                if (Integer.MIN_VALUE <= casted.longValue() && casted.longValue() <= Integer.MAX_VALUE) {
-                    return Integer.parseInt(value.toString());
+                String stringValue = value.toString();
+                long casted = Long.parseLong(stringValue);
+                if (withinIntegerBounds(casted)) {
+                    return Integer.parseInt(stringValue);
                 } else {
-                    return Long.parseLong(value.toString());
+                    return casted;
                 }
-            } catch (Exception e) {
+            } catch (Exception ignored) {
             }
         }
         return null;
@@ -74,5 +74,9 @@ public class IntegerSchema extends Schema<Number> {
         sb.append("    ").append(toIndentedString(super.toString())).append("\n");
         sb.append("}");
         return sb.toString();
+    }
+
+    private boolean withinIntegerBounds(long value) {
+        return Integer.MIN_VALUE <= value && value <= Integer.MAX_VALUE;
     }
 }

--- a/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/media/IntegerSchemaTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/media/IntegerSchemaTest.java
@@ -1,0 +1,86 @@
+package io.swagger.v3.oas.models.media;
+
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+
+import static org.testng.Assert.*;
+
+public class IntegerSchemaTest {
+
+    private static final IntegerSchema INTEGER_SCHEMA = new IntegerSchema();
+    private static final Locale SWEDISH_LOCALE = new Locale("se");
+    private static final String INTEGER_STRING = "123";
+    private static final String LONG_STRING = "1111111111111111111";
+    private static final String NEGATIVE_INTEGER = "-123";
+    private static final String INTEGER_WITH_SPACE_THOUSAND_SEPARATOR = "2 000";
+    private static final String INTEGER_WITH_DECIMAL_THOUSAND_SEPARATOR = "2.000";
+    private static final String INTEGER_WITH_COMMA_THOUSAND_SEPARATOR = "2,000";
+    private static final Integer NUMBER = 123;
+    private static final Integer NEGATIVE_NUMBER = -123;
+    private static final Long LONG = 1111111111111111111L;
+
+    @Test
+    public void testCastInteger() {
+        assertEquals(INTEGER_SCHEMA.cast(INTEGER_STRING), NUMBER);
+    }
+
+    @Test
+    public void testCastLong() {
+        assertEquals(INTEGER_SCHEMA.cast(LONG_STRING), LONG);
+    }
+
+    @Test
+    public void testCastNegativeInteger() {
+        assertEquals(INTEGER_SCHEMA.cast(NEGATIVE_INTEGER), NEGATIVE_NUMBER);
+    }
+
+    @Test
+    public void testCastIntegerWithSpaceThousandSeparatorFailsWithNull() {
+        assertNull(INTEGER_SCHEMA.cast(INTEGER_WITH_SPACE_THOUSAND_SEPARATOR));
+    }
+
+    @Test
+    public void testCastIntegerWithDecimalThousandSeparatorFailsWithNull() {
+        assertNull(INTEGER_SCHEMA.cast(INTEGER_WITH_DECIMAL_THOUSAND_SEPARATOR));
+    }
+
+    @Test
+    public void testCastIntegerWithCommaThousandSeparatorFailsWithNull() {
+        assertNull(INTEGER_SCHEMA.cast(INTEGER_WITH_COMMA_THOUSAND_SEPARATOR));
+    }
+
+    @Test
+    public void testCastIntegerWithSwedishLocale() {
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(SWEDISH_LOCALE);
+            assertEquals(new IntegerSchema().cast(INTEGER_STRING), NUMBER);
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+
+    @Test
+    public void testCastLongWithSwedishLocale() {
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(SWEDISH_LOCALE);
+            assertEquals(new IntegerSchema().cast(LONG_STRING), LONG);
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+
+    @Test
+    public void testCastNegativeIntegerWithSwedishLocale() {
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(SWEDISH_LOCALE);
+            assertEquals(new IntegerSchema().cast(NEGATIVE_INTEGER), NEGATIVE_NUMBER);
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
+
+}


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

This is a revival of https://github.com/swagger-api/swagger-core/pull/4178.

NumberFormat.getInstance().parse(Integer.toString(-1)) always throws exception in the following locales: ar· ·ckb· ·he· ·ks· ·pa_Arab· ·ur· ·fa· ·ps· ·uz_Arab· ·eo· ·et· ·fi· ·fo· ·gsw· ·ksh· ·lt· ·nb· ·nn· ·rm· ·se· ·sv· (see https://bugs.openjdk.java.net/browse/JDK-8189097)

To see this in action, try running the following code:

```java
import java.text.NumberFormat;
import java.text.ParseException;
import java.util.Locale;

public class NumberFormatIsBroken {
    public static void main(String[] args) throws ParseException {
        Locale.setDefault(new Locale("no"));
        NumberFormat.getInstance().parse(Long.toString(-1));
    }
}
```
It should be valid to ignore locale for `IntegerSchema`, since we are not conducting any parsing based upon the locale (since we are doing `Integer.parseInt()` and `Long.parseLong()`, without considering the `Number casted` that we instantiate).

The locale is mainly used for different decimal representations and thousand separators, but these already fail silently in the current implementation. This since the `Number casted` is properly read and populated. E.g., `2 000` to `2000`, but we then do Integer.parseInt() with `2 000`, which will fail.

Fixes: #4223

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->