### PR TITLE
fix: exclude overridable annotation values when parsing composed annotations

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ValidationAnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ValidationAnnotationsUtils.java
@@ -3,8 +3,10 @@ package io.swagger.v3.core.util;
 import io.swagger.v3.oas.models.SpecVersion;
 import io.swagger.v3.oas.models.media.Schema;
 
+import javax.validation.OverridesAttribute;
 import javax.validation.constraints.*;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.ArrayDeque;
 import java.util.HashSet;
@@ -12,25 +14,28 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
+import java.util.List;
+import java.util.ArrayList;
 
 import static io.swagger.v3.core.util.SchemaTypeUtils.*;
 
 public class ValidationAnnotationsUtils {
 
-    public static final String JAVAX_NOT_NULL = "javax.validation.constraints.NotNull";
-    public static final String JAVAX_NOT_EMPTY = "javax.validation.constraints.NotEmpty";
-    public static final String JAVAX_NOT_BLANK = "javax.validation.constraints.NotBlank";
-    public static final String JAVAX_MIN = "javax.validation.constraints.Min";
-    public static final String JAVAX_MAX = "javax.validation.constraints.Max";
-    public static final String JAVAX_SIZE = "javax.validation.constraints.Size";
-    public static final String JAVAX_DECIMAL_MIN = "javax.validation.constraints.DecimalMin";
-    public static final String JAVAX_DECIMAL_MAX = "javax.validation.constraints.DecimalMax";
-    public static final String JAVAX_PATTERN = "javax.validation.constraints.Pattern";
-    public static final String JAVAX_EMAIL = "javax.validation.constraints.Email";
-    public static final String JAVAX_POSITIVE = "javax.validation.constraints.Positive";
-    public static final String JAVAX_POSITIVE_OR_ZERO = "javax.validation.constraints.PositiveOrZero";
-    public static final String JAVAX_NEGATIVE = "javax.validation.constraints.Negative";
-    public static final String JAVAX_NEGATIVE_OR_ZERO = "javax.validation.constraints.NegativeOrZero";
+    private static final String JAVAX_PACKAGE_BASE = "javax.validation.constraints";
+    public static final String JAVAX_NOT_NULL = JAVAX_PACKAGE_BASE + ".NotNull";
+    public static final String JAVAX_NOT_EMPTY = JAVAX_PACKAGE_BASE + ".NotEmpty";
+    public static final String JAVAX_NOT_BLANK = JAVAX_PACKAGE_BASE + ".NotBlank";
+    public static final String JAVAX_MIN = JAVAX_PACKAGE_BASE + ".Min";
+    public static final String JAVAX_MAX = JAVAX_PACKAGE_BASE + ".Max";
+    public static final String JAVAX_SIZE = JAVAX_PACKAGE_BASE + ".Size";
+    public static final String JAVAX_DECIMAL_MIN = JAVAX_PACKAGE_BASE + ".DecimalMin";
+    public static final String JAVAX_DECIMAL_MAX = JAVAX_PACKAGE_BASE + ".DecimalMax";
+    public static final String JAVAX_PATTERN = JAVAX_PACKAGE_BASE + ".Pattern";
+    public static final String JAVAX_EMAIL = JAVAX_PACKAGE_BASE + ".Email";
+    public static final String JAVAX_POSITIVE = JAVAX_PACKAGE_BASE + ".Positive";
+    public static final String JAVAX_POSITIVE_OR_ZERO = JAVAX_PACKAGE_BASE + ".PositiveOrZero";
+    public static final String JAVAX_NEGATIVE = JAVAX_PACKAGE_BASE + ".Negative";
+    public static final String JAVAX_NEGATIVE_OR_ZERO = JAVAX_PACKAGE_BASE + ".NegativeOrZero";
 
     private static final String SCHEMA_EMAIL_FORMAT_NAME = "email";
 
@@ -338,13 +343,16 @@ public class ValidationAnnotationsUtils {
                 if (a != null) queue.add(a);
             }
             while (!queue.isEmpty()) {
-                Annotation a = queue.poll();
-                if (!visited.add(a.annotationType())) continue;
-                for (Annotation meta : a.annotationType().getAnnotations()) {
+                Annotation annotation = queue.poll();
+                if (!visited.add(annotation.annotationType())) continue;
+                List<Class<? extends Annotation>> annotationsThatRelyOnOverride = findOverrides(annotation);
+                for (Annotation meta : annotation.annotationType().getAnnotations()) {
                     if (meta == null) continue;
                     String name = meta.annotationType().getName();
-                    if (name.startsWith("javax.validation.constraints")) {
-                        merged.putIfAbsent(name, meta);
+                    if (name.startsWith(JAVAX_PACKAGE_BASE)) {
+                        if (!annotationsThatRelyOnOverride.contains(meta.annotationType())) {
+                            merged.putIfAbsent(name, meta);
+                        }
                     } else {
                         queue.add(meta);
                     }
@@ -373,6 +381,27 @@ public class ValidationAnnotationsUtils {
 
     private static boolean currentMaximumOutsideNegativeRange(BigDecimal currentMaximum) {
         return currentMaximum == null || currentMaximum.compareTo(BigDecimal.ZERO) > 0;
+    }
+
+    /**
+     *
+     * @param annotation the composed constraint annotation
+     * @return the composing annotations that are overridden with {@link OverridesAttribute}
+     */
+    private static List<Class<? extends Annotation>> findOverrides(Annotation annotation) {
+        List<Class<? extends Annotation>> overriddenConstraintAnnotations = new ArrayList<>();
+
+        Class<? extends Annotation> type = annotation.annotationType();
+
+        for (Method method : type.getDeclaredMethods()) {
+            OverridesAttribute oa = method.getAnnotation(OverridesAttribute.class);
+
+            if (oa != null) {
+                overriddenConstraintAnnotations.add(oa.constraint());
+            }
+        }
+
+        return overriddenConstraintAnnotations;
     }
 
 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ValidationAnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ValidationAnnotationsUtils.java
@@ -14,8 +14,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.List;
-import java.util.ArrayList;
 
 import static io.swagger.v3.core.util.SchemaTypeUtils.*;
 
@@ -345,7 +343,7 @@ public class ValidationAnnotationsUtils {
             while (!queue.isEmpty()) {
                 Annotation annotation = queue.poll();
                 if (!visited.add(annotation.annotationType())) continue;
-                List<Class<? extends Annotation>> annotationsThatRelyOnOverride = findOverrides(annotation);
+                Set<Class<? extends Annotation>> annotationsThatRelyOnOverride = findOverrides(annotation);
                 for (Annotation meta : annotation.annotationType().getAnnotations()) {
                     if (meta == null) continue;
                     String name = meta.annotationType().getName();
@@ -388,16 +386,16 @@ public class ValidationAnnotationsUtils {
      * @param annotation the composed constraint annotation
      * @return the composing annotations that are overridden with {@link OverridesAttribute}
      */
-    private static List<Class<? extends Annotation>> findOverrides(Annotation annotation) {
-        List<Class<? extends Annotation>> overriddenConstraintAnnotations = new ArrayList<>();
+    private static Set<Class<? extends Annotation>> findOverrides(Annotation annotation) {
+        Set<Class<? extends Annotation>> overriddenConstraintAnnotations = new HashSet<>();
 
         Class<? extends Annotation> type = annotation.annotationType();
 
         for (Method method : type.getDeclaredMethods()) {
-            OverridesAttribute oa = method.getAnnotation(OverridesAttribute.class);
-
-            if (oa != null) {
-                overriddenConstraintAnnotations.add(oa.constraint());
+            for (OverridesAttribute oa : method.getAnnotationsByType(OverridesAttribute.class)) {
+                if (oa != null) {
+                    overriddenConstraintAnnotations.add(oa.constraint());
+                }
             }
         }
 

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedConstraintMetaAnnotationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedConstraintMetaAnnotationTest.java
@@ -88,6 +88,51 @@ public class ComposedConstraintMetaAnnotationTest {
         Class<? extends Payload>[] payload() default {};
     }
 
+    @Min(0)
+    @Max(Long.MAX_VALUE)
+    @Target({ElementType.FIELD, ElementType.PARAMETER})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Constraint(validatedBy = {})
+    public @interface RangeWithOverridesAttributeList {
+        @OverridesAttribute.List({
+                @OverridesAttribute(constraint = Min.class, name = "value"),
+                @OverridesAttribute(constraint = Max.class, name = "value")
+        })
+        long value() default 0;
+
+        String message() default "Out of range";
+        Class<?>[] groups() default {};
+        Class<? extends Payload>[] payload() default {};
+    }
+
+    @Min(0)
+    @Max(Long.MAX_VALUE)
+    @Target({ElementType.FIELD, ElementType.PARAMETER})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Constraint(validatedBy = {})
+    public @interface RangeWithRepeatedOverridesAttribute {
+        @OverridesAttribute(constraint = Min.class, name = "value")
+        @OverridesAttribute(constraint = Max.class, name = "value")
+        long value() default 0;
+
+        String message() default "Out of range";
+        Class<?>[] groups() default {};
+        Class<? extends Payload>[] payload() default {};
+    }
+
+    @Size(min = 2, max = 100)
+    @Target({ElementType.FIELD, ElementType.PARAMETER})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Constraint(validatedBy = {})
+    public @interface LimitedText {
+        @OverridesAttribute(constraint = Size.class, name = "max")
+        int max() default 100;
+
+        String message() default "Invalid text";
+        Class<?>[] groups() default {};
+        Class<? extends Payload>[] payload() default {};
+    }
+
     @FourOrMore(max = 10)
     @Max(value = 10)
     @Target({ElementType.FIELD, ElementType.PARAMETER})
@@ -157,6 +202,15 @@ public class ComposedConstraintMetaAnnotationTest {
         @ComposedFourOrMoreWithFixedMax
         private Short composedFourOrMoreWithFixedMax;
 
+        @RangeWithOverridesAttributeList(5)
+        private Short rangeWithOverridesAttributeList;
+
+        @RangeWithRepeatedOverridesAttribute(5)
+        private Short rangeWithRepeatedOverridesAttribute;
+
+        @LimitedText(max = 20)
+        private String limitedText;
+
         public Short getRangeField() { return rangeField; }
         public void setRangeField(Short rangeField) { this.rangeField = rangeField; }
         public Short getPartiallyOverriddenComposedField() { return partiallyOverriddenComposedField; }
@@ -170,6 +224,30 @@ public class ComposedConstraintMetaAnnotationTest {
 
         public void setComposedFourOrMoreWithFixedMax(Short composedFourOrMoreWithFixedMax) {
             this.composedFourOrMoreWithFixedMax = composedFourOrMoreWithFixedMax;
+        }
+
+        public Short getRangeWithOverridesAttributeList() {
+            return rangeWithOverridesAttributeList;
+        }
+
+        public void setRangeWithOverridesAttributeList(Short rangeWithOverridesAttributeList) {
+            this.rangeWithOverridesAttributeList = rangeWithOverridesAttributeList;
+        }
+
+        public Short getRangeWithRepeatedOverridesAttribute() {
+            return rangeWithRepeatedOverridesAttribute;
+        }
+
+        public void setRangeWithRepeatedOverridesAttribute(Short rangeWithRepeatedOverridesAttribute) {
+            this.rangeWithRepeatedOverridesAttribute = rangeWithRepeatedOverridesAttribute;
+        }
+
+        public String getLimitedText() {
+            return limitedText;
+        }
+
+        public void setLimitedText(String limitedText) {
+            this.limitedText = limitedText;
         }
     }
 
@@ -273,5 +351,46 @@ public class ComposedConstraintMetaAnnotationTest {
                 "expected 4 from type definition since it does not have an OverridesAttribute");
         assertEquals(range.getMaximum().longValue(), 10L,
                 "expected 10 from type definition since we have an explicit non-overridden @Max annotation next to @FourOrMore");
+    }
+
+    @Test
+    public void detectsOverridesAttributeListContainer() {
+        Map<String, Schema> schemas = ModelConverters.getInstance().readAll(ComposedAnnotationsDto.class);
+        Schema model = schemas.get("ComposedAnnotationsDto");
+        Schema range = (Schema) model.getProperties().get("rangeWithOverridesAttributeList");
+        assertNotNull(range, "rangeWithOverridesAttributeList property should exist");
+        assertNull(range.getMinimum(),
+                "expected null since container-declared @OverridesAttribute makes @Min override-dependent");
+        assertNull(range.getMaximum(),
+                "expected null since container-declared @OverridesAttribute makes @Max override-dependent");
+    }
+
+    @Test
+    public void detectsRepeatedOverridesAttributeDeclarations() {
+        Map<String, Schema> schemas = ModelConverters.getInstance().readAll(ComposedAnnotationsDto.class);
+        Schema model = schemas.get("ComposedAnnotationsDto");
+        Schema range = (Schema) model.getProperties().get("rangeWithRepeatedOverridesAttribute");
+        assertNotNull(range, "rangeWithRepeatedOverridesAttribute property should exist");
+        assertNull(range.getMinimum(),
+                "expected null since repeated @OverridesAttribute makes @Min override-dependent");
+        assertNull(range.getMaximum(),
+                "expected null since repeated @OverridesAttribute makes @Max override-dependent");
+    }
+
+    /**
+     * Future override resolution should keep the fixed {@code min=2} and apply the use-site
+     * {@code max=20}. The current conservative behavior omits the whole {@code @Size}
+     * composing annotation once any of its attributes are override-dependent.
+     */
+    @Test
+    public void partialMultiAttributeOverrideSuppressesWholeComposingAnnotation() {
+        Map<String, Schema> schemas = ModelConverters.getInstance().readAll(ComposedAnnotationsDto.class);
+        Schema model = schemas.get("ComposedAnnotationsDto");
+        Schema limitedText = (Schema) model.getProperties().get("limitedText");
+        assertNotNull(limitedText, "limitedText property should exist");
+        assertNull(limitedText.getMinLength(),
+                "expected null because the whole @Size composing annotation is currently suppressed");
+        assertNull(limitedText.getMaxLength(),
+                "expected null because swagger-core does not yet resolve use-site @OverridesAttribute values");
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedConstraintMetaAnnotationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/ComposedConstraintMetaAnnotationTest.java
@@ -8,19 +8,14 @@ import org.testng.annotations.Test;
 import javax.validation.Constraint;
 import javax.validation.OverridesAttribute;
 import javax.validation.Payload;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.*;
 
 public class ComposedConstraintMetaAnnotationTest {
 
@@ -56,11 +51,11 @@ public class ComposedConstraintMetaAnnotationTest {
     }
 
     /**
-     * Mimics how Hibernate Validator's @Range works: meta-annotations @Min/@Max carry default
+     * Mimics how Hibernate Validator's {@code @Range} works: meta-annotations @Min/@Max carry default
      * values, while the actual per-use values are meant to be applied via @OverridesAttribute.
      * Our implementation reads meta-annotations from the annotation *type definition*, so it
      * always sees the defaults (min=0, max=Long.MAX_VALUE) — not whatever the caller passes
-     * as @ValidRange(min=5, max=50). This is a known limitation documented by the test below.
+     * as {@code @ValidRange(min=5, max=50)}. This is a known limitation documented by the test below.
      */
     @Min(0)
     @Max(Long.MAX_VALUE)
@@ -73,6 +68,32 @@ public class ComposedConstraintMetaAnnotationTest {
 
         @OverridesAttribute(constraint = Max.class, name = "value")
         long max() default Long.MAX_VALUE;
+
+        String message() default "Out of range";
+        Class<?>[] groups() default {};
+        Class<? extends Payload>[] payload() default {};
+    }
+
+    @Min(4)
+    @Max(Long.MAX_VALUE)
+    @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Constraint(validatedBy = {})
+    public @interface FourOrMore {
+        @OverridesAttribute(constraint = Max.class, name = "value")
+        long max() default Long.MAX_VALUE;
+
+        String message() default "Out of range";
+        Class<?>[] groups() default {};
+        Class<? extends Payload>[] payload() default {};
+    }
+
+    @FourOrMore(max = 10)
+    @Max(value = 10)
+    @Target({ElementType.FIELD, ElementType.PARAMETER})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Constraint(validatedBy = {})
+    public @interface ComposedFourOrMoreWithFixedMax {
 
         String message() default "Out of range";
         Class<?>[] groups() default {};
@@ -105,9 +126,6 @@ public class ComposedConstraintMetaAnnotationTest {
         @ValidEmail
         private String email;
 
-        @ValidRange(min = 5, max = 50)
-        private Short rangeField;
-
         @ValidStoreIdNested
         private Short nestedStoreId;
 
@@ -123,12 +141,36 @@ public class ComposedConstraintMetaAnnotationTest {
         public void setName(String name) { this.name = name; }
         public String getEmail() { return email; }
         public void setEmail(String email) { this.email = email; }
-        public Short getRangeField() { return rangeField; }
-        public void setRangeField(Short rangeField) { this.rangeField = rangeField; }
         public Short getNestedStoreId() { return nestedStoreId; }
         public void setNestedStoreId(Short nestedStoreId) { this.nestedStoreId = nestedStoreId; }
         public Short getPriorityStoreId() { return priorityStoreId; }
         public void setPriorityStoreId(Short priorityStoreId) { this.priorityStoreId = priorityStoreId; }
+    }
+
+    static class ComposedAnnotationsDto {
+        @ValidRange(min = 5, max = 50)
+        private Short rangeField;
+
+        @FourOrMore(max = 10)
+        private Short partiallyOverriddenComposedField;
+
+        @ComposedFourOrMoreWithFixedMax
+        private Short composedFourOrMoreWithFixedMax;
+
+        public Short getRangeField() { return rangeField; }
+        public void setRangeField(Short rangeField) { this.rangeField = rangeField; }
+        public Short getPartiallyOverriddenComposedField() { return partiallyOverriddenComposedField; }
+        public void setPartiallyOverriddenComposedField(Short partiallyOverriddenComposedField) {
+            this.partiallyOverriddenComposedField = partiallyOverriddenComposedField;
+        }
+
+        public Short getComposedFourOrMoreWithFixedMax() {
+            return composedFourOrMoreWithFixedMax;
+        }
+
+        public void setComposedFourOrMoreWithFixedMax(Short composedFourOrMoreWithFixedMax) {
+            this.composedFourOrMoreWithFixedMax = composedFourOrMoreWithFixedMax;
+        }
     }
 
     @Test
@@ -192,23 +234,44 @@ public class ComposedConstraintMetaAnnotationTest {
     }
 
     /**
-     * Documents a known limitation: for @Range-style constraints that rely on @OverridesAttribute
-     * to propagate per-use values (e.g. @ValidRange(min=5, max=50)) into their meta-annotations
-     * (@Min/@Max), our implementation reads constraints from the annotation *type definition*
-     * and therefore always sees the default values (min=0, max=Long.MAX_VALUE), not the
-     * caller-supplied ones. Handling @OverridesAttribute is not yet supported.
+     * Documents a known limitation: handling {@link OverridesAttribute} is not yet supported,
+     * and instead the annotation and its composing/meta annotations are ignored entirely.
      */
     @Test
-    public void rangeStyleConstraintUsesDefaultsNotOverriddenValues() {
-        Map<String, Schema> schemas = ModelConverters.getInstance().readAll(TestStoreDto.class);
-        Schema model = schemas.get("TestStoreDto");
+    public void rangeStyleConstraintDoesNotDefineConstraintsSinceItReliesOnOverriddenValues() {
+        Map<String, Schema> schemas = ModelConverters.getInstance().readAll(ComposedAnnotationsDto.class);
+        Schema model = schemas.get("ComposedAnnotationsDto");
         Schema range = (Schema) model.getProperties().get("rangeField");
         assertNotNull(range, "rangeField property should exist");
         // We pick up the *default* values from @Min(0) and @Max(Long.MAX_VALUE) on the type
-        // definition of @ValidRange, NOT the caller-supplied @ValidRange(min=5, max=50).
-        assertEquals(range.getMinimum().longValue(), 0L,
-                "expected default @Min(0) from type definition, not overridden min=5");
-        assertEquals(range.getMaximum().longValue(), Long.MAX_VALUE,
-                "expected default @Max(Long.MAX_VALUE) from type definition, not overridden max=50");
+        // definition of @ValidRange, But we then drop them since we see that they are modified with an OverridesAttribute.
+        assertNull(range.getMinimum(),
+                "expected null since we drop the @Min from the overridden composed @ValidRange annotation");
+        assertNull(range.getMaximum(),
+                "expected null since we drop the @Max from the overridden composed @ValidRange annotation");
+    }
+
+    @Test
+    public void composedStyleConstraintUsesOnlyNonOverrideableValues() {
+        Map<String, Schema> schemas = ModelConverters.getInstance().readAll(ComposedAnnotationsDto.class);
+        Schema model = schemas.get("ComposedAnnotationsDto");
+        Schema range = (Schema) model.getProperties().get("partiallyOverriddenComposedField");
+        assertNotNull(range, "partiallyOverriddenComposedField property should exist");
+        assertEquals(range.getMinimum().longValue(), 4L,
+                "expected 4 from type definition since it does not have an OverridesAttribute");
+        assertNull(range.getMaximum(),
+                "expected null since we drop the @Max from the overridden composed @FourOrMore annotation");
+    }
+
+    @Test
+    public void nestedComposedStyleConstraintUsesOnlyNonOverrideableValues() {
+        Map<String, Schema> schemas = ModelConverters.getInstance().readAll(ComposedAnnotationsDto.class);
+        Schema model = schemas.get("ComposedAnnotationsDto");
+        Schema range = (Schema) model.getProperties().get("composedFourOrMoreWithFixedMax");
+        assertNotNull(range, "composedFourOrMoreWithFixedMax property should exist");
+        assertEquals(range.getMinimum().longValue(), 4L,
+                "expected 4 from type definition since it does not have an OverridesAttribute");
+        assertEquals(range.getMaximum().longValue(), 10L,
+                "expected 10 from type definition since we have an explicit non-overridden @Max annotation next to @FourOrMore");
     }
 }


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

Change the meta-annotation parsing so that annotations that utilize `@OverridesAttribute` do not take the overridden annotation into consideration. This since the library currently does not support parsing the `@OverridesAttribute` value definition.

I know that the Hibernate validator most likely has code to manage this, but I do not believe that is a dependency that this project needs or wants as of now. Both swagger-core and springdoc-openapi both have extension possibilities for injecting interpretation logic of annotations, so that is how these annotations can be managed currently.

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->

Fixes: #5178

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->