### PR TITLE
fix: apply explicit @Schema(type) to the types set under OpenAPI 3.1

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -685,7 +685,11 @@ public abstract class AnnotationsUtils {
             schemaObject.set$ref(schema.ref());
         }
         if (StringUtils.isNotBlank(schema.type())) {
-            schemaObject.setType(schema.type());
+            if (openapi31) {
+                schemaObject.setTypes(new LinkedHashSet<>(Arrays.asList(schema.type())));
+            } else {
+                schemaObject.setType(schema.type());
+            }
         }
 
         if (schema.types().length > 0) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/Ticket5233Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/Ticket5233Test.java
@@ -1,0 +1,60 @@
+package io.swagger.v3.core.resolving.v31;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContextImpl;
+import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.core.resolving.SwaggerTestBase;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * An explicit {@code @Schema(type = "number" | "integer" | "boolean")} must be reflected in the
+ * OpenAPI 3.1 "types" set, not only in the legacy scalar "type" field. Previously the explicit type
+ * was applied via {@code setType} (scalar) while the "types" set kept the default {@code ["string"]},
+ * so the serialized 3.1 schema rendered every explicitly-typed field as {@code string}.
+ */
+public class Ticket5233Test extends SwaggerTestBase {
+
+    @Test
+    public void testExplicitSchemaTypeIsAppliedToTypesSetUnderOpenApi31() {
+        final ModelResolver modelResolver = new ModelResolver(mapper()).openapi31(true);
+        final ModelConverterContextImpl context = new ModelConverterContextImpl(modelResolver);
+        final Schema model = context.resolve(new AnnotatedType(Model.class));
+
+        final Map<String, Schema> properties = model.getProperties();
+        assertEquals(properties.get("amount").getTypes(), Collections.singleton("number"));
+        assertEquals(properties.get("count").getTypes(), Collections.singleton("integer"));
+        assertEquals(properties.get("flag").getTypes(), Collections.singleton("boolean"));
+
+        // controls: inferred type and enum are unaffected
+        assertEquals(properties.get("inferred").getTypes(), Collections.singleton("number"));
+        assertEquals(properties.get("unit").getTypes(), Collections.singleton("string"));
+        assertEquals(properties.get("unit").getEnum(), Arrays.asList("DAY", "WEEK", "MONTH"));
+    }
+
+    enum Freq {DAY, WEEK, MONTH}
+
+    private static class Model {
+        @io.swagger.v3.oas.annotations.media.Schema(title = "Inferred")
+        public BigDecimal inferred;
+
+        @io.swagger.v3.oas.annotations.media.Schema(title = "Amount", type = "number")
+        public BigDecimal amount;
+
+        @io.swagger.v3.oas.annotations.media.Schema(title = "Count", type = "integer")
+        public Integer count;
+
+        @io.swagger.v3.oas.annotations.media.Schema(title = "Flag", type = "boolean")
+        public Boolean flag;
+
+        @io.swagger.v3.oas.annotations.media.Schema(title = "Unit")
+        public Freq unit;
+    }
+}


### PR DESCRIPTION
## Description

Under OpenAPI 3.1, an explicit `@Schema(type = ...)` was applied via the legacy scalar `setType()`, while the 3.1 serializer reads the `types` set. The set kept its default (`"string"`), so `number` / `integer` / `boolean` fields were rendered as `string`. This change populates the `types` set when `openapi31` is enabled, mirroring the handling of the plural `types()` attribute directly below.

`AnnotationsUtils.getSchemaFromAnnotation`:

```java
if (StringUtils.isNotBlank(schema.type())) {
    if (openapi31) {
        schemaObject.setTypes(new LinkedHashSet<>(Arrays.asList(schema.type())));
    } else {
        schemaObject.setType(schema.type());
    }
}
```

**Before / After (OpenAPI 3.1)** — given `@Schema(type = "number") BigDecimal amount;`:

- **Before:** `amount: { type: "string" }`
- **After:** `amount: { type: "number" }`

This is a bug fix. It is distinct from #5061 / #5062 (numeric **example** serialization); it concerns the property **type** and reproduces with no `example` present. Fields relying on type inference (no explicit `type`) were already correct.

Fixes: #5233

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

Added `io.swagger.v3.core.resolving.v31.Ticket5233Test`, asserting that explicit `number` / `integer` / `boolean` types land in the `types` set under OpenAPI 3.1, with inferred-type and enum properties as controls. The full `swagger-core` module test suite passes locally (721 tests, 0 failures).