### PR TITLE
fix: keep polymorphic subtype composition when re-resolved standalone (#5028)

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/converter/ModelConverterContextImpl.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/converter/ModelConverterContextImpl.java
@@ -57,7 +57,7 @@ public class ModelConverterContextImpl implements ModelConverterContext {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(String.format("defineModel %s %s", name, model));
         }
-        modelByName.put(name, model);
+        putModelByName(name, model);
 
         if (StringUtils.isNotBlank(prevName) && !prevName.equals(name)) {
             modelByName.remove(prevName);
@@ -66,6 +66,27 @@ public class ModelConverterContextImpl implements ModelConverterContext {
         if (type != null && type.getType() != null) {
             modelByType.put(type, model);
         }
+    }
+
+    /**
+     * Registers {@code model} under {@code name}, but never lets a schema without composition keywords
+     * overwrite an already-registered composed schema of the same name. This preserves the {@code allOf}
+     * reference a polymorphic subtype gains from its parent's {@code resolveSubtypes} when the same subtype
+     * is later resolved standalone (e.g. while resolving a discriminator mapping), which otherwise clobbers
+     * it back to a plain object schema.
+     */
+    private void putModelByName(String name, Schema model) {
+        Schema existing = modelByName.get(name);
+        if (existing != null && hasComposition(existing) && !hasComposition(model)) {
+            return;
+        }
+        modelByName.put(name, model);
+    }
+
+    private static boolean hasComposition(Schema schema) {
+        return (schema.getAllOf() != null && !schema.getAllOf().isEmpty())
+                || (schema.getAnyOf() != null && !schema.getAnyOf().isEmpty())
+                || (schema.getOneOf() != null && !schema.getOneOf().isEmpty());
     }
 
     @Override
@@ -101,7 +122,7 @@ public class ModelConverterContextImpl implements ModelConverterContext {
 
             Schema resolvedImpl = resolved;
             if (resolvedImpl.getName() != null) {
-                modelByName.put(resolvedImpl.getName(), resolved);
+                putModelByName(resolvedImpl.getName(), resolved);
             }
         } else {
             processedTypes.remove(type);

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket5028Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket5028Test.java
@@ -1,0 +1,82 @@
+package io.swagger.v3.core.resolving;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.swagger.v3.core.resolving.SwaggerTestBase.mapper;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class Ticket5028Test {
+
+    @Test
+    public void testSubtypeKeepsCompositionOpenApi30() {
+        final ModelResolver modelResolver = new ModelResolver(mapper());
+        final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        context.resolve(new AnnotatedType(AttributeType.class));
+        final Map<String, io.swagger.v3.oas.models.media.Schema> models = context.getDefinedModels();
+
+        final io.swagger.v3.oas.models.media.Schema subtype = models.get("DateAttributeTypeImpl");
+        assertNotNull(subtype, "subtype schema should be defined");
+        assertNotNull(subtype.getAllOf(),
+                "subtype must keep its allOf reference to the parent, but was: " + subtype);
+        assertEquals(subtype.getAllOf().size(), 1);
+        assertEquals(((io.swagger.v3.oas.models.media.Schema) subtype.getAllOf().get(0)).get$ref(),
+                "#/components/schemas/AttributeType");
+    }
+
+    @Test
+    public void testSubtypeKeepsCompositionOpenApi31() {
+        final ModelResolver modelResolver = new ModelResolver(mapper());
+        modelResolver.setOpenapi31(true);
+        final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+
+        context.resolve(new AnnotatedType(AttributeType.class));
+        final Map<String, io.swagger.v3.oas.models.media.Schema> models = context.getDefinedModels();
+
+        final io.swagger.v3.oas.models.media.Schema subtype = models.get("DateAttributeTypeImpl");
+        assertNotNull(subtype, "subtype schema should be defined");
+        assertNotNull(subtype.getAllOf(),
+                "subtype must keep its allOf reference to the parent, but was: " + subtype);
+        assertTrue(subtype.getAllOf().stream()
+                        .anyMatch(s -> ("#/components/schemas/AttributeType")
+                                .equals(((io.swagger.v3.oas.models.media.Schema) s).get$ref())),
+                "allOf must reference the parent AttributeType, but was: " + subtype.getAllOf());
+    }
+
+    interface ResourceType {
+    }
+
+    @Schema(
+            subTypes = {DateAttributeType.class},
+            discriminatorProperty = "resourceType",
+            discriminatorMapping = {
+                    @DiscriminatorMapping(value = "DateAttributeType", schema = DateAttributeType.class)
+            })
+    interface AttributeType extends ResourceType {
+        @Schema(description = "The public id of the attribute type.", example = "ApprovalDate_C")
+        String getPublicId();
+    }
+
+    @Schema(implementation = DateAttributeTypeImpl.class)
+    interface DateAttributeType extends AttributeType {
+    }
+
+    static class AttributeTypeImpl implements AttributeType {
+        @Override
+        public String getPublicId() {
+            return "";
+        }
+    }
+
+    static class DateAttributeTypeImpl extends AttributeTypeImpl implements DateAttributeType {
+    }
+}


### PR DESCRIPTION
Fixes #5028

## Root cause

Polymorphic subtypes lose their `allOf` reference to the parent (regression in 2.2.41): a subtype that resolved to
```json
"DateAttributeTypeImpl": { "type": "object", "allOf": [ { "$ref": "#/components/schemas/AttributeType" } ] }
```
degrades to `{ "type": "object", "properties": {} }`.

The parent's `resolveSubtypes` builds each subtype's composed schema (`allOf` → parent) and registers it via `defineModel`. However, when the same subtype is resolved **standalone** afterwards — here while resolving the parent's `@DiscriminatorMapping`, whose `resolveDiscriminator` calls `context.resolve(new AnnotatedType().type(mapping.schema()))` **without** the `subtype(true)` flag — the resolution-cache lookup misses (`AnnotatedType` equality was tightened in #4975 / #5005), so the subtype is re-resolved as a plain object and `modelByName` is overwritten, dropping the composition.

## Fix

Guard model registration in `ModelConverterContextImpl` so a schema **without** composition keywords (`allOf`/`anyOf`/`oneOf`) never overwrites an already-registered **composed** schema of the same name. The forward direction (plain → composed) is unaffected, so the composed subtype definition survives the later plain re-resolution. Applied at both storage sites (`defineModel` and the `resolve()` name mapping).

## Tests

Added `Ticket5028Test` reproducing the reporter's hierarchy (interface parent with `subTypes` + `discriminatorMapping`, subtype via `@Schema(implementation=...)`). Both assertions fail on master and pass with the fix, for OpenAPI 3.0 and 3.1.

## Verification done
- (1/2) No in-flight PR: searched open/all PRs for the symbol and my own open PRs — none cover this root cause; only cross-ref is a Copilot WIP bot issue.
- (4) Confirmed the overwrite path on master (`resolveDiscriminator` L2746 → `ModelConverterContextImpl.resolve`/`defineName`).
- (3) Regression source #5003 is closed; this is the residual case.
- Full `swagger-core` module suite (722 tests) + focused composition/subtype/discriminator suite (38 tests) pass with the change. `git commit -s` (DCO).