### PR TITLE
fix(model-resolver): retain identical recursive properties

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/converter/AnnotatedType.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/converter/AnnotatedType.java
@@ -277,9 +277,13 @@ public class AnnotatedType {
         AnnotatedType that = (AnnotatedType) o;
         List<Annotation> thisAnnotations = getProcessedAnnotations(this.ctxAnnotations);
         List<Annotation> thatAnnotations = getProcessedAnnotations(that.ctxAnnotations);
+        String thisParentName = this.parent != null ? this.parent.getName() : null;
+        String thatParentName = that.parent != null ? that.parent.getName() : null;
+
         return  includePropertiesWithoutJSONView == that.includePropertiesWithoutJSONView &&
                 schemaProperty == that.schemaProperty &&
                 isSubtype == that.isSubtype &&
+                (!schemaProperty || Objects.equals(thisParentName, thatParentName)) &&
                 Objects.equals(type, that.type) &&
                 Objects.equals(thisAnnotations, thatAnnotations) &&
                 Objects.equals(jsonViewAnnotation, that.jsonViewAnnotation) &&
@@ -289,7 +293,8 @@ public class AnnotatedType {
     @Override
     public int hashCode() {
         List<Annotation> processedAnnotations = getProcessedAnnotations(this.ctxAnnotations);
-        return Objects.hash(type, jsonViewAnnotation, includePropertiesWithoutJSONView, processedAnnotations, schemaProperty, isSubtype, schemaProperty ? propertyName : null);
+        String parentName = (schemaProperty && this.parent != null) ? this.parent.getName() : null;
+        return Objects.hash(type, jsonViewAnnotation, includePropertiesWithoutJSONView, processedAnnotations, schemaProperty, isSubtype, schemaProperty ? propertyName : null, parentName);
     }
 
     private boolean processableAnnotationPackage(Package pkg) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/RecursivePropertyMissingTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/RecursivePropertyMissingTest.java
@@ -1,0 +1,43 @@
+package io.swagger.v3.core.resolving;
+
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+
+public class RecursivePropertyMissingTest {
+
+    static class WrapperDTO {
+        @JsonProperty("nodes")
+        @JsonPropertyDescription("Child nodes")
+        public List<TestNodeDTO> nodes;
+    }
+
+    static class TestNodeDTO {
+        @JsonProperty("name")
+        public String name;
+
+        @JsonProperty("nodes")
+        @JsonPropertyDescription("Child nodes")
+        public List<TestNodeDTO> nodes;
+    }
+
+    @Test
+    public void testRecursivePropertyNotMissing() {
+        Map<String, Schema> schemas = ModelConverters.getInstance().readAll(WrapperDTO.class);
+        Schema testNodeDTOSchema = schemas.get("TestNodeDTO");
+        assertNotNull(testNodeDTOSchema);
+        
+        Map<String, Schema> properties = testNodeDTOSchema.getProperties();
+        assertNotNull(properties, "Properties should not be null");
+        assertNotNull(properties.get("nodes"), "The 'nodes' property is missing from TestNodeDTO schema");
+    }
+}

--- a/modules/swagger-core/src/test/resources/converting/ArrayOfSubclassTest_expected30.json
+++ b/modules/swagger-core/src/test/resources/converting/ArrayOfSubclassTest_expected30.json
@@ -79,6 +79,15 @@
         },
         "friend" : {
           "type" : "string"
+        },
+        "baseArray" : {
+          "minItems" : 0,
+          "uniqueItems" : true,
+          "type" : "array",
+          "description" : "Thingy",
+          "items" : {
+            "$ref" : "#/components/schemas/Base"
+          }
         }
       },
       "description" : "The SubB class"


### PR DESCRIPTION
# Pull Request

## Description

This PR fixes a bug where recursive properties are silently dropped from the generated OpenAPI schema if they happen to share the exact same name and annotations as a property in their wrapper class.

**Root cause:**
The cycle detection cache (`processedTypes`) in `ModelConverterContextImpl` uses `AnnotatedType` to prevent infinite recursion. Previously, `AnnotatedType.equals()` did not check the `parent` class for schema properties. As a result, when it encountered a child property with the exact same signature as a previously processed wrapper property, it mistakenly treated it as a self-referential cycle and dropped it.

**Fix:**
Updated `AnnotatedType.equals()` and `hashCode()` to conditionally include the `parent` class name when `schemaProperty == true`. This correctly differentiates identically-annotated properties across different classes while preserving the cycle guard for truly self-referential loops.

Fixes: #5231
Fixes: #5226

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

- Includes `RecursivePropertyMissingTest.java` to prevent future regressions.
- Fixed a legacy test expectation (`ArrayOfSubclassTest_expected30.json`) that was previously masking this bug by falsely asserting that the property should be omitted.
