### PR TITLE
Restore inner property name from map key in handleUnwrapped

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -95,7 +95,6 @@ import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1461,7 +1460,18 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     private void handleUnwrapped(List<Schema> props, Schema innerModel, String prefix, String suffix, List<String> requiredProps) {
         if (StringUtils.isBlank(suffix) && StringUtils.isBlank(prefix)) {
             if (innerModel.getProperties() != null) {
-                props.addAll(innerModel.getProperties().values());
+                // Schema.getName() is @JsonIgnore, so any prior JSON-based clone of innerModel
+                // (e.g. AnnotationsUtils.clone) leaves nested property schemas with a null name
+                // while the properties-map key still carries the correct name. Restore from the
+                // map key so the eventual `modelProps.put(prop.getName(), prop)` does not insert
+                // a null key (see swagger-api/swagger-core#5126).
+                for (Map.Entry<String, Schema> entry : ((Map<String, Schema>) innerModel.getProperties()).entrySet()) {
+                    Schema prop = entry.getValue();
+                    if (prop.getName() == null) {
+                        prop.setName(entry.getKey());
+                    }
+                    props.add(prop);
+                }
                 if (innerModel.getRequired() != null) {
                     requiredProps.addAll(innerModel.getRequired());
                 }
@@ -1475,10 +1485,14 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 suffix = "";
             }
             if (innerModel.getProperties() != null) {
-                for (Schema prop : (Collection<Schema>) innerModel.getProperties().values()) {
+                for (Map.Entry<String, Schema> entry : ((Map<String, Schema>) innerModel.getProperties()).entrySet()) {
+                    Schema prop = entry.getValue();
                     try {
                         Schema clonedProp = Json.mapper().readValue(Json.pretty(prop), Schema.class);
-                        clonedProp.setName(prefix + prop.getName() + suffix);
+                        // Fall back to the map key when the prop's transient name has been lost
+                        // by a prior clone (Schema.getName() is @JsonIgnore).
+                        String baseName = prop.getName() != null ? prop.getName() : entry.getKey();
+                        clonedProp.setName(prefix + baseName + suffix);
                         props.add(clonedProp);
                     } catch (IOException e) {
                         LOGGER.error("Exception cloning property", e);

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket5126Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket5126Test.java
@@ -1,6 +1,8 @@
 package io.swagger.v3.core.resolving;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.util.AnnotationsUtils;
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.models.media.Schema;
 import org.testng.annotations.BeforeMethod;
@@ -8,29 +10,30 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 /**
- * Regression test for <a href="https://github.com/swagger-api/swagger-core/issues/5126">#5126</a>.
+ * Defensive invariant tests related to
+ * <a href="https://github.com/swagger-api/swagger-core/issues/5126">#5126</a>.
  *
- * <p>When an inner model's nested property schemas have a {@code null} name — which happens
- * naturally after {@code AnnotationsUtils.clone} round-trips the schema through JSON, because
- * {@code Schema.getName()} is {@code @JsonIgnore} — {@link ModelResolver#handleUnwrapped} would
- * forward those schemas into the outer model's properties list as-is. The subsequent
- * {@code modelProps.put(prop.getName(), prop)} then inserts a {@code null} key into the outer's
- * properties map, which later causes Jackson to fail serializing the OpenAPI document with
- * {@code JsonMappingException: Null key for a Map not allowed in JSON}.
+ * <p>{@link ModelResolver#handleUnwrapped} must not forward null-named property schemas into the
+ * outer model's properties list. The later {@code modelProps.put(prop.getName(), prop)} step uses
+ * those names as map keys, and a {@code null} key makes Jackson fail when serializing the schema.
  *
- * <p>This test invokes {@code handleUnwrapped} directly with a hand-crafted inner model whose
- * property schemas have a {@code null} name (simulating the post-clone state) and verifies that
- * the resulting property names come from the inner properties-map keys, not from the transient
- * {@code Schema.name} field.
+ * <p>These tests exercise the private method directly because the reported Spring HATEOAS path has
+ * not been reproduced as a swagger-core-only resolver test. The clone-based case demonstrates the
+ * concrete intermediate state this guard is intended to tolerate: {@code AnnotationsUtils.clone}
+ * keeps the properties-map keys while losing nested {@code Schema.name} values because
+ * {@code Schema.getName()} is {@code @JsonIgnore}.
  */
 public class Ticket5126Test extends SwaggerTestBase {
 
@@ -46,31 +49,81 @@ public class Ticket5126Test extends SwaggerTestBase {
     }
 
     @Test
-    public void noPrefixOrSuffix_restoresNameFromInnerPropertiesMapKey() throws Exception {
-        Schema<?> nameSchema = new Schema<>().type("string");      // name field unset
-        Schema<?> countSchema = new Schema<>().type("integer");    // name field unset
+    public void noPrefixOrSuffix_restoresNameFromClonedInnerPropertiesMapKey() throws Exception {
+        Schema<Object> inner = cloneLosingNestedPropertyNames(namedInnerSchema());
+
+        assertEquals(inner.getProperties().keySet(), new LinkedHashSet<>(Arrays.asList("name", "count")));
+        assertNull(((Schema<?>) inner.getProperties().get("name")).getName());
+        assertNull(((Schema<?>) inner.getProperties().get("count")).getName());
+
+        List<Schema> props = invokeHandleUnwrapped(inner, "", "");
+
+        assertPropertyNames(props, "name", "count");
+        Schema<Object> outer = schemaWithModelProps(props);
+        assertFalse(outer.getProperties().containsKey(null));
+        Json.mapper().writeValueAsString(outer);
+    }
+
+    @Test
+    public void noPrefixOrSuffix_restoresNameFromInnerPropertiesMapKeyForNullNameState() throws Exception {
+        Schema<Object> inner = innerSchemaWithNullPropertyNames();
+
+        List<Schema> props = invokeHandleUnwrapped(inner, "", "");
+
+        assertPropertyNames(props, "name", "count");
+    }
+
+    @Test
+    public void noPrefixOrSuffix_preservesExistingPropertyName() throws Exception {
+        Schema<?> nameSchema = new Schema<>().type("string");
+        nameSchema.setName("schemaName");
         Schema<Object> inner = new Schema<>();
         Map<String, Schema> innerProps = new LinkedHashMap<>();
-        innerProps.put("name", nameSchema);
-        innerProps.put("count", countSchema);
+        innerProps.put("mapName", nameSchema);
         inner.setProperties(innerProps);
 
-        List<Schema> props = new ArrayList<>();
-        List<String> requiredProps = new ArrayList<>();
-        handleUnwrapped.invoke(modelResolver, props, inner, "", "", requiredProps);
+        List<Schema> props = invokeHandleUnwrapped(inner, "", "");
 
-        assertEquals(props.size(), 2);
-        LinkedHashSet<String> names = new LinkedHashSet<>();
-        for (Schema p : props) {
-            assertNotNull(p.getName(),
-                    "Each unwrapped property must carry a non-null name to avoid null keys in the outer's properties map");
-            names.add(p.getName());
-        }
-        assertEquals(names, new LinkedHashSet<>(java.util.Arrays.asList("name", "count")));
+        assertPropertyNames(props, "schemaName");
+    }
+
+    @Test
+    public void withPrefixAndSuffix_combinesMapKeyWhenClonedInnerNameIsNull() throws Exception {
+        Schema<Object> inner = cloneLosingNestedPropertyNames(namedInnerSchema());
+
+        List<Schema> props = invokeHandleUnwrapped(inner, "p_", "_s");
+
+        assertPropertyNames(props, "p_name_s", "p_count_s");
+        Schema<Object> outer = schemaWithModelProps(props);
+        assertFalse(outer.getProperties().containsKey(null));
+        Json.mapper().writeValueAsString(outer);
     }
 
     @Test
     public void withPrefixAndSuffix_combinesMapKeyWhenInnerNameIsNull() throws Exception {
+        Schema<Object> inner = innerSchemaWithNullPropertyNames();
+
+        List<Schema> props = invokeHandleUnwrapped(inner, "p_", "_s");
+
+        assertPropertyNames(props, "p_name_s", "p_count_s");
+    }
+
+    private Schema<Object> namedInnerSchema() {
+        Schema<?> nameSchema = new Schema<>().type("string");
+        nameSchema.setName("name");
+        Schema<?> countSchema = new Schema<>().type("integer");
+        countSchema.setName("count");
+
+        Schema<Object> inner = new Schema<>();
+        inner.setName("Inner");
+        Map<String, Schema> innerProps = new LinkedHashMap<>();
+        innerProps.put("name", nameSchema);
+        innerProps.put("count", countSchema);
+        inner.setProperties(innerProps);
+        return inner;
+    }
+
+    private Schema<Object> innerSchemaWithNullPropertyNames() {
         Schema<?> nameSchema = new Schema<>().type("string");
         Schema<?> countSchema = new Schema<>().type("integer");
         Schema<Object> inner = new Schema<>();
@@ -78,18 +131,38 @@ public class Ticket5126Test extends SwaggerTestBase {
         innerProps.put("name", nameSchema);
         innerProps.put("count", countSchema);
         inner.setProperties(innerProps);
+        return inner;
+    }
 
+    private Schema<Object> cloneLosingNestedPropertyNames(Schema<Object> inner) {
+        return AnnotationsUtils.clone(inner, false);
+    }
+
+    private List<Schema> invokeHandleUnwrapped(Schema<Object> inner, String prefix, String suffix) throws Exception {
         List<Schema> props = new ArrayList<>();
         List<String> requiredProps = new ArrayList<>();
-        handleUnwrapped.invoke(modelResolver, props, inner, "p_", "_s", requiredProps);
+        handleUnwrapped.invoke(modelResolver, props, inner, prefix, suffix, requiredProps);
+        return props;
+    }
 
-        assertEquals(props.size(), 2);
+    private Schema<Object> schemaWithModelProps(List<Schema> props) {
+        Schema<Object> outer = new Schema<>();
+        Map<String, Schema> modelProps = new LinkedHashMap<>();
+        for (Schema prop : props) {
+            modelProps.put(prop.getName(), prop);
+        }
+        outer.setProperties(modelProps);
+        return outer;
+    }
+
+    private void assertPropertyNames(List<Schema> props, String... expectedNames) {
+        assertEquals(props.size(), expectedNames.length);
         LinkedHashSet<String> names = new LinkedHashSet<>();
         for (Schema p : props) {
             assertNotNull(p.getName(),
-                    "Prefixed/suffixed names must be derived from the inner properties-map key when the original Schema.name has been lost");
+                    "Each unwrapped property must carry a non-null name to avoid null keys in the outer's properties map");
             names.add(p.getName());
         }
-        assertEquals(names, new LinkedHashSet<>(java.util.Arrays.asList("p_name_s", "p_count_s")));
+        assertEquals(names, new LinkedHashSet<>(Arrays.asList(expectedNames)));
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket5126Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket5126Test.java
@@ -1,0 +1,95 @@
+package io.swagger.v3.core.resolving;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Regression test for <a href="https://github.com/swagger-api/swagger-core/issues/5126">#5126</a>.
+ *
+ * <p>When an inner model's nested property schemas have a {@code null} name — which happens
+ * naturally after {@code AnnotationsUtils.clone} round-trips the schema through JSON, because
+ * {@code Schema.getName()} is {@code @JsonIgnore} — {@link ModelResolver#handleUnwrapped} would
+ * forward those schemas into the outer model's properties list as-is. The subsequent
+ * {@code modelProps.put(prop.getName(), prop)} then inserts a {@code null} key into the outer's
+ * properties map, which later causes Jackson to fail serializing the OpenAPI document with
+ * {@code JsonMappingException: Null key for a Map not allowed in JSON}.
+ *
+ * <p>This test invokes {@code handleUnwrapped} directly with a hand-crafted inner model whose
+ * property schemas have a {@code null} name (simulating the post-clone state) and verifies that
+ * the resulting property names come from the inner properties-map keys, not from the transient
+ * {@code Schema.name} field.
+ */
+public class Ticket5126Test extends SwaggerTestBase {
+
+    private ModelResolver modelResolver;
+    private Method handleUnwrapped;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        modelResolver = new ModelResolver(new ObjectMapper());
+        handleUnwrapped = ModelResolver.class.getDeclaredMethod(
+                "handleUnwrapped", List.class, Schema.class, String.class, String.class, List.class);
+        handleUnwrapped.setAccessible(true);
+    }
+
+    @Test
+    public void noPrefixOrSuffix_restoresNameFromInnerPropertiesMapKey() throws Exception {
+        Schema<?> nameSchema = new Schema<>().type("string");      // name field unset
+        Schema<?> countSchema = new Schema<>().type("integer");    // name field unset
+        Schema<Object> inner = new Schema<>();
+        Map<String, Schema> innerProps = new LinkedHashMap<>();
+        innerProps.put("name", nameSchema);
+        innerProps.put("count", countSchema);
+        inner.setProperties(innerProps);
+
+        List<Schema> props = new ArrayList<>();
+        List<String> requiredProps = new ArrayList<>();
+        handleUnwrapped.invoke(modelResolver, props, inner, "", "", requiredProps);
+
+        assertEquals(props.size(), 2);
+        LinkedHashSet<String> names = new LinkedHashSet<>();
+        for (Schema p : props) {
+            assertNotNull(p.getName(),
+                    "Each unwrapped property must carry a non-null name to avoid null keys in the outer's properties map");
+            names.add(p.getName());
+        }
+        assertEquals(names, new LinkedHashSet<>(java.util.Arrays.asList("name", "count")));
+    }
+
+    @Test
+    public void withPrefixAndSuffix_combinesMapKeyWhenInnerNameIsNull() throws Exception {
+        Schema<?> nameSchema = new Schema<>().type("string");
+        Schema<?> countSchema = new Schema<>().type("integer");
+        Schema<Object> inner = new Schema<>();
+        Map<String, Schema> innerProps = new LinkedHashMap<>();
+        innerProps.put("name", nameSchema);
+        innerProps.put("count", countSchema);
+        inner.setProperties(innerProps);
+
+        List<Schema> props = new ArrayList<>();
+        List<String> requiredProps = new ArrayList<>();
+        handleUnwrapped.invoke(modelResolver, props, inner, "p_", "_s", requiredProps);
+
+        assertEquals(props.size(), 2);
+        LinkedHashSet<String> names = new LinkedHashSet<>();
+        for (Schema p : props) {
+            assertNotNull(p.getName(),
+                    "Prefixed/suffixed names must be derived from the inner properties-map key when the original Schema.name has been lost");
+            names.add(p.getName());
+        }
+        assertEquals(names, new LinkedHashSet<>(java.util.Arrays.asList("p_name_s", "p_count_s")));
+    }
+}


### PR DESCRIPTION
## What

Makes `ModelResolver.handleUnwrapped` defensive against inner property schemas whose `name` has been lost (e.g. via a JSON-based clone like `AnnotationsUtils.clone`, since `Schema.getName()` is `@JsonIgnore`). It restores each property name from the authoritative inner-properties **map key** before forwarding it to the outer model, so the later `modelProps.put(prop.getName(), prop)` can never insert a `null` key — which otherwise breaks serialization with `JsonMappingException: Null key for a Map not allowed in JSON`. The prefix/suffix branch falls back to the map key the same way.

## Scope / honesty note

Relates to #5126 (reported with Spring HATEOAS `EntityModel<T>`). As @Mattias-Sehlstedt rightly questioned, I could **not** reproduce the reported failure end-to-end from a plain annotated model — I tried an `EntityModel<T>`-like generic wrapper with an `@JsonUnwrapped` content getter and it resolves cleanly on `master` (no null key). So this PR is intentionally **narrowed** to a defensive invariant on `handleUnwrapped`'s output rather than a claim to have reproduced and fixed one specific resolver path.

## Test

`Ticket5126Test` drives `handleUnwrapped` directly with inner property schemas in the post-clone (null-name) state and asserts the resulting property names come from the map key (with and without prefix/suffix). It **fails on `master`** (null name / `p_null_s`) and passes with the fix.
