### PR TITLE
fix(gradle-plugin): avoid eager classpath resolution in Gradle plugin

### DIFF
--- a/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/SwaggerPlugin.java
+++ b/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/SwaggerPlugin.java
@@ -24,7 +24,7 @@ public class SwaggerPlugin implements Plugin<Project> {
         });
         TaskProvider<ResolveTask> lazyTask = project.getTasks().register("resolve", ResolveTask.class,task -> {
             task.buildClasspath.setFrom(config);
-            task.classpath.setFrom(project.getExtensions().findByType(SourceSetContainer.class).getByName("main").getRuntimeClasspath().getFiles());
+            task.classpath.setFrom(project.getExtensions().findByType(SourceSetContainer.class).getByName("main").getRuntimeClasspath());
             task.prettyPrint.convention(false);
             task.readAllResources.convention(true);
             task.outputFormat.convention(ResolveTask.Format.JSON);

--- a/modules/swagger-gradle-plugin/src/test/java/io/swagger/v3/plugins/gradle/SwaggerResolveTest.java
+++ b/modules/swagger-gradle-plugin/src/test/java/io/swagger/v3/plugins/gradle/SwaggerResolveTest.java
@@ -271,6 +271,160 @@ public class SwaggerResolveTest {
         assertTrue(new File(outputDir + "/PetStoreAPIDefaults.json").exists());
     }
 
+    /**
+     * Regression test for https://github.com/swagger-api/swagger-core/issues/4813
+     *
+     * When the resolve { } configuration block appears before the dependencies { } block
+     * in build.gradle, accessing the task by name triggers the registration lambda which
+     * used to call getRuntimeClasspath().getFiles(). That eagerly resolved the runtime
+     * classpath, locking the implementation configuration. Any subsequent attempt to add
+     * a dependency (e.g. in the dependencies { } block below) then failed with:
+     *   Cannot change dependencies of dependency configuration '<CONFIG>'
+     *   after it has been included in dependency resolution.
+     */
+    @Test
+    public void testSwaggerPluginAllowsDependenciesAfterResolveBlock() throws IOException {
+        outputDir = testProjectDir.toString() + "/target";
+
+        String buildFileContent =
+                "plugins {\n" +
+                "    id 'java'\n" +
+                "    id 'io.swagger.core.v3.swagger-gradle-plugin'\n" +
+                "}\n" +
+                // resolve block appears BEFORE dependencies
+                "resolve {\n" +
+                "    outputFileName = 'PetStoreAPI'\n" +
+                "    classpath = sourceSets.test.runtimeClasspath\n" +
+                "    resourcePackages = ['io.swagger.v3.plugins.gradle.petstore']\n" +
+                "    outputPath = '" + toNormalizedPath(outputDir) + "'\n" +
+                "}\n" +
+                "repositories {\n" +
+                "    maven { url mavenLocal().url }\n" +
+                "    mavenCentral()\n" +
+                "}\n" +
+                "dependencies {\n" +
+                "    implementation 'io.swagger.core.v3:swagger-jaxrs2:2.2.49-SNAPSHOT'\n" +
+                "    implementation 'javax.ws.rs:javax.ws.rs-api:2.1'\n" +
+                "    implementation 'javax.servlet:javax.servlet-api:3.1.0'\n" +
+                "    testImplementation 'org.testng:testng:7.10.2'\n" +
+                "}\n" +
+                "sourceSets {\n" +
+                "    test {\n" +
+                "        java {\n" +
+                "            srcDirs('" + toNormalizedPath(new File("src/test/java").getAbsolutePath()) + "')\n" +
+                "            exclude('**/*Test.java')\n" +
+                "        }\n" +
+                "    }\n" +
+                "}\n";
+
+        String settingsFileContent =
+                "pluginManagement {\n" +
+                "    repositories {\n" +
+                "        maven { url mavenLocal().url }\n" +
+                "        mavenCentral()\n" +
+                "        gradlePluginPortal()\n" +
+                "    }\n" +
+                "}\n" +
+                "rootProject.name = 'gradle-test'\n";
+
+        writeFile(buildFile, buildFileContent);
+        writeFile(settingsFile, settingsFileContent);
+
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments("resolve", "--stacktrace")
+                .forwardOutput()
+                .build();
+
+        assertTrue(result.taskPaths(SUCCESS).contains(":resolve"));
+        assertTrue(new File(outputDir + "/PetStoreAPI.json").exists());
+    }
+
+    /**
+     * Regression test for https://github.com/swagger-api/swagger-core/issues/4841
+     *
+     * In a multi-project build where a subproject depends on another subproject that
+     * applies the `application` plugin, the swagger plugin must not eagerly resolve
+     * the runtime classpath during task registration. Doing so forces Gradle to evaluate
+     * the dependency subproject, which in turn calls afterEvaluate() from DistributionPlugin
+     * in an illegal context, producing:
+     *   Project#afterEvaluate(Action) on project ':app' cannot be executed in the current context.
+     */
+    @Test
+    public void testSwaggerPluginWithMultiProjectAndApplicationPlugin() throws IOException {
+        // app subproject uses the `application` plugin (which calls afterEvaluate via DistributionPlugin)
+        Path appDir = testProjectDir.resolve("app");
+        Files.createDirectories(appDir.resolve("src/main/java/com/example"));
+        writeFile(appDir.resolve("build.gradle"),
+                "plugins {\n" +
+                "    id 'java'\n" +
+                "    id 'application'\n" +
+                "}\n" +
+                "application {\n" +
+                "    mainClass = 'com.example.App'\n" +
+                "}\n" +
+                "repositories { mavenCentral() }\n");
+        writeFile(appDir.resolve("src/main/java/com/example/App.java"),
+                "package com.example;\n" +
+                "public class App {\n" +
+                "    public static void main(String[] args) {}\n" +
+                "}\n");
+
+        // api subproject uses swagger plugin and depends on :app
+        Path apiDir = testProjectDir.resolve("api");
+        Files.createDirectories(apiDir.resolve("src/main/java/com/example/api"));
+        writeFile(apiDir.resolve("build.gradle"),
+                "plugins {\n" +
+                "    id 'java'\n" +
+                "    id 'io.swagger.core.v3.swagger-gradle-plugin'\n" +
+                "}\n" +
+                "repositories {\n" +
+                "    maven { url mavenLocal().url }\n" +
+                "    mavenCentral()\n" +
+                "}\n" +
+                "dependencies {\n" +
+                "    implementation project(':app')\n" +
+                "    implementation 'javax.ws.rs:javax.ws.rs-api:2.1'\n" +
+                "}\n" +
+                "resolve {\n" +
+                "    resourcePackages = ['com.example.api']\n" +
+                "    outputPath = '" + toNormalizedPath(testProjectDir.resolve("api/build/swagger").toString()) + "'\n" +
+                "}\n");
+        writeFile(apiDir.resolve("src/main/java/com/example/api/HelloResource.java"),
+                "package com.example.api;\n" +
+                "import javax.ws.rs.GET;\n" +
+                "import javax.ws.rs.Path;\n" +
+                "@Path(\"/hello\")\n" +
+                "public class HelloResource {\n" +
+                "    @GET\n" +
+                "    public String hello() { return \"hello\"; }\n" +
+                "}\n");
+
+        writeFile(settingsFile,
+                "pluginManagement {\n" +
+                "    repositories {\n" +
+                "        maven { url mavenLocal().url }\n" +
+                "        mavenCentral()\n" +
+                "        gradlePluginPortal()\n" +
+                "    }\n" +
+                "}\n" +
+                "rootProject.name = 'issue-4841-repro'\n" +
+                "include 'app', 'api'\n");
+
+        // build.gradle at root is not needed, subprojects configure themselves
+        Files.deleteIfExists(buildFile);
+
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(":api:resolve", "--stacktrace")
+                .forwardOutput()
+                .build();
+
+        assertTrue(result.taskPaths(SUCCESS).contains(":api:resolve"));
+    }
+
     private static void writeFile(Path destination, String content) throws IOException {
         try (BufferedWriter output = new BufferedWriter(new FileWriter(destination.toFile()))) {
             output.write(content);


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->
Both issues (#4841 and #4813) were introduced in 2.2.27 by commit 583c21b11 ("feat(gradle-plugin): enable lazy configuration") and share the same root cause: a single `.getFiles()` call inside the task registration lambda in SwaggerPlugin.java

`ConfigurableFileCollection.setFrom()` accepts a `FileCollection` directly and resolves it lazily. Calling `.getFiles()` instead returns a plain `Set<File>`, forcing Gradle to fully resolve the runtime classpath at configuration time (inside the register() lambda that was supposed to be lazy).

This resolution had two distinct failure modes:
- [#4841](https://github.com/swagger-api/swagger-core/issues/4841) — multi-project builds with the application plugin
- [#4813](https://github.com/swagger-api/swagger-core/issues/4813) — single-project builds with resolve {} before dependencies {}

Fixes: #4841 and #4813

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->