### PR TITLE
fix: serialize a boolean schema example value as a JsonNode

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -938,13 +938,18 @@ public abstract class AnnotationsUtils {
         if (node.isObject() || node.isArray()) {
             return true;
         }
-        if (schemaObject != null && SchemaTypeUtils.isNumberSchema(schemaObject)) {
-            return true;
+        if (schemaObject != null) {
+            if (SchemaTypeUtils.isNumberSchema(schemaObject)) {
+                return true;
+            }
+            if (SchemaTypeUtils.isBooleanSchema(schemaObject)) {
+                return true;
+            }
+            if (SchemaTypeUtils.isStringSchema(schemaObject)) {
+                return false;
+            }
         }
-        if (schemaObject != null && SchemaTypeUtils.isStringSchema(schemaObject)) {
-            return false;
-        }
-        return node.isNumber();
+        return node.isNumber() || node.isBoolean();
     }
 
     private static void setDefaultSchema(io.swagger.v3.oas.annotations.media.Schema schema, boolean openapi31, Schema schemaObject) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/SchemaTypeUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/SchemaTypeUtils.java
@@ -9,6 +9,7 @@ public class SchemaTypeUtils {
     private static final String STRING_TYPE = "string";
     private static final String NUMBER_TYPE = "number";
     private static final String INTEGER_TYPE = "integer";
+    private static final String BOOLEAN_TYPE = "boolean";
 
     public static boolean isObjectSchema(Schema schema) {
         return isSchemaType(schema, OBJECT_TYPE) || (schema.getType() == null && (hasProperties(schema) || hasPatternProperties(schema)));
@@ -24,6 +25,10 @@ public class SchemaTypeUtils {
 
     public static boolean isNumberSchema(Schema schema) {
         return isSchemaType(schema, NUMBER_TYPE) || isSchemaType(schema, INTEGER_TYPE);
+    }
+
+    public static boolean isBooleanSchema(Schema schema) {
+        return isSchemaType(schema, BOOLEAN_TYPE);
     }
 
     private static boolean isSchemaType(Schema schema, String type) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5168Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5168Test.java
@@ -1,0 +1,83 @@
+package io.swagger.v3.core.converting;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
+import io.swagger.v3.core.util.Json31;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * test documenting how example values for booleans behave in their JSON-representation.
+ */
+public class Issue5168Test {
+
+    @Test
+    public void testExampleValuesAreSerializedAsJsonDifferentlyBetweenStringAndBoolean() throws Exception {
+        ResolvedSchema schema = ModelConverters.getInstance(true).readAllAsResolvedSchema(
+                ModelWithDifferentCombinationOfBooleanFieldsWithExamples.class
+        );
+
+        assertNotNull(schema, "Schema should resolve");
+        String json = Json31.pretty(schema);
+        assertNotNull(json);
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root = mapper.readTree(json);
+
+        JsonNode stringFieldType = root.at("/schema/properties/stringFieldType");
+        assertExampleIsString(stringFieldType);
+
+        JsonNode stringFieldTypeWithExplicitBooleanSchemaType = root.at("/schema/properties/stringFieldTypeWithExplicitBooleanSchemaType");
+        assertExampleIsBoolean(stringFieldTypeWithExplicitBooleanSchemaType);
+
+        JsonNode booleanFieldTypeWithExplicitStringSchemaType = root.at("/schema/properties/booleanFieldTypeWithExplicitStringSchemaType");
+        assertExampleIsString(booleanFieldTypeWithExplicitStringSchemaType);
+
+        JsonNode booleanFieldType = root.at("/schema/properties/booleanFieldType");
+        assertExampleIsBoolean(booleanFieldType);
+    }
+
+    private void assertExampleIsBoolean(JsonNode node) {
+        assertTrue(node.get("example").isBoolean(), "should be a boolean");
+    }
+
+    private void assertExampleIsString(JsonNode node) {
+        assertTrue(node.get("example").isTextual(), "should be a string");
+    }
+
+    public static class ModelWithDifferentCombinationOfBooleanFieldsWithExamples {
+
+        @io.swagger.v3.oas.annotations.media.Schema(example = "true")
+        String stringFieldType;
+
+        @io.swagger.v3.oas.annotations.media.Schema(type = "boolean", example = "true")
+        String stringFieldTypeWithExplicitBooleanSchemaType;
+
+        @io.swagger.v3.oas.annotations.media.Schema(type = "string", example = "true")
+        boolean booleanFieldTypeWithExplicitStringSchemaType;
+
+        @io.swagger.v3.oas.annotations.media.Schema(example = "true")
+        boolean booleanFieldType;
+
+        public String getStringFieldType() {
+            return stringFieldType;
+        }
+
+        public String getStringFieldTypeWithExplicitBooleanSchemaType() {
+            return stringFieldTypeWithExplicitBooleanSchemaType;
+        }
+
+        public boolean isBooleanFieldTypeWithExplicitStringSchemaType() {
+            return booleanFieldTypeWithExplicitStringSchemaType;
+        }
+
+        public boolean getBooleanFieldType() {
+            return booleanFieldType;
+        }
+    }
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/util/AnnotationsUtilsTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/util/AnnotationsUtilsTest.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.core.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
@@ -138,6 +139,15 @@ public class AnnotationsUtilsTest {
 
         @io.swagger.v3.oas.annotations.media.Schema(examples = {"42"}, type = "string")
         String stringExamplesWith42;
+
+        @io.swagger.v3.oas.annotations.media.Schema(example = "true")
+        boolean aBoolean;
+
+        @io.swagger.v3.oas.annotations.media.Schema(example = "true", type = "boolean")
+        String stringWithBooleanType;
+
+        @io.swagger.v3.oas.annotations.media.Schema(example = "true", type = "string")
+        String stringWithBooleanExample;
     }
 
     @Test
@@ -204,6 +214,72 @@ public class AnnotationsUtilsTest {
 
         assertTrue(schema.isPresent());
         assertEquals(schema.get().getExample(), IntNode.valueOf(5));
+    }
+
+    @Test
+    public void testExampleBooleanShouldBeNode() throws Exception {
+        io.swagger.v3.oas.annotations.media.Schema schemaAnnotation =
+                ExampleHolder.class
+                        .getDeclaredField("aBoolean")
+                        .getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+
+        Optional<Schema> schema =
+                AnnotationsUtils.getSchemaFromAnnotation(
+                        schemaAnnotation,
+                        null,
+                        null,
+                        false,
+                        null,
+                        Schema.SchemaResolution.DEFAULT,
+                        null
+                );
+
+        assertTrue(schema.isPresent());
+        assertEquals(schema.get().getExample(), BooleanNode.getTrue());
+    }
+
+    @Test
+    public void testExampleStringWithBooleanTypeShouldBeNode() throws Exception {
+        io.swagger.v3.oas.annotations.media.Schema schemaAnnotation =
+                ExampleHolder.class
+                        .getDeclaredField("stringWithBooleanType")
+                        .getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+
+        Optional<Schema> schema =
+                AnnotationsUtils.getSchemaFromAnnotation(
+                        schemaAnnotation,
+                        null,
+                        null,
+                        false,
+                        null,
+                        Schema.SchemaResolution.DEFAULT,
+                        null
+                );
+
+        assertTrue(schema.isPresent());
+        assertEquals(schema.get().getExample(), BooleanNode.getTrue());
+    }
+
+    @Test
+    public void testExampleStringWithBooleanShouldBeString() throws Exception {
+        io.swagger.v3.oas.annotations.media.Schema schemaAnnotation =
+                ExampleHolder.class
+                        .getDeclaredField("stringWithBooleanExample")
+                        .getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class);
+
+        Optional<Schema> schema =
+                AnnotationsUtils.getSchemaFromAnnotation(
+                        schemaAnnotation,
+                        null,
+                        null,
+                        false,
+                        null,
+                        Schema.SchemaResolution.DEFAULT,
+                        null
+                );
+
+        assertTrue(schema.isPresent());
+        assertEquals(schema.get().getExample(), "true");
     }
 
     static class DefaultHolder {


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

Fixes so that a boolean example value is serialized as a JsonNode rather than as a string (`true` vs `"true"`). This makes it so that the example in the json/yaml aligns with the type of the field.

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->

Fixes: #5168

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->