### PR TITLE
feat: add Schema.NullableMode for explicit per-property nullable override (#5160)

### DIFF
--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
@@ -215,7 +215,7 @@ public @interface Schema {
     /**
      * If true, designates a value as possibly null.
      *
-     * @deprecated As of 2.2.49, replaced by {@link #nullableMode()}
+     * @deprecated As of 2.2.50, replaced by {@link #nullableMode()}
      *
      * @return whether or not this schema is nullable
      **/

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
@@ -215,9 +215,24 @@ public @interface Schema {
     /**
      * If true, designates a value as possibly null.
      *
+     * @deprecated As of 2.2.49, replaced by {@link #nullableMode()}
+     *
      * @return whether or not this schema is nullable
      **/
+    @Deprecated
     boolean nullable() default false;
+
+    /**
+     * Allows to specify the nullable mode (NullableMode.AUTO, NULLABLE, NOT_NULLABLE)
+     *
+     * NullableMode.AUTO: will let the library decide based on its heuristics (e.g. @Nullable annotation auto-detection).
+     * NullableMode.NULLABLE: will force the item to be considered as nullable regardless of heuristics.
+     * NullableMode.NOT_NULLABLE: will force the item to be considered as not nullable regardless of heuristics.
+     *
+     * @return the nullableMode for this schema (property)
+     *
+     */
+    NullableMode nullableMode() default NullableMode.AUTO;
 
     /**
      * Sets whether the value should only be read during a response but not read to during a request.
@@ -565,6 +580,12 @@ public @interface Schema {
         AUTO,
         REQUIRED,
         NOT_REQUIRED;
+    }
+
+    enum NullableMode {
+        AUTO,
+        NULLABLE,
+        NOT_NULLABLE;
     }
 
     enum SchemaResolution {

--- a/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
+++ b/modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java
@@ -215,7 +215,7 @@ public @interface Schema {
     /**
      * If true, designates a value as possibly null.
      *
-     * @deprecated As of 2.2.50, replaced by {@link #nullableMode()}
+     * @deprecated As of 2.2.51, replaced by {@link #nullableMode()}
      *
      * @return whether or not this schema is nullable
      **/

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -2287,12 +2287,12 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             try {
                 ObjectMapper mapper = ObjectMapperFactory.buildStrictGenericObjectMapper();
                 JsonNode node = mapper.readTree(schema.defaultValue());
-                // Only return null for "null" string when nullable=true
+                // Only return null for "null" string when the schema is effectively nullable
                 if (node.isNull()) {
-                    if (schema.nullable()) {
+                    if (isSchemaAnnotationNullable(schema)) {
                         return null;
                     } else {
-                        // When nullable=false, treat "null" as literal string
+                        // When not nullable, treat "null" as literal string
                         return schema.defaultValue();
                     }
                 }
@@ -2331,7 +2331,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                     ObjectMapper mapper = ObjectMapperFactory.buildStrictGenericObjectMapper();
                     JsonNode node = mapper.readTree(schema.example());
                     if (node.isNull()) {
-                        if (schema.nullable()) {
+                        if (isSchemaAnnotationNullable(schema)) {
                             return null;
                         } else {
                             return schema.example();
@@ -2450,8 +2450,30 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     }
 
     protected Boolean resolveNullable(Annotated a, Annotation[] annotations, io.swagger.v3.oas.annotations.media.Schema schema) {
-        if (schema != null && schema.nullable()) {
-            return true;
+        // Resolve the effective @Schema annotation - prefer the one passed directly, otherwise scan the annotations array.
+        // Some callers (notably property-level resolution) pass schema=null and put @Schema in the annotations array instead.
+        io.swagger.v3.oas.annotations.media.Schema effectiveSchema = schema;
+        if (effectiveSchema == null && annotations != null) {
+            for (Annotation annotation : annotations) {
+                if (annotation instanceof io.swagger.v3.oas.annotations.media.Schema) {
+                    effectiveSchema = (io.swagger.v3.oas.annotations.media.Schema) annotation;
+                    break;
+                }
+            }
+        }
+        // NullableMode takes precedence over both the legacy nullable boolean and auto-detection.
+        if (effectiveSchema != null) {
+            io.swagger.v3.oas.annotations.media.Schema.NullableMode mode = effectiveSchema.nullableMode();
+            if (mode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NULLABLE) {
+                return true;
+            }
+            if (mode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NOT_NULLABLE) {
+                return false;
+            }
+            // mode == AUTO: honor legacy nullable boolean if set, otherwise fall through to heuristics.
+            if (effectiveSchema.nullable()) {
+                return true;
+            }
         }
         if (annotations != null) {
             for (Annotation annotation : annotations) {
@@ -2461,6 +2483,30 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             }
         }
         return null;
+    }
+
+    /**
+     * Returns true if the @Schema annotation effectively declares nullable, honoring
+     * the {@code nullableMode} field with precedence over the legacy {@code nullable}
+     * boolean. Returns false if the annotation explicitly declares not-nullable, or
+     * if no nullability intent is expressed.
+     *
+     * <p>Used for derivative decisions (e.g. whether a "null" defaultValue/example
+     * literal should be treated as actual null). Does not consult auto-detected
+     * @Nullable annotations - for full resolution use {@link #resolveNullable}.
+     */
+    private static boolean isSchemaAnnotationNullable(io.swagger.v3.oas.annotations.media.Schema schema) {
+        if (schema == null) {
+            return false;
+        }
+        io.swagger.v3.oas.annotations.media.Schema.NullableMode mode = schema.nullableMode();
+        if (mode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NULLABLE) {
+            return true;
+        }
+        if (mode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NOT_NULLABLE) {
+            return false;
+        }
+        return schema.nullable();
     }
 
     protected BigDecimal resolveMultipleOf(Annotated a, Annotation[] annotations, io.swagger.v3.oas.annotations.media.Schema schema) {
@@ -3141,15 +3187,15 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         Object defaultValue = resolveDefaultValue(a, annotations, schemaAnnotation);
         if (defaultValue != null) {
             schema.setDefault(defaultValue);
-        } else if (schemaAnnotation != null && "null".equals(schemaAnnotation.defaultValue().trim()) && schemaAnnotation.nullable()) {
-            // Explicitly set to null when defaultValue="null" AND nullable=true
+        } else if (schemaAnnotation != null && "null".equals(schemaAnnotation.defaultValue().trim()) && isSchemaAnnotationNullable(schemaAnnotation)) {
+            // Explicitly set to null when defaultValue="null" AND the schema is effectively nullable
             schema.setDefault(null);
         }
         Object example = resolveExample(a, annotations, schemaAnnotation);
         if (example != null) {
             schema.example(example);
-        } else if (schemaAnnotation != null && "null".equals(schemaAnnotation.example().trim()) && schemaAnnotation.nullable()) {
-            // Explicitly set to null when example="null" AND nullable=true
+        } else if (schemaAnnotation != null && "null".equals(schemaAnnotation.example().trim()) && isSchemaAnnotationNullable(schemaAnnotation)) {
+            // Explicitly set to null when example="null" AND the schema is effectively nullable
             schema.example(null);
         }
         Boolean readOnly = resolveReadOnly(a, annotations, schemaAnnotation);

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -2450,32 +2450,25 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     }
 
     protected Boolean resolveNullable(Annotated a, Annotation[] annotations, io.swagger.v3.oas.annotations.media.Schema schema) {
-        // Resolve the effective @Schema annotation - prefer the one passed directly, otherwise scan the annotations array.
-        // Some callers (notably property-level resolution) pass schema=null and put @Schema in the annotations array instead.
-        io.swagger.v3.oas.annotations.media.Schema effectiveSchema = schema;
-        if (effectiveSchema == null && annotations != null) {
-            for (Annotation annotation : annotations) {
-                if (annotation instanceof io.swagger.v3.oas.annotations.media.Schema) {
-                    effectiveSchema = (io.swagger.v3.oas.annotations.media.Schema) annotation;
-                    break;
-                }
-            }
-        }
-        // NullableMode takes precedence over both the legacy nullable boolean and auto-detection.
-        if (effectiveSchema != null) {
-            io.swagger.v3.oas.annotations.media.Schema.NullableMode mode = effectiveSchema.nullableMode();
+        // NullableMode on the explicit @Schema parameter takes precedence over both the legacy
+        // nullable boolean and auto-detection. NullableMode handling for property-level @Schema
+        // (when this method is called with schema=null) is centralized in AnnotationsUtils, where
+        // the @Schema annotation is the canonical source - per the project convention that
+        // @Schema must not be scanned out of the annotations array (sibling handling depends on
+        // that separation).
+        if (schema != null) {
+            io.swagger.v3.oas.annotations.media.Schema.NullableMode mode = schema.nullableMode();
             if (mode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NULLABLE) {
                 return true;
             }
             if (mode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NOT_NULLABLE) {
-                // Explicit override: skip both legacy nullable and auto-detection. Returning null
-                // (not Boolean.FALSE) avoids the caller emitting `"nullable": false` literally;
-                // the actual clearing of any prior nullable indication happens in AnnotationsUtils
-                // when the @Schema annotation is processed.
+                // Returning null (not Boolean.FALSE) avoids the caller emitting `"nullable": false`
+                // literally; AnnotationsUtils clears any prior nullable indication when it processes
+                // the @Schema annotation.
                 return null;
             }
             // mode == AUTO: honor legacy nullable boolean if set, otherwise fall through to heuristics.
-            if (effectiveSchema.nullable()) {
+            if (schema.nullable()) {
                 return true;
             }
         }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -2468,7 +2468,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 return true;
             }
             if (mode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NOT_NULLABLE) {
-                return false;
+                // Explicit override: skip both legacy nullable and auto-detection. Returning null
+                // (not Boolean.FALSE) avoids the caller emitting `"nullable": false` literally;
+                // the actual clearing of any prior nullable indication happens in AnnotationsUtils
+                // when the @Schema annotation is processed.
+                return null;
             }
             // mode == AUTO: honor legacy nullable boolean if set, otherwise fall through to heuristics.
             if (effectiveSchema.nullable()) {
@@ -2487,9 +2491,9 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
     /**
      * Returns true if the @Schema annotation effectively declares nullable, honoring
-     * the {@code nullableMode} field with precedence over the legacy {@code nullable}
-     * boolean. Returns false if the annotation explicitly declares not-nullable, or
-     * if no nullability intent is expressed.
+     * {@code nullableMode} with precedence over the legacy {@code nullable} boolean.
+     * Returns false if the annotation explicitly declares not-nullable (NullableMode.NOT_NULLABLE)
+     * or if no nullability intent is expressed.
      *
      * <p>Used for derivative decisions (e.g. whether a "null" defaultValue/example
      * literal should be treated as actual null). Does not consult auto-detected

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -86,6 +86,7 @@ public abstract class AnnotationsUtils {
                 && !schema.required()
                 && schema.requiredMode().equals(io.swagger.v3.oas.annotations.media.Schema.RequiredMode.AUTO)
                 && !schema.nullable()
+                && schema.nullableMode().equals(io.swagger.v3.oas.annotations.media.Schema.NullableMode.AUTO)
                 && !schema.readOnly()
                 && !schema.writeOnly()
                 && schema.accessMode().equals(io.swagger.v3.oas.annotations.media.Schema.AccessMode.AUTO)
@@ -291,6 +292,9 @@ public abstract class AnnotationsUtils {
             return false;
         }
         if (thisSchema.nullable() != thatSchema.nullable()) {
+            return false;
+        }
+        if (!thisSchema.nullableMode().equals(thatSchema.nullableMode())) {
             return false;
         }
         if (thisSchema.readOnly() != thatSchema.readOnly()) {
@@ -835,12 +839,28 @@ public abstract class AnnotationsUtils {
             String filteredMinimum = schema.minimum().replace(Constants.COMMA, StringUtils.EMPTY);
             schemaObject.setMinimum(new BigDecimal(filteredMinimum));
         }
-        if (schema.nullable()) {
+        // Honor nullableMode (NULLABLE/NOT_NULLABLE) with precedence over legacy nullable boolean.
+        io.swagger.v3.oas.annotations.media.Schema.NullableMode nullableMode = schema.nullableMode();
+        boolean effectiveNullable;
+        if (nullableMode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NULLABLE) {
+            effectiveNullable = true;
+        } else if (nullableMode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NOT_NULLABLE) {
+            effectiveNullable = false;
+        } else {
+            effectiveNullable = schema.nullable();
+        }
+        if (effectiveNullable) {
             if (openapi31) {
                 schemaObject.addType("null");
             } else {
                 schemaObject.setNullable(true);
             }
+        } else if (nullableMode == io.swagger.v3.oas.annotations.media.Schema.NullableMode.NOT_NULLABLE) {
+            // Explicit NOT_NULLABLE overrides prior nullable indications (e.g. from @Nullable auto-detection).
+            if (openapi31 && schemaObject.getTypes() != null) {
+                schemaObject.getTypes().remove("null");
+            }
+            schemaObject.setNullable(null);
         }
         if (StringUtils.isNotBlank(schema.title())) {
             schemaObject.setTitle(schema.title());
@@ -2403,6 +2423,14 @@ public abstract class AnnotationsUtils {
                     return master.requiredMode();
                 }
                 return patch.requiredMode();
+            }
+
+            @Override
+            public NullableMode nullableMode() {
+                if (!master.nullableMode().equals(NullableMode.AUTO) || patch.nullableMode().equals(NullableMode.AUTO)) {
+                    return master.nullableMode();
+                }
+                return patch.nullableMode();
             }
 
             @Override

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue5160Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue5160Test.java
@@ -1,0 +1,188 @@
+package io.swagger.v3.core.issues;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.util.Configuration;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Json31;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.testng.annotations.Test;
+
+import javax.annotation.Nullable;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests for GitHub Issue #5160 -
+ * Schema.NullableMode enum mirroring RequiredMode / AccessMode.
+ *
+ * Validates the precedence chain:
+ * 1. nullableMode = NULLABLE / NOT_NULLABLE wins over everything
+ * 2. legacy nullable = true (deprecated) wins over auto-detection
+ * 3. nullableMode = AUTO + no legacy nullable → consult @Nullable heuristics
+ *
+ * @see <a href="https://github.com/swagger-api/swagger-core/issues/5160">...</a>
+ */
+public class Issue5160Test {
+
+    @Test
+    public void testModeNullableForcesNullableOAS30() {
+        io.swagger.v3.oas.models.media.Schema model = resolve30(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("modeNullable");
+        assertNotNull(field);
+        assertEquals(field.getNullable(), Boolean.TRUE,
+                "nullableMode=NULLABLE must force nullable=true in OAS 3.0");
+    }
+
+    @Test
+    public void testModeNullableForcesNullableOAS31() {
+        io.swagger.v3.oas.models.media.Schema model = resolve31(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("modeNullable");
+        assertNotNull(field);
+        assertNotNull(field.getTypes(),
+                "nullableMode=NULLABLE must produce a types array in OAS 3.1");
+        assertTrue(field.getTypes().contains("null"),
+                "nullableMode=NULLABLE must include 'null' in types array");
+    }
+
+    @Test
+    public void testModeNotNullableOverridesNullableAnnotationOAS30() {
+        io.swagger.v3.oas.models.media.Schema model = resolve30(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("modeNotNullableWithAnnotation");
+        assertNotNull(field);
+        assertNotEquals(field.getNullable(), Boolean.TRUE,
+                "nullableMode=NOT_NULLABLE must override @Nullable auto-detection in OAS 3.0");
+    }
+
+    @Test
+    public void testModeNotNullableOverridesNullableAnnotationOAS31() {
+        io.swagger.v3.oas.models.media.Schema model = resolve31(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("modeNotNullableWithAnnotation");
+        assertNotNull(field);
+        if (field.getTypes() != null) {
+            assertFalse(field.getTypes().contains("null"),
+                    "nullableMode=NOT_NULLABLE must override @Nullable auto-detection in OAS 3.1");
+        }
+    }
+
+    @Test
+    public void testModeAutoWithAnnotationStillDetectsNullableOAS30() {
+        io.swagger.v3.oas.models.media.Schema model = resolve30(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("modeAutoWithAnnotation");
+        assertNotNull(field);
+        assertEquals(field.getNullable(), Boolean.TRUE,
+                "nullableMode=AUTO must let @Nullable auto-detection apply in OAS 3.0");
+    }
+
+    @Test
+    public void testModeAutoWithAnnotationStillDetectsNullableOAS31() {
+        io.swagger.v3.oas.models.media.Schema model = resolve31(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("modeAutoWithAnnotation");
+        assertNotNull(field);
+        assertNotNull(field.getTypes());
+        assertTrue(field.getTypes().contains("null"),
+                "nullableMode=AUTO must let @Nullable auto-detection apply in OAS 3.1");
+    }
+
+    @Test
+    public void testModeAutoWithoutAnyNullableSignalIsNotNullableOAS30() {
+        io.swagger.v3.oas.models.media.Schema model = resolve30(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("modeAutoNoSignal");
+        assertNotNull(field);
+        assertNotEquals(field.getNullable(), Boolean.TRUE,
+                "nullableMode=AUTO with no signals must not be nullable");
+    }
+
+    @Test
+    public void testLegacyNullableTrueStillWorksOAS30() {
+        io.swagger.v3.oas.models.media.Schema model = resolve30(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("legacyNullable");
+        assertNotNull(field);
+        assertEquals(field.getNullable(), Boolean.TRUE,
+                "Legacy nullable=true must still work for backward compatibility");
+    }
+
+    @Test
+    public void testLegacyNullableTrueStillWorksOAS31() {
+        io.swagger.v3.oas.models.media.Schema model = resolve31(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("legacyNullable");
+        assertNotNull(field);
+        assertNotNull(field.getTypes());
+        assertTrue(field.getTypes().contains("null"),
+                "Legacy nullable=true must still produce types array in OAS 3.1");
+    }
+
+    private io.swagger.v3.oas.models.media.Schema resolve30(Class<?> clazz) {
+        ModelResolver modelResolver = new ModelResolver(Json.mapper());
+        Configuration configuration = new Configuration();
+        configuration.setOpenAPI31(false);
+        modelResolver.setConfiguration(configuration);
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+        io.swagger.v3.oas.models.media.Schema model = context.resolve(new AnnotatedType(clazz));
+        assertNotNull(model);
+        assertNotNull(model.getProperties());
+        return model;
+    }
+
+    private io.swagger.v3.oas.models.media.Schema resolve31(Class<?> clazz) {
+        ModelResolver modelResolver = new ModelResolver(Json31.mapper());
+        Configuration configuration = new Configuration();
+        configuration.setOpenAPI31(true);
+        modelResolver.setConfiguration(configuration);
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+        io.swagger.v3.oas.models.media.Schema model = context.resolve(new AnnotatedType(clazz));
+        assertNotNull(model);
+        assertNotNull(model.getProperties());
+        return model;
+    }
+
+    public static class NullableModeModel {
+        @Schema(nullableMode = Schema.NullableMode.NULLABLE)
+        private String modeNullable;
+
+        @Nullable
+        @Schema(nullableMode = Schema.NullableMode.NOT_NULLABLE)
+        private String modeNotNullableWithAnnotation;
+
+        @Nullable
+        @Schema(description = "auto with annotation")
+        private String modeAutoWithAnnotation;
+
+        @Schema(description = "auto with no nullable signal")
+        private String modeAutoNoSignal;
+
+        @SuppressWarnings("deprecation")
+        @Schema(nullable = true)
+        private String legacyNullable;
+
+        public String getModeNullable() { return modeNullable; }
+        public void setModeNullable(String s) { this.modeNullable = s; }
+
+        public String getModeNotNullableWithAnnotation() { return modeNotNullableWithAnnotation; }
+        public void setModeNotNullableWithAnnotation(String s) { this.modeNotNullableWithAnnotation = s; }
+
+        public String getModeAutoWithAnnotation() { return modeAutoWithAnnotation; }
+        public void setModeAutoWithAnnotation(String s) { this.modeAutoWithAnnotation = s; }
+
+        public String getModeAutoNoSignal() { return modeAutoNoSignal; }
+        public void setModeAutoNoSignal(String s) { this.modeAutoNoSignal = s; }
+
+        public String getLegacyNullable() { return legacyNullable; }
+        public void setLegacyNullable(String s) { this.legacyNullable = s; }
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue5160Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue5160Test.java
@@ -59,8 +59,10 @@ public class Issue5160Test {
         io.swagger.v3.oas.models.media.Schema field =
                 (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("modeNotNullableWithAnnotation");
         assertNotNull(field);
-        assertNotEquals(field.getNullable(), Boolean.TRUE,
-                "nullableMode=NOT_NULLABLE must override @Nullable auto-detection in OAS 3.0");
+        // Stricter than `!= true`: nullable must be unset (null), not explicitly false,
+        // so the spec output omits the field rather than emitting `"nullable": false`.
+        assertNull(field.getNullable(),
+                "nullableMode=NOT_NULLABLE must clear nullable to null in OAS 3.0 (not Boolean.FALSE)");
     }
 
     @Test
@@ -104,6 +106,16 @@ public class Issue5160Test {
         assertNotNull(field);
         assertNotEquals(field.getNullable(), Boolean.TRUE,
                 "nullableMode=AUTO with no signals must not be nullable");
+    }
+
+    @Test
+    public void testModeNotNullableWithoutAnnotationIsNotNullableOAS30() {
+        io.swagger.v3.oas.models.media.Schema model = resolve30(NullableModeModel.class);
+        io.swagger.v3.oas.models.media.Schema field =
+                (io.swagger.v3.oas.models.media.Schema) model.getProperties().get("modeNotNullableOnly");
+        assertNotNull(field);
+        assertNull(field.getNullable(),
+                "nullableMode=NOT_NULLABLE with no @Nullable must leave nullable unset (not Boolean.FALSE)");
     }
 
     @Test
@@ -159,6 +171,9 @@ public class Issue5160Test {
         @Schema(nullableMode = Schema.NullableMode.NOT_NULLABLE)
         private String modeNotNullableWithAnnotation;
 
+        @Schema(nullableMode = Schema.NullableMode.NOT_NULLABLE)
+        private String modeNotNullableOnly;
+
         @Nullable
         @Schema(description = "auto with annotation")
         private String modeAutoWithAnnotation;
@@ -175,6 +190,9 @@ public class Issue5160Test {
 
         public String getModeNotNullableWithAnnotation() { return modeNotNullableWithAnnotation; }
         public void setModeNotNullableWithAnnotation(String s) { this.modeNotNullableWithAnnotation = s; }
+
+        public String getModeNotNullableOnly() { return modeNotNullableOnly; }
+        public void setModeNotNullableOnly(String s) { this.modeNotNullableOnly = s; }
 
         public String getModeAutoWithAnnotation() { return modeAutoWithAnnotation; }
         public void setModeAutoWithAnnotation(String s) { this.modeAutoWithAnnotation = s; }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/util/AnnotationsUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/util/AnnotationsUtilsTest.java
@@ -402,6 +402,11 @@ public class AnnotationsUtilsTest {
             }
 
             @Override
+            public NullableMode nullableMode() {
+                return schemaAnnotation.nullableMode();
+            }
+
+            @Override
             public String description() {
                 return schemaAnnotation.description();
             }


### PR DESCRIPTION
## Summary

Introduces `Schema.NullableMode { AUTO, NULLABLE, NOT_NULLABLE }` mirroring the established `RequiredMode` (#4221) and `AccessMode` (#2675) pattern, providing the missing explicit per-property override for nullable.

Closes #5160.

## Motivation

The existing `nullable()` boolean defaults to `false`, which is indistinguishable from "not specified" via reflection. Users cannot opt a property out of nullable auto-detection (added in #5018 for `@Nullable` annotations, and used downstream by springdoc-openapi for Kotlin `T?` reflection in springdoc/springdoc-openapi#3256, since reverted in springdoc/springdoc-openapi#3276 pending this proposal).

This is the same problem class that prompted `RequiredMode` in 2022. From commit b1729fcf1: *"so we can have a property annotated @NotNull but still have required = false in the openapi spec"* — identical situation, just `nullable` instead of `required`.

## Precedence

Mirrors PR #4533 ("give precedence to requiredMode annotation"):

1. `nullableMode = NULLABLE` or `NOT_NULLABLE` → use that
2. Legacy `nullable = true` (deprecated path) → treat as `NULLABLE`
3. `nullableMode = AUTO` (default) → run heuristics (`@Nullable` annotations from #5018, downstream Kotlin reflection, etc.)

## Changes

**`modules/swagger-annotations/src/main/java/io/swagger/v3/oas/annotations/media/Schema.java`**
- Add `NullableMode` enum (AUTO, NULLABLE, NOT_NULLABLE).
- Add `nullableMode()` annotation field defaulting to `AUTO`.
- Deprecate `nullable()` boolean pointing to `nullableMode()`.

**`modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java`**
- `resolveNullable` honors `NullableMode` precedence. When the @Schema annotation is not passed directly (typical for property-level resolution), it is extracted from the `annotations` array.
- Adds `isSchemaAnnotationNullable` helper for downstream "is this nullable" checks (used at the `defaultValue="null"` and `example="null"` literal handling sites, where the existing `schema.nullable()` checks now route through the helper to also honor `NullableMode`).

**`modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java`**
- Parity with `RequiredMode` handling in `hasSchemaAnnotation` (NullableMode != AUTO counts as "has annotation"), `equals` (compares `nullableMode`), and `mergeSchemaAnnotations` (master-wins precedence on `nullableMode`).
- Property-level `@Schema` processing (line ~842) honors `NullableMode`. When `NOT_NULLABLE` is set, explicitly clears any prior nullable indication on the schema object (e.g. `null` already added to the types array by upstream `@Nullable` auto-detection from #5018).

**`modules/swagger-core/src/test/java/io/swagger/v3/core/util/AnnotationsUtilsTest.java`**
- One existing anonymous Schema implementation needed the new `nullableMode()` method override (delegating to the wrapped schema, mirroring the existing `requiredMode()` delegation).

## Tests

`modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue5160Test.java` — 9 new tests covering all combinations across OAS 3.0 and OAS 3.1:

- `testModeNullableForcesNullable{OAS30,OAS31}` — `nullableMode=NULLABLE` produces nullable output.
- `testModeNotNullableOverridesNullableAnnotation{OAS30,OAS31}` — `nullableMode=NOT_NULLABLE` overrides upstream `@Nullable` auto-detection.
- `testModeAutoWithAnnotationStillDetectsNullable{OAS30,OAS31}` — `AUTO` (default) lets `@Nullable` detection apply unchanged.
- `testModeAutoWithoutAnyNullableSignalIsNotNullableOAS30` — `AUTO` with no signals is not nullable (no regression).
- `testLegacyNullableTrueStillWorks{OAS30,OAS31}` — backward compatibility for `nullable = true`.

Full existing suite passes (660 tests, 0 failures, 0 errors).

## OAS 3.0 vs 3.1 mapping

Same as the existing handling for `nullable: true`:

- **OAS 3.0:** sets `nullable: true` on the schema object.
- **OAS 3.1:** adds `"null"` to the `type` array.
- `NOT_NULLABLE` suppresses any of the above and clears any prior nullable indication.

## Impact on downstream

- `@Nullable` auto-detection added in #5018 continues to work unchanged when `nullableMode = AUTO`.
- Provides the override mechanism springdoc-openapi needs to safely re-introduce its Kotlin `T?` auto-detection (springdoc/springdoc-openapi#3276 reverted that work pending this proposal).
- `nullable()` boolean is now `@Deprecated` but still honored, mirroring the deprecation pattern used for `required`/`readOnly`/`writeOnly`.

## Test plan

- [ ] CI passes
- [x] Local: `./mvnw -pl modules/swagger-core test -Dmaven.javadoc.skip=true` → 660/660 tests pass including 9 new
- [x] Manual verification of OAS 3.0 / 3.1 output for all five test cases via the snapshot dump in `Issue5160Test`