### PR TITLE
feat(schema): add first-class $defs field + traverse all sibling keywords in SpecFilter

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
@@ -302,6 +302,15 @@ public class SpecFilter {
         if (schema == null) {
             return;
         }
+        // $defs siblings of $ref must be traversed first: OAS 3.1 allows $ref siblings,
+        // and the dynamic-ref binding pattern ($ref + $defs) relies on $defs entries being
+        // tracked even when the enclosing schema is a $ref.
+        if (schema.get$defs() != null) {
+            for (Object defName : schema.get$defs().keySet()) {
+                Schema def = (Schema) schema.get$defs().get(defName);
+                addSchemaRef(def, referencedDefinitions);
+            }
+        }
         if (!StringUtils.isBlank(schema.get$ref())) {
             referencedDefinitions.add(schema.get$ref());
             return;

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.callbacks.Callback;
 import io.swagger.v3.oas.models.headers.Header;
-import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
@@ -26,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -298,22 +298,19 @@ public class SpecFilter {
     }
 
     private void addSchemaRef(Schema schema, Set<String> referencedDefinitions) {
+        addSchemaRef(schema, referencedDefinitions, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
 
-        if (schema == null) {
+    private void addSchemaRef(Schema schema, Set<String> referencedDefinitions, Set<Schema> visited) {
+        if (schema == null || !visited.add(schema)) {
             return;
         }
-        // $defs siblings of $ref must be traversed first: OAS 3.1 allows $ref siblings,
-        // and the dynamic-ref binding pattern ($ref + $defs) relies on $defs entries being
-        // tracked even when the enclosing schema is a $ref.
-        if (schema.get$defs() != null) {
-            for (Object defName : schema.get$defs().keySet()) {
-                Schema def = (Schema) schema.get$defs().get(defName);
-                addSchemaRef(def, referencedDefinitions);
-            }
-        }
+        // Record $ref but do NOT early-return: OAS 3.1 allows $ref siblings, so any keyword
+        // container on the same schema may hold additional refs that must be tracked. For
+        // OAS 3.0 docs the worst case is over-retention (a referenced schema survives the
+        // filter), which is the safe failure mode for a "remove unreferenced" filter.
         if (!StringUtils.isBlank(schema.get$ref())) {
             referencedDefinitions.add(schema.get$ref());
-            return;
         }
         if (schema.getDiscriminator() != null && schema.getDiscriminator().getMapping() != null) {
             for (Map.Entry<String, String> mapping: schema.getDiscriminator().getMapping().entrySet()) {
@@ -321,53 +318,48 @@ public class SpecFilter {
             }
         }
 
-        if (schema.getProperties() != null) {
-            for (Object propName : schema.getProperties().keySet()) {
-                Schema property = (Schema) schema.getProperties().get(propName);
-                addSchemaRef(property, referencedDefinitions);
-            }
-        }
+        traverseSchemaMap(schema.getProperties(), referencedDefinitions, visited);
+        traverseSchemaMap(schema.getPatternProperties(), referencedDefinitions, visited);
+        traverseSchemaMap(schema.get$defs(), referencedDefinitions, visited);
+        traverseSchemaMap(schema.getDependentSchemas(), referencedDefinitions, visited);
+
+        traverseSchemaList(schema.getPrefixItems(), referencedDefinitions, visited);
+        traverseSchemaList(schema.getAllOf(), referencedDefinitions, visited);
+        traverseSchemaList(schema.getAnyOf(), referencedDefinitions, visited);
+        traverseSchemaList(schema.getOneOf(), referencedDefinitions, visited);
+
+        addSchemaRef(schema.getNot(), referencedDefinitions, visited);
+        addSchemaRef(schema.getItems(), referencedDefinitions, visited);
+        addSchemaRef(schema.getContains(), referencedDefinitions, visited);
+        addSchemaRef(schema.getContentSchema(), referencedDefinitions, visited);
+        addSchemaRef(schema.getPropertyNames(), referencedDefinitions, visited);
+        addSchemaRef(schema.getUnevaluatedProperties(), referencedDefinitions, visited);
+        addSchemaRef(schema.getAdditionalItems(), referencedDefinitions, visited);
+        addSchemaRef(schema.getUnevaluatedItems(), referencedDefinitions, visited);
+        addSchemaRef(schema.getIf(), referencedDefinitions, visited);
+        addSchemaRef(schema.getElse(), referencedDefinitions, visited);
+        addSchemaRef(schema.getThen(), referencedDefinitions, visited);
 
         if (schema.getAdditionalProperties() instanceof Schema) {
-            addSchemaRef((Schema)schema.getAdditionalProperties(), referencedDefinitions);
+            addSchemaRef((Schema) schema.getAdditionalProperties(), referencedDefinitions, visited);
         }
+    }
 
-        if (schema.getPatternProperties() != null) {
-            for (Object propName : schema.getPatternProperties().keySet()) {
-                Schema property = (Schema) schema.getPatternProperties().get(propName);
-                addSchemaRef(property, referencedDefinitions);
-            }
+    private void traverseSchemaMap(Map<String, Schema> map, Set<String> referencedDefinitions, Set<Schema> visited) {
+        if (map == null) {
+            return;
         }
-
-        if (schema.getPropertyNames() != null) {
-            addSchemaRef(schema.getPropertyNames(), referencedDefinitions);
+        for (Schema child : map.values()) {
+            addSchemaRef(child, referencedDefinitions, visited);
         }
+    }
 
-        if (schema instanceof ArraySchema &&
-                ((ArraySchema) schema).getItems() != null) {
-            addSchemaRef(((ArraySchema) schema).getItems(), referencedDefinitions);
-        } else if (schema.getTypes() != null && schema.getTypes().contains("array") && schema.getItems() != null) {
-            addSchemaRef(schema.getItems(), referencedDefinitions);
-        } else {
-            List<Schema> allOf = schema.getAllOf();
-            List<Schema> anyOf = schema.getAnyOf();
-            List<Schema> oneOf = schema.getOneOf();
-
-            if (allOf != null) {
-                for (Schema ref : allOf) {
-                    addSchemaRef(ref, referencedDefinitions);
-                }
-            }
-            if (anyOf != null) {
-                for (Schema ref : anyOf) {
-                    addSchemaRef(ref, referencedDefinitions);
-                }
-            }
-            if (oneOf != null) {
-                for (Schema ref : oneOf) {
-                    addSchemaRef(ref, referencedDefinitions);
-                }
-            }
+    private void traverseSchemaList(List<Schema> list, Set<String> referencedDefinitions, Set<Schema> visited) {
+        if (list == null) {
+            return;
+        }
+        for (Schema child : list) {
+            addSchemaRef(child, referencedDefinitions, visited);
         }
     }
 

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/SchemaMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/SchemaMixin.java
@@ -98,6 +98,9 @@ public abstract class SchemaMixin {
     public abstract Map<String, Schema> getDependentSchemas();
 
     @JsonIgnore
+    public abstract Map<String, Schema> get$defs();
+
+    @JsonIgnore
     public abstract Map<String, List<String>> getDependentRequired();
 
     @JsonIgnore

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/SwaggerSerializerTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/SwaggerSerializerTest.java
@@ -6,6 +6,7 @@ import io.swagger.v3.core.matchers.SerializationMatchers;
 import io.swagger.v3.core.oas.models.Person;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.JsonAssert;
+import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.core.util.OutputReplacer;
 import io.swagger.v3.core.util.ResourceUtils;
 import io.swagger.v3.oas.models.Components;
@@ -34,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -231,6 +233,64 @@ public class SwaggerSerializerTest {
         String json = Json.mapper().writeValueAsString(openAPI);
 
         assertTrue(json.contains("\"$dynamicRef\":\"#node\""));
+    }
+
+    @Test
+    public void test$defsSerializationV31Only() throws IOException {
+        Schema<?> schema = new Schema<>().add$defs("dataType",
+                new Schema<>().$dynamicAnchor("dataType").$ref("#/components/schemas/Pet"));
+
+        Components components = new Components().addSchemas("Response", schema);
+        OpenAPI openAPI = new OpenAPI().components(components);
+
+        String json31 = Json31.mapper().writeValueAsString(openAPI);
+        assertTrue(json31.contains("\"$defs\""));
+        assertTrue(json31.contains("\"dataType\""));
+
+        String json30 = Json.mapper().writeValueAsString(openAPI);
+        assertFalse(json30.contains("\"$defs\""));
+    }
+
+    @Test
+    public void test$defsExtensionsCoexistence() throws IOException {
+        // Legacy producer workaround: $defs injected into extensions map, $defs field is null.
+        // Expected: still emits $defs once, sourced from extensions. No regression for producers
+        // that haven't migrated to set$defs().
+        Schema<?> legacyOnly = new Schema<>();
+        Map<String, Object> legacyExt = new HashMap<>();
+        legacyExt.put("$defs", java.util.Collections.singletonMap("legacy", "value"));
+        legacyOnly.setExtensions(legacyExt);
+        String legacyJson = Json31.mapper().writeValueAsString(legacyOnly);
+        assertEquals(countOccurrences(legacyJson, "\"$defs\""), 1,
+                "legacy workaround (extensions only) should emit $defs exactly once");
+        assertTrue(legacyJson.contains("\"legacy\""));
+
+        // New path: $defs field only. Expected: clean single emission.
+        Schema<?> fieldOnly = new Schema<>();
+        fieldOnly.add$defs("k", new Schema<>());
+        String fieldJson = Json31.mapper().writeValueAsString(fieldOnly);
+        assertEquals(countOccurrences(fieldJson, "\"$defs\""), 1);
+
+        // Mixed (both field and extensions populated): documented edge case.
+        // Jackson emits both — duplicate $defs keys. This is not a regression (impossible before
+        // the field existed) but producers MUST NOT mix the two paths.
+        Schema<?> mixed = new Schema<>();
+        mixed.add$defs("fromField", new Schema<>());
+        Map<String, Object> mixedExt = new HashMap<>();
+        mixedExt.put("$defs", java.util.Collections.singletonMap("fromExt", "v"));
+        mixed.setExtensions(mixedExt);
+        String mixedJson = Json31.mapper().writeValueAsString(mixed);
+        assertEquals(countOccurrences(mixedJson, "\"$defs\""), 2,
+                "mixing field and extensions produces duplicate $defs keys (documented, not a bug)");
+    }
+
+    private static int countOccurrences(String haystack, String needle) {
+        int count = 0, idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) != -1) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
     }
 
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/OpenAPI3_1DeserializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/deserialization/OpenAPI3_1DeserializationTest.java
@@ -13,10 +13,12 @@ import io.swagger.v3.oas.models.media.Schema;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
 
 public class OpenAPI3_1DeserializationTest {
@@ -264,6 +266,83 @@ public class OpenAPI3_1DeserializationTest {
         assertNotNull(baseNodeSchema.getProperties().get("children"));
         JsonSchema childrenSchema = (JsonSchema) baseNodeSchema.getProperties().get("children");
         assertEquals(childrenSchema.getItems().get$dynamicRef(), "#node");
+    }
+
+    @Test
+    public void test$defsRoundTripOnOAS31() throws IOException {
+        Schema<?> dataTypeSlot = new Schema<>()
+                .$dynamicAnchor("dataType")
+                .not(new Schema<>());
+        Schema<?> template = new Schema<>()
+                .$dynamicAnchor("dataType")
+                .addProperty("data", new Schema<>().$dynamicRef("#dataType"))
+                .$defs(new LinkedHashMap<>());
+        template.get$defs().put("dataType", dataTypeSlot);
+
+        Schema<?> binding = new Schema<>()
+                .$ref("#/components/schemas/Response")
+                .add$defs("dataType", new Schema<>().$dynamicAnchor("dataType").$ref("#/components/schemas/Pet"));
+
+        Components components = new Components()
+                .addSchemas("Response", template)
+                .addSchemas("Pet", new Schema().type("object").addProperty("id", new Schema().type("integer")));
+        OpenAPI openAPI = new OpenAPI().openapi("3.1.0").components(components);
+        openAPI.path("/pet", new io.swagger.v3.oas.models.PathItem()
+                .get(new io.swagger.v3.oas.models.Operation()
+                        .responses(new io.swagger.v3.oas.models.responses.ApiResponses()
+                                .addApiResponse("200", new io.swagger.v3.oas.models.responses.ApiResponse()
+                                        .content(new io.swagger.v3.oas.models.media.Content()
+                                                .addMediaType("application/json", new io.swagger.v3.oas.models.media.MediaType()
+                                                        .schema(binding)))))));
+
+        String json = Json31.pretty(openAPI);
+        OpenAPI parsed = Json31.mapper().readValue(json, OpenAPI.class);
+        String jsonAgain = Json31.pretty(parsed);
+
+        Schema<?> parsedTemplate = parsed.getComponents().getSchemas().get("Response");
+        assertNotNull(parsedTemplate.get$defs(), "template $defs should round-trip");
+        assertNotNull(parsedTemplate.get$defs().get("dataType"), "template $defs dataType slot should survive");
+        assertEquals(parsedTemplate.get$defs().get("dataType").get$dynamicAnchor(), "dataType");
+
+        Schema<?> parsedBinding = parsed.getPaths().get("/pet").getGet().getResponses().get("200")
+                .getContent().get("application/json").getSchema();
+        assertNotNull(parsedBinding.get$defs(), "inline binding $defs should round-trip");
+        assertEquals(parsedBinding.get$defs().get("dataType").get$ref(), "#/components/schemas/Pet");
+        assertEquals(parsedBinding.get$ref(), "#/components/schemas/Response");
+
+        SerializationMatchers.assertEqualsToJson31(parsed, jsonAgain);
+    }
+
+    @Test
+    public void test$defsAccumulationAndEquality() {
+        Schema<?> a = new Schema<>();
+        assertNull(a.get$defs());
+        a.add$defs("k1", new Schema().type("string"));
+        a.add$defs("k2", new Schema().type("integer"));
+        assertEquals(a.get$defs().size(), 2);
+
+        Schema<?> b = new Schema<>();
+        b.add$defs("k1", new Schema().type("string"));
+        b.add$defs("k2", new Schema().type("integer"));
+        assertEquals(a, b);
+
+        Schema<?> c = new Schema<>();
+        c.add$defs("k1", new Schema().type("string"));
+        assertNotEquals(a, c);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void test$defsRoutedToFieldNotExtensions() throws IOException {
+        // Behavioral change: $defs in input JSON is now routed to the first-class field,
+        // not the extensions map. Consumers reading $defs from extensions must migrate to get$defs().
+        String json = "{\"$defs\":{\"k\":{\"type\":\"string\"}}}";
+        Schema<?> parsed = Json31.mapper().readValue(json, Schema.class);
+
+        assertNotNull(parsed.get$defs(), "$defs should land in the dedicated field");
+        assertNotNull(parsed.get$defs().get("k"), "$defs entry should be parsed as a Schema");
+        assertNull(parsed.getExtensions(),
+                "$defs must NOT also appear in extensions (would cause duplicate emission on re-serialize)");
     }
 
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/SpecFilterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/SpecFilterTest.java
@@ -23,19 +23,26 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.tags.Tag;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -341,6 +348,104 @@ public class SpecFilterTest {
         assertNotNull(filtered.getComponents().getSchemas().get("Response"), "entry-point schema must survive");
         assertNotNull(filtered.getComponents().getSchemas().get("Pet"), "schema referenced only via $defs must survive");
         assertNull(filtered.getComponents().getSchemas().get("Stray"), "unreferenced schema must be dropped");
+    }
+
+    /**
+     * Enumerates every Schema keyword container that can hold a $ref-bearing subschema.
+     * Each case is {keywordName, setter} where setter attaches a child schema via that keyword.
+     */
+    @DataProvider(name = "schemaSiblingKeywords")
+    public Object[][] schemaSiblingKeywords() {
+        return new Object[][] {
+                {"properties", (BiConsumer<Schema, Schema>) (p, c) -> p.addProperty("k", c)},
+                {"patternProperties", (BiConsumer<Schema, Schema>) (p, c) -> p.addPatternProperty("^k$", c)},
+                {"$defs", (BiConsumer<Schema, Schema>) (p, c) -> p.add$defs("k", c)},
+                {"dependentSchemas", (BiConsumer<Schema, Schema>) (p, c) -> p.setDependentSchemas(Collections.singletonMap("k", c))},
+                {"additionalProperties", (BiConsumer<Schema, Schema>) (p, c) -> p.setAdditionalProperties(c)},
+                {"prefixItems", (BiConsumer<Schema, Schema>) (p, c) -> p.setPrefixItems(Collections.singletonList(c))},
+                {"allOf", (BiConsumer<Schema, Schema>) (p, c) -> p.addAllOfItem(c)},
+                {"anyOf", (BiConsumer<Schema, Schema>) (p, c) -> p.addAnyOfItem(c)},
+                {"oneOf", (BiConsumer<Schema, Schema>) (p, c) -> p.addOneOfItem(c)},
+                {"not", (BiConsumer<Schema, Schema>) Schema::setNot},
+                {"items", (BiConsumer<Schema, Schema>) Schema::setItems},
+                {"contains", (BiConsumer<Schema, Schema>) Schema::setContains},
+                {"contentSchema", (BiConsumer<Schema, Schema>) Schema::setContentSchema},
+                {"propertyNames", (BiConsumer<Schema, Schema>) Schema::setPropertyNames},
+                {"unevaluatedProperties", (BiConsumer<Schema, Schema>) Schema::setUnevaluatedProperties},
+                {"additionalItems", (BiConsumer<Schema, Schema>) Schema::setAdditionalItems},
+                {"unevaluatedItems", (BiConsumer<Schema, Schema>) Schema::setUnevaluatedItems},
+                {"if", (BiConsumer<Schema, Schema>) Schema::setIf},
+                {"else", (BiConsumer<Schema, Schema>) Schema::setElse},
+                {"then", (BiConsumer<Schema, Schema>) Schema::setThen},
+        };
+    }
+
+    @Test(dataProvider = "schemaSiblingKeywords",
+            description = "a schema referenced via any sibling keyword must survive RemoveUnreferencedDefinitionsFilter")
+    public void siblingKeywordReferenceSurvivesFilter(String keyword, BiConsumer<Schema, Schema> setter) {
+        Schema<?> target = new Schema<>().$ref("#/components/schemas/Target");
+        Schema<?> source = new Schema<>();
+        setter.accept(source, target);
+
+        OpenAPI openAPI = baseOpenAPIWithSchema("Source", source);
+
+        // V31 filter is required: filterComponentsSchema clones via Jackson round-trip, and the
+        // V30 mapper strips @OpenAPI31 keywords (@JsonIgnore in SchemaMixin) before addSchemaRef runs.
+        OpenAPI filtered = new SpecFilter().filter(openAPI, new RemoveUnreferencedDefinitionsFilter() {
+            @Override public boolean isOpenAPI31Filter() { return true; }
+        }, null, null, null);
+
+        assertNotNull(filtered.getComponents().getSchemas().get("Source"), "entry-point schema must survive");
+        assertNotNull(filtered.getComponents().getSchemas().get("Target"),
+                "Target must survive when referenced via " + keyword);
+        assertNull(filtered.getComponents().getSchemas().get("Stray"), "unreferenced schema must be dropped");
+    }
+
+    @Test(dataProvider = "schemaSiblingKeywords",
+            description = "siblings of $ref must also be traversed (OAS 3.1 $ref sibling support)")
+    public void refSiblingKeepsBoth(String keyword, BiConsumer<Schema, Schema> setter) {
+        Schema<?> target = new Schema<>().$ref("#/components/schemas/Target");
+        Schema<?> parent = new Schema<>().$ref("#/components/schemas/Parent");
+        setter.accept(parent, target);
+
+        OpenAPI openAPI = new OpenAPI()
+                .components(new Components()
+                        .addSchemas("Parent", new Schema<>().type("object"))
+                        .addSchemas("Target", new Schema<>().type("object"))
+                        .addSchemas("Stray", new Schema<>().type("string")))
+                .path("/x", new PathItem().get(new Operation()
+                        .responses(new ApiResponses()
+                                .addApiResponse("200", new ApiResponse()
+                                        .content(new Content()
+                                                .addMediaType("application/json", new MediaType()
+                                                        .schema(parent)))))));
+
+        OpenAPI filtered = new SpecFilter().filter(openAPI, new RemoveUnreferencedDefinitionsFilter() {
+            @Override public boolean isOpenAPI31Filter() { return true; }
+        }, null, null, null);
+
+        assertNotNull(filtered.getComponents().getSchemas().get("Parent"), "Parent must survive via $ref");
+        assertNotNull(filtered.getComponents().getSchemas().get("Target"),
+                "Target must survive via $ref sibling " + keyword);
+        assertNull(filtered.getComponents().getSchemas().get("Stray"), "unreferenced schema must be dropped");
+    }
+
+    /**
+     * Builds an OpenAPI where `sourceName` is referenced from a GET /x 200 response and
+     * `Target` is defined as an empty object, plus an unreferenced `Stray` schema.
+     */
+    private static OpenAPI baseOpenAPIWithSchema(String sourceName, Schema<?> sourceSchema) {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSchemas(sourceName, sourceSchema)
+                        .addSchemas("Target", new Schema<>().type("object"))
+                        .addSchemas("Stray", new Schema<>().type("string")))
+                .path("/x", new PathItem().get(new Operation()
+                        .responses(new ApiResponses()
+                                .addApiResponse("200", new ApiResponse()
+                                        .content(new Content()
+                                                .addMediaType("application/json", new MediaType()
+                                                        .schema(new Schema<>().$ref("#/components/schemas/" + sourceName))))))));
     }
 
     @Test

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/SpecFilterTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/filter/SpecFilterTest.java
@@ -307,6 +307,42 @@ public class SpecFilterTest {
         assertTrue(filtered.getComponents().getSchemas().containsKey("PatternPropertiesReferencedObject"), "Schemas should contains pattern properties referenced schema");
     }
 
+    @Test(description = "a schema referenced only via $defs should survive RemoveUnreferencedDefinitionsFilter")
+    public void shouldKeepSchemasReferencedFrom$defs() {
+        // OpenAPI 3.1 generic-template binding pattern: an operation references `Response`,
+        // whose $defs.dataType points to `Pet`. `Stray` is unreferenced and should be dropped.
+        Schema<?> template = new Schema<>()
+                .$ref("#/components/schemas/Response")
+                .add$defs("dataType", new Schema<>()
+                        .$dynamicAnchor("dataType")
+                        .$ref("#/components/schemas/Pet"));
+        Schema<?> pet = new Schema<>().type("object").addProperty("id", new Schema().type("integer"));
+        Schema<?> stray = new Schema<>().type("object").addProperty("unused", new Schema().type("string"));
+
+        OpenAPI openAPI = new OpenAPI()
+                .openapi("3.1.0")
+                .components(new Components()
+                        .addSchemas("Response", new Schema<>()
+                                .$dynamicAnchor("dataType")
+                                .addProperty("data", new Schema<>().$dynamicRef("#dataType"))
+                                .add$defs("dataType", new Schema<>().$dynamicAnchor("dataType").not(new Schema<>())))
+                        .addSchemas("Pet", pet)
+                        .addSchemas("Stray", stray))
+                .path("/pet", new PathItem()
+                        .get(new Operation()
+                                .responses(new io.swagger.v3.oas.models.responses.ApiResponses()
+                                        .addApiResponse("200", new io.swagger.v3.oas.models.responses.ApiResponse()
+                                                .content(new io.swagger.v3.oas.models.media.Content()
+                                                        .addMediaType("application/json", new io.swagger.v3.oas.models.media.MediaType()
+                                                                .schema(template)))))));
+
+        OpenAPI filtered = new SpecFilter().filter(openAPI, new RemoveUnreferencedDefinitionsFilter(), null, null, null);
+
+        assertNotNull(filtered.getComponents().getSchemas().get("Response"), "entry-point schema must survive");
+        assertNotNull(filtered.getComponents().getSchemas().get("Pet"), "schema referenced only via $defs must survive");
+        assertNull(filtered.getComponents().getSchemas().get("Stray"), "unreferenced schema must be dropped");
+    }
+
     @Test
     public void shouldNotRemoveGoodRefs() throws IOException {
         final OpenAPI openAPI = getOpenAPI(RESOURCE_PATH);

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/media/Schema.java
@@ -296,6 +296,12 @@ public class Schema<T> {
     private Map<String, Schema> dependentSchemas;
 
     /**
+     * @since 2.2.52 (OpenAPI 3.1.0)
+     */
+    @OpenAPI31
+    private Map<String, Schema> $defs;
+
+    /**
      * @since 2.2.0 (OpenAPI 3.1.0)
      */
     @OpenAPI31
@@ -2015,6 +2021,47 @@ public class Schema<T> {
 
     /**
      *
+     * @since 2.2.52 (OpenAPI 3.1.0)
+     */
+    @OpenAPI31
+    public Map<String, Schema> get$defs() {
+        return $defs;
+    }
+
+    /**
+     *
+     * @since 2.2.52 (OpenAPI 3.1.0)
+     */
+    @OpenAPI31
+    public void set$defs(Map<String, Schema> $defs) {
+        this.$defs = $defs;
+    }
+
+    /**
+     *
+     * @since 2.2.52 (OpenAPI 3.1.0)
+     */
+    @OpenAPI31
+    public Schema $defs(Map<String, Schema> $defs) {
+        this.$defs = $defs;
+        return this;
+    }
+
+    /**
+     *
+     * @since 2.2.52 (OpenAPI 3.1.0)
+     */
+    @OpenAPI31
+    public Schema add$defs(String key, Schema $defsItem) {
+        if (this.$defs == null) {
+            this.$defs = new LinkedHashMap<>();
+        }
+        this.$defs.put(key, $defsItem);
+        return this;
+    }
+
+    /**
+     *
      * @since 2.2.0 (OpenAPI 3.1.0)
      */
     @OpenAPI31
@@ -2180,6 +2227,7 @@ public class Schema<T> {
                 Objects.equals(this.then, schema.then) &&
                 Objects.equals(this.dependentRequired, schema.dependentRequired) &&
                 Objects.equals(this.dependentSchemas, schema.dependentSchemas) &&
+                Objects.equals(this.$defs, schema.$defs) &&
                 Objects.equals(this.$comment, schema.$comment) &&
                 Objects.equals(this.examples, schema.examples) &&
                 Objects.equals(this.prefixItems, schema.prefixItems) &&
@@ -2197,7 +2245,7 @@ public class Schema<T> {
                 discriminator, _enum, _default, patternProperties, $id, $anchor, $schema, $vocabulary, $dynamicAnchor,
                 $dynamicRef, types, allOf, anyOf, oneOf, _const, contentEncoding, contentMediaType, contentSchema,
                 propertyNames, unevaluatedProperties, maxContains, minContains, additionalItems, unevaluatedItems,
-                _if, _else, then, dependentRequired, dependentSchemas, $comment, examples, prefixItems, items, booleanSchemaValue);
+                _if, _else, then, dependentRequired, dependentSchemas, $defs, $comment, examples, prefixItems, items, booleanSchemaValue);
     }
 
     public java.util.Map<String, Object> getExtensions() {
@@ -2284,6 +2332,7 @@ public class Schema<T> {
             sb.append("    then: ").append(toIndentedString(then)).append("\n");
             sb.append("    dependentRequired: ").append(toIndentedString(dependentRequired)).append("\n");
             sb.append("    dependentSchemas: ").append(toIndentedString(dependentSchemas)).append("\n");
+            sb.append("    $defs: ").append(toIndentedString($defs)).append("\n");
             sb.append("    $comment: ").append(toIndentedString($comment)).append("\n");
             sb.append("    prefixItems: ").append(toIndentedString(prefixItems)).append("\n");
             sb.append("    booleanSchemaValue: ").append(toIndentedString(booleanSchemaValue)).append("\n");


### PR DESCRIPTION
## Description

Adds a first-class `$defs` field to `io.swagger.v3.oas.models.media.Schema`, mirroring how the other JSON Schema 2020-12 keywords (`$dynamicAnchor`, `$dynamicRef`, `$anchor`, `$id`, `$schema`, `$vocabulary`, `patternProperties`, `dependentSchemas`, …) were added. `$defs` is the canonical location for the generic-template binding used with `$dynamicRef`/`$dynamicAnchor` and was the notable omission. Also fixes two related gaps in `SpecFilter.addSchemaRef` that dropped schema references.

Fixes: #4469

## What & why

### 1. First-class `$defs` field (`feat(schema)` commit)

- `Schema`: `$defs` field + `get$defs`/`set$defs`/`$defs(Map)`/`add$defs` accessors, gated by `@OpenAPI31`; included in `equals`/`hashCode`/`toString`.
- `SchemaMixin`: `@JsonIgnore` on `get$defs()` for V30 exclusion (matches the existing pattern for `$id`, `$anchor`, `patternProperties`, `dependentSchemas`, etc.).
- V31 serializer/deserializer need no changes — auto-discovery via getters/setters, same as `$dynamicAnchor`/`$dynamicRef`.

**Behavioral change for consumers:** `$defs` in input JSON is now routed to the dedicated field rather than the extensions map. Producers using the extension-injection workaround continue to work (the `$defs` field stays null, the extensions entry is still emitted via `@JsonAnyGetter`). See the [breaking-change analysis comment on the issue](https://github.com/swagger-api/swagger-core/issues/4469#issuecomment-4729778495) for migration impact.

### 2. `SpecFilter.addSchemaRef` restructure (`fix(filter)` commit)

While wiring `$defs` into the filter I uncovered two pre-existing bugs in `addSchemaRef` (used by `RemoveUnreferencedDefinitionsFilter`):

1. **Bug A — `$ref` siblings skipped.** Seven keyword traversals sat *after* an early-return on `$ref`, so any sibling of `$ref` was skipped. With OAS 3.1 allowing `$ref` siblings, schemas like `{$ref: Parent, $defs: {x: {$ref: Target}}}` lost `Target`.
2. **Bug B — 9 JSON Schema 2020-12 keywords never traversed at all**, `$ref` or not: `not`, `prefixItems`, `contains`, `contentSchema`, `unevaluatedProperties`, `additionalItems`, `unevaluatedItems`, `if`/`else`/`then`, `dependentSchemas`. A schema like `{contains: {$ref: X}}` dropped `X`.

Restructure:
- Record `$ref` without early-return; always traverse siblings.
- Traverse all 20 sibling keyword containers uniformly via `traverseSchemaMap`/`traverseSchemaList` helpers.
- `IdentityHashMap`-backed `visited`-set for cycle protection.
- **Incidental fix:** the old `if/else` chain made `items` and `allOf/anyOf/oneOf` mutually exclusive — an `ArraySchema` with `allOf` had its `allOf` entries silently dropped.

For OAS 3.0 documents the behavioral change is **over-retention** of referenced schemas (safe failure mode for a "remove unreferenced" filter); the worst case is a referenced schema surviving, never a needed one being dropped. Full sibling traversal was chosen over V31-gating for consistency with how every prior 2020-12 keyword (`patternProperties`, `prefixItems`, `dependentSchemas`, `$dynamicAnchor`, `$dynamicRef`) was wired up unconditionally, and because the missing-keyword traversals (Bug B) only affect keywords that cannot appear in strict OAS 3.0 docs anyway.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally (`mvn test` on `swagger-models` + `swagger-core`; 69 `SpecFilterTest` cases pass, full `swagger-core` suite green)
- [x] I have linked related issues

## Tests

- `OpenAPI3_1DeserializationTest`: `$defs` round-trip, accumulation, equality, and the consumer-side deserialization routing change.
- `SwaggerSerializerTest`: V31-only emission + extension-coexistence characterization (legacy workaround still works; mixing field + extensions produces duplicate keys, documented).
- `SpecFilterTest`: 40 new data-driven cases via `@DataProvider` (20 sibling keywords × 2 scenarios — standalone `{$ref: kw}` and `$ref` sibling `{$ref, kw}`).

## Downstream follow-ups (out of scope)

- **swagger-parser PR [#2332](https://github.com/swagger-api/swagger-parser/pull/2332)** currently reads `$defs` from the extensions map; it should switch to `get$defs()` once this ships.
- **Micronaut OpenAPI** has a `SchemaDefinitionUtils.setSchemaDefs()` helper behind a cached reflection check for `set$defs` — it auto-switches to the native method once available.

## Additional Context

Detailed motivation, empirical evidence, and downstream layering context are in the issue thread (#4469). The two commits are split deliberately: reviewers who only care about the new field can focus on the first; the filter restructure is separable.