### PR TITLE
Revert "hotfix: temporarily allow Release workflow to skip mvn deploy to recover 2.2.52 (#5220)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,6 @@ name: Release
 on:
   workflow_dispatch:
     branches: ["master"]
-    inputs:
-      skip_deploy:
-        description: "Skip 'mvn -Prelease deploy' (use to recover when the current version is already on Maven Central). Runs 'mvn -Prelease verify' instead so javadocs are prepared for gh-pages."
-        type: boolean
-        default: false
 
 jobs:
   build:
@@ -78,13 +73,9 @@ jobs:
         git config --global hub.protocol https
         git remote set-url origin https://\${{ secrets.GITHUB_TOKEN }}:x-oauth-basic@github.com/''' + 'swagger-api/swagger-core' + '''.git
     - name:  Run maven deploy/release
-      if: env.RELEASE_OK == 'yes' && inputs.skip_deploy != true
+      if: env.RELEASE_OK == 'yes'
       run: |
         ./mvnw --no-transfer-progress -B -Prelease deploy
-    - name: Run maven verify (recovery — javadocs only, no Central publish)
-      if: env.RELEASE_OK == 'yes' && inputs.skip_deploy == true
-      run: |
-        ./mvnw --no-transfer-progress -B -Prelease verify
     - name: Run prepare javadocs script
       id: prepareJavadocs
       if: env.RELEASE_OK == 'yes'

--- a/modules/swagger-annotations/pom.xml
+++ b/modules/swagger-annotations/pom.xml
@@ -66,7 +66,7 @@
                         <executions>
                             <execution>
                                 <id>copy-resources</id>
-                                <phase>verify</phase>
+                                <phase>deploy</phase>
                                 <goals>
                                     <goal>copy-resources</goal>
                                 </goals>


### PR DESCRIPTION
This reverts commit f97c40830abb69c0dd12d71d444e9689919ef60a.

The 2.2.52 release has been fully recovered (Maven Central, gh-pages javadocs, Gradle plugin, GitHub release, next-snapshot bump). The temporary skip_deploy workflow input and the verify-phase binding for javadocprep are no longer needed