### PR TITLE
Honor PropertyNamingStrategy for get/is-prefixed property names

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -669,7 +669,15 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
             // hack to avoid clobbering properties with get/is names
             // it's ugly but gets around https://github.com/swagger-api/swagger-core/issues/415
-            if (propDef.getPrimaryMember() != null) {
+            //
+            // This restores the raw member name for members that merely start with a get/is prefix
+            // (e.g. a Scala accessor "is_persistent", or a JAXB-renamed field, see #415 and #2635).
+            // It must NOT run when a custom PropertyNamingStrategy (e.g. SNAKE_CASE) is configured:
+            // in that case the strategy legitimately translates names such as "issuanceDate" ->
+            // "issuance_date" and the raw member name must not clobber the translated one
+            // (see springdoc/springdoc-openapi#3293).
+            if (propDef.getPrimaryMember() != null
+                    && _mapper.getSerializationConfig().getPropertyNamingStrategy() == null) {
                 final JsonProperty jsonPropertyAnn = propDef.getPrimaryMember().getAnnotation(JsonProperty.class);
                 if (jsonPropertyAnn == null || !jsonPropertyAnn.value().equals(propName)) {
                     if (member != null) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyMetadata;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.introspect.Annotated;
 import com.fasterxml.jackson.databind.introspect.AnnotatedClass;
@@ -640,6 +641,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         }
 
         final XmlAccessorType xmlAccessorTypeAnnotation = beanDesc.getClassAnnotations().get(XmlAccessorType.class);
+        final JsonNaming jsonNamingAnnotation = beanDesc.getClassAnnotations().get(JsonNaming.class);
 
         // see if @JsonIgnoreProperties exist
         Set<String> propertiesToIgnore = resolveIgnoredProperties(beanDesc.getClassAnnotations(), annotatedType.getCtxAnnotations());
@@ -677,7 +679,8 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
             // "issuance_date" and the raw member name must not clobber the translated one
             // (see springdoc/springdoc-openapi#3293).
             if (propDef.getPrimaryMember() != null
-                    && _mapper.getSerializationConfig().getPropertyNamingStrategy() == null) {
+                    && _mapper.getSerializationConfig().getPropertyNamingStrategy() == null
+                    && jsonNamingAnnotation == null) {
                 final JsonProperty jsonPropertyAnn = propDef.getPrimaryMember().getAnnotation(JsonProperty.class);
                 if (jsonPropertyAnn == null || !jsonPropertyAnn.value().equals(propName)) {
                     if (member != null) {

--- a/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/RecordPropertyNamingStrategyTest.java
+++ b/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/RecordPropertyNamingStrategyTest.java
@@ -1,0 +1,52 @@
+package io.swagger.v3.java17.resolving;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Reproduces the property-naming inconsistency reported in
+ * springdoc/springdoc-openapi#3293: when a {@link PropertyNamingStrategies} such as
+ * {@code SNAKE_CASE} is configured, record components whose names start with the
+ * {@code is}/{@code get} accessor prefixes followed by a lower-case letter (e.g.
+ * {@code issuanceDate}) were not being translated, because the
+ * "avoid clobbering get/is names" hack in {@code ModelResolver} replaced the
+ * Jackson-resolved (translated) name with the raw component name.
+ */
+public class RecordPropertyNamingStrategyTest {
+
+    public record PidLookupResponse(
+            String familyName,
+            String expiryDate,
+            String issuanceDate,
+            String issuingCountry,
+            String issuingAuthority
+    ) {
+    }
+
+    @Test
+    public void testSnakeCaseNamingStrategyAppliedToRecordComponents() {
+        ModelResolver modelResolver = new ModelResolver(
+                Json.mapper().copy().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE));
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        Schema<?> schema = modelResolver.resolve(new AnnotatedType(PidLookupResponse.class), context, null);
+
+        assertTrue(schema.getProperties().containsKey("family_name"));
+        assertTrue(schema.getProperties().containsKey("expiry_date"));
+        assertTrue(schema.getProperties().containsKey("issuance_date"),
+                "expected issuance_date but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("issuing_country"),
+                "expected issuing_country but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("issuing_authority"),
+                "expected issuing_authority but got " + schema.getProperties().keySet());
+        assertEquals(schema.getProperties().size(), 5, "unexpected properties: " + schema.getProperties().keySet());
+    }
+}

--- a/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/RecordPropertyNamingStrategyTest.java
+++ b/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/RecordPropertyNamingStrategyTest.java
@@ -1,6 +1,7 @@
 package io.swagger.v3.java17.resolving;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverterContextImpl;
 import io.swagger.v3.core.jackson.ModelResolver;
@@ -8,7 +9,10 @@ import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.Schema;
 import org.testng.annotations.Test;
 
+import javax.xml.bind.annotation.XmlElement;
+
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -27,8 +31,68 @@ public class RecordPropertyNamingStrategyTest {
             String expiryDate,
             String issuanceDate,
             String issuingCountry,
-            String issuingAuthority
+            String issuingAuthority,
+            String getawayDate
     ) {
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record JsonNamingPidLookupResponse(
+            String familyName,
+            String expiryDate,
+            String issuanceDate,
+            String issuingCountry,
+            String issuingAuthority,
+            String getawayDate
+    ) {
+    }
+
+    public record MixInPidLookupResponse(
+            String familyName,
+            String expiryDate,
+            String issuanceDate,
+            String issuingCountry,
+            String issuingAuthority,
+            String getawayDate
+    ) {
+    }
+
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public abstract static class SnakeCaseMixIn {
+    }
+
+    public record BooleanStatusResponse(
+            boolean isActive
+    ) {
+    }
+
+    public static class LegacyIsPersistentResponse {
+
+        public boolean is_persistent() {
+            return true;
+        }
+
+        public String gettersAndHaters() {
+            return null;
+        }
+    }
+
+    public static class XmlRenamedIsPrefixResponse {
+
+        @XmlElement(name = "beerDrinkXmlElement")
+        private String isotonicDrinkOnlyXmlElement;
+
+        public String getIsotonicDrinkOnlyXmlElement() {
+            return isotonicDrinkOnlyXmlElement;
+        }
+    }
+
+    public static class CustomPrefixStrategy extends PropertyNamingStrategies.NamingBase {
+
+        @Override
+        public String translate(String propertyName) {
+            return propertyName == null ? null : "custom_" + propertyName;
+        }
     }
 
     @Test
@@ -47,6 +111,121 @@ public class RecordPropertyNamingStrategyTest {
                 "expected issuing_country but got " + schema.getProperties().keySet());
         assertTrue(schema.getProperties().containsKey("issuing_authority"),
                 "expected issuing_authority but got " + schema.getProperties().keySet());
-        assertEquals(schema.getProperties().size(), 5, "unexpected properties: " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("getaway_date"),
+                "expected getaway_date but got " + schema.getProperties().keySet());
+        assertEquals(schema.getProperties().size(), 6, "unexpected properties: " + schema.getProperties().keySet());
+    }
+
+    @Test
+    public void testClassLevelJsonNamingAppliedToRecordComponents() {
+        ModelResolver modelResolver = new ModelResolver(Json.mapper().copy());
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        Schema<?> schema = modelResolver.resolve(new AnnotatedType(JsonNamingPidLookupResponse.class), context, null);
+
+        assertNull(modelResolver.objectMapper()
+                        .getSerializationConfig()
+                        .getPropertyNamingStrategy());
+        assertTrue(schema.getProperties().containsKey("family_name"));
+        assertTrue(schema.getProperties().containsKey("expiry_date"));
+        assertTrue(schema.getProperties().containsKey("issuance_date"),
+                "expected issuance_date but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("issuing_country"),
+                "expected issuing_country but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("issuing_authority"),
+                "expected issuing_authority but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("getaway_date"),
+                "expected getaway_date but got " + schema.getProperties().keySet());
+        assertEquals(schema.getProperties().size(), 6, "unexpected properties: " + schema.getProperties().keySet());
+    }
+
+    @Test
+    public void testMixInJsonNamingAppliedToRecordComponents() {
+        ModelResolver modelResolver = new ModelResolver(Json.mapper().copy()
+                .addMixIn(MixInPidLookupResponse.class, SnakeCaseMixIn.class));
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        Schema<?> schema = modelResolver.resolve(new AnnotatedType(MixInPidLookupResponse.class), context, null);
+
+        assertNull(modelResolver.objectMapper()
+                .getSerializationConfig()
+                .getPropertyNamingStrategy());
+        assertTrue(schema.getProperties().containsKey("family_name"));
+        assertTrue(schema.getProperties().containsKey("expiry_date"));
+        assertTrue(schema.getProperties().containsKey("issuance_date"),
+                "expected issuance_date but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("issuing_country"),
+                "expected issuing_country but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("issuing_authority"),
+                "expected issuing_authority but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("getaway_date"),
+                "expected getaway_date but got " + schema.getProperties().keySet());
+        assertEquals(schema.getProperties().size(), 6, "unexpected properties: " + schema.getProperties().keySet());
+    }
+
+    @Test
+    public void testBooleanIsRecordComponentWithSnakeCaseNamingStrategy() {
+        ModelResolver modelResolver = new ModelResolver(
+                Json.mapper().copy().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE));
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        Schema<?> schema = modelResolver.resolve(new AnnotatedType(BooleanStatusResponse.class), context, null);
+
+        assertTrue(schema.getProperties().containsKey("is_active"),
+                "expected is_active but got " + schema.getProperties().keySet());
+        assertEquals(schema.getProperties().size(), 1, "unexpected properties: " + schema.getProperties().keySet());
+    }
+
+    @Test
+    public void testLegacyIsPersistentNameWithNoNamingStrategy() {
+        ModelResolver modelResolver = new ModelResolver(Json.mapper().copy());
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        Schema<?> schema = modelResolver.resolve(new AnnotatedType(LegacyIsPersistentResponse.class), context, null);
+
+        assertNull(modelResolver.objectMapper()
+                .getSerializationConfig()
+                .getPropertyNamingStrategy());
+        assertTrue(schema.getProperties().containsKey("is_persistent"),
+                "expected is_persistent but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("gettersAndHaters"),
+                "expected gettersAndHaters but got " + schema.getProperties().keySet());
+        assertEquals(schema.getProperties().size(), 2, "unexpected properties: " + schema.getProperties().keySet());
+    }
+
+    @Test
+    public void testXmlRenamedIsPrefixFieldKeepsOriginalNameWithNoNamingStrategy() {
+        ModelResolver modelResolver = new ModelResolver(Json.mapper().copy());
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        Schema<?> schema = modelResolver.resolve(new AnnotatedType(XmlRenamedIsPrefixResponse.class), context, null);
+
+        assertNull(modelResolver.objectMapper()
+                .getSerializationConfig()
+                .getPropertyNamingStrategy());
+        assertTrue(schema.getProperties().containsKey("isotonicDrinkOnlyXmlElement"),
+                "expected isotonicDrinkOnlyXmlElement but got " + schema.getProperties().keySet());
+        assertEquals(schema.getProperties().size(), 1, "unexpected properties: " + schema.getProperties().keySet());
+    }
+
+    @Test
+    public void testCustomNamingStrategyAppliedToGetAndIsPrefixedRecordComponents() {
+        ModelResolver modelResolver = new ModelResolver(
+                Json.mapper().copy().setPropertyNamingStrategy(new CustomPrefixStrategy()));
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        Schema<?> schema = modelResolver.resolve(new AnnotatedType(PidLookupResponse.class), context, null);
+
+        assertTrue(schema.getProperties().containsKey("custom_familyName"));
+        assertTrue(schema.getProperties().containsKey("custom_expiryDate"));
+        assertTrue(schema.getProperties().containsKey("custom_issuanceDate"),
+                "expected custom_issuanceDate but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("custom_issuingCountry"),
+                "expected custom_issuingCountry but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("custom_issuingAuthority"),
+                "expected custom_issuingAuthority but got " + schema.getProperties().keySet());
+        assertTrue(schema.getProperties().containsKey("custom_getawayDate"),
+                "expected custom_getawayDate but got " + schema.getProperties().keySet());
+        assertEquals(schema.getProperties().size(), 6, "unexpected properties: " + schema.getProperties().keySet());
     }
 }


### PR DESCRIPTION
## Description

When a custom `PropertyNamingStrategy` (e.g. `SNAKE_CASE`) is configured on the mapper, `ModelResolver` produced **inconsistent** schema property names: most fields were translated, but any property whose member name starts with a `get`/`is` prefix followed by a lower-case letter kept its original camelCase name.

Example (`SNAKE_CASE`, Java record):

```java
public record PidLookupResponse(
    String familyName, String expiryDate,
    String issuanceDate, String issuingCountry, String issuingAuthority) {}
```

Produced:

```
family_name, expiry_date, issuanceDate, issuingCountry, issuingAuthority
```

instead of the expected `issuance_date`, `issuing_country`, `issuing_authority`.

### Root cause

The "avoid clobbering properties with get/is names" hack (added for #415) overwrites the Jackson-resolved property name with the **raw member name** whenever the member name starts with `get`/`is` + lower-case. For record components the accessor's physical name is the bare component name (`issuanceDate`), which starts with `is`, so the hack replaced the strategy-translated `issuance_date` with `issuanceDate`.

### Fix

Only apply the hack when **no** `PropertyNamingStrategy` is configured. When a strategy is active the resolved name is authoritative and must be honored uniformly. The hack was only ever needed to restore raw names in the absence of a strategy:
- **#415** (Scala accessor `is_persistent` wrongly shortened to `_persistent`) — default mapper, no strategy → hack still runs.
- **#2635** (JAXB-renamed `is`-prefixed fields keeping their original name) — JAXB mapper, no strategy → hack still runs.

Both existing test cases continue to pass.

This bug surfaces through springdoc and was traced to swagger-core: springdoc/springdoc-openapi#3293.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Tests

## Checklist

- [x] I have added/updated tests as needed
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues

## Test evidence

Added `RecordPropertyNamingStrategyTest` (in `swagger-java17-support`, which compiles at Java 17 for records). It fails on `master` (`issuanceDate` not translated) and passes with this change.

Verification done: reproduced on `master`; ran the full test suites for `swagger-core`, `swagger-jaxrs2` (incl. `ReaderTest#testModelResolverXMLPropertiesName` for #2635) and `swagger-java17-support` — all green (`BUILD SUCCESS`).
