### PR TITLE
Honor PropertyNamingStrategy for is-prefixed record components

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -678,7 +678,11 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
 
             // hack to avoid clobbering properties with get/is names
             // it's ugly but gets around https://github.com/swagger-api/swagger-core/issues/415
-            if (propDef.getPrimaryMember() != null) {
+            // Skip it when a PropertyNamingStrategy is configured: propName already reflects the
+            // strategy-translated name, and falling back to the raw member name (e.g. a record
+            // accessor such as "issuanceDate") would wrongly leave "is"-prefixed names untranslated.
+            if (propDef.getPrimaryMember() != null
+                    && _mapper.getSerializationConfig().getPropertyNamingStrategy() == null) {
                 final JsonProperty jsonPropertyAnn = propDef.getPrimaryMember().getAnnotation(JsonProperty.class);
                 if (jsonPropertyAnn == null || !jsonPropertyAnn.value().equals(propName)) {
                     if (member != null) {

--- a/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/Ticket3293Test.java
+++ b/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/Ticket3293Test.java
@@ -1,0 +1,51 @@
+package io.swagger.v3.java17.resolving;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.java17.matchers.SerializationMatchers;
+import org.testng.annotations.Test;
+
+public class Ticket3293Test extends SwaggerTestBase {
+
+    @Test
+    public void testSnakeCaseNamingWithIsPrefixedRecordComponents() {
+        ModelResolver modelResolver = new ModelResolver(
+                Json.mapper().copy().setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE));
+        ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+        context.resolve(new AnnotatedType(PidLookupResponse.class));
+
+        // Every component must be snake_cased, including the non-boolean "is"-prefixed ones
+        // (issuanceDate / issuingCountry / issuingAuthority) which used to leak through as camelCase.
+        // A genuine boolean accessor (isActive) keeps behaving correctly.
+        String expectedYaml = "PidLookupResponse:\n" +
+                "  type: object\n" +
+                "  properties:\n" +
+                "    family_name:\n" +
+                "      type: string\n" +
+                "    expiry_date:\n" +
+                "      type: string\n" +
+                "    issuance_date:\n" +
+                "      type: string\n" +
+                "    issuing_country:\n" +
+                "      type: string\n" +
+                "    issuing_authority:\n" +
+                "      type: string\n" +
+                "    is_active:\n" +
+                "      type: boolean";
+
+        SerializationMatchers.assertEqualsToYaml(context.getDefinedModels(), expectedYaml);
+    }
+
+    record PidLookupResponse(
+            String familyName,
+            String expiryDate,
+            String issuanceDate,
+            String issuingCountry,
+            String issuingAuthority,
+            boolean isActive
+    ) {
+    }
+}


### PR DESCRIPTION
### Problem

When a Jackson `PropertyNamingStrategy` (e.g. `SNAKE_CASE`) is configured on the `ObjectMapper` used by `ModelResolver`, **non-boolean record components whose name starts with `is`** are left in camelCase in the generated schema, while every other field is translated correctly.

Given:

```java
public record PidLookupResponse(
        String familyName, String expiryDate,
        String issuanceDate, String issuingCountry, String issuingAuthority) {}
```

with `SNAKE_CASE`, the resolved schema contains `family_name`, `expiry_date` — but `issuanceDate`, `issuingCountry`, `issuingAuthority` (untranslated).

This was diagnosed as a swagger-core issue by the springdoc-openapi maintainer in springdoc/springdoc-openapi#3293 (reproducible directly against `ModelResolver`, no Spring involved).

### Root cause

The get/is name-clobbering hack (added for #415) in `ModelResolver` falls back to the raw member name when an accessor starts with `get`/`is` followed by a lowercase letter:

```java
if (altName.startsWith(prefix) && length > offset
        && !Character.isUpperCase(altName.charAt(offset))) {
    propName = altName;
}
```

For a **record**, the accessor name equals the component name (`issuanceDate`), so `"is"` + lowercase matches and `propName` is overwritten with the camelCase member name — discarding the strategy-translated value that Jackson already computed in `propDef.getName()`. Classic getters (`getIssuanceDate`/`isActive`) are unaffected because the character after the prefix is uppercase.

### Fix

Skip the hack when a `PropertyNamingStrategy` is configured. In that case `propDef.getName()` is already authoritative and must not be overridden. Default (no-strategy) behavior is unchanged, so the #415 workaround is fully preserved.

```java
if (propDef.getPrimaryMember() != null
        && _mapper.getSerializationConfig().getPropertyNamingStrategy() == null) {
```

### Tests

Added `Ticket3293Test` in the `swagger-java17-support` module (records require Java 17). It resolves the record above with a `SNAKE_CASE` `ModelResolver` and asserts all five string components plus a genuine boolean component (`isActive` → `is_active`) are snake_cased.

Verified the test **fails without the fix** (the three `is*` components leak as `issuanceDate`/`issuingCountry`/`issuingAuthority`) and **passes with it**, with `is_active` correct in both runs (no boolean-getter regression). Full `swagger-java17-support` module and the `io.swagger.v3.core.resolving.*` package pass.

Refs springdoc/springdoc-openapi#3293