### PR TITLE
fix: correct sibling logic when reading type from schema annotation

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -798,7 +798,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 });
 
                 boolean areSiblingsAllowed = AnnotationsUtils.areSiblingsAllowed(resolvedSchemaResolution, openapi31);
-                aType = AnnotationsUtils.addTypeWhenSiblingsAllowed(aType, ctxSchema, areSiblingsAllowed);
+                aType = AnnotationsUtils.addTypeWhenSiblingsAllowed(aType, ctxSchema, openapi31, areSiblingsAllowed);
                 property = context.resolve(aType);
                 property = clone(property);
                 Schema ctxProperty = null;

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -61,6 +61,7 @@ import java.util.Set;
 public abstract class AnnotationsUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationsUtils.class);
+    private static final String TYPE_STRING = "string";
     public static final String COMPONENTS_REF = Components.COMPONENTS_SCHEMAS_REF;
 
     public static boolean hasSchemaAnnotation(io.swagger.v3.oas.annotations.media.Schema schema) {
@@ -992,7 +993,7 @@ public abstract class AnnotationsUtils {
                 // Only parse "null" as null value when nullable=true
                 if (node.isNull() && schema.nullable()) {
                     parsedExamples.add(null);
-                } else if (schemaObject == null && "string".equals(schema.type())) {
+                } else if (schemaObject == null && TYPE_STRING.equals(schema.type())) {
                     parsedExamples.add(trimmed);
                 } else if (shouldUseNodeAsExample(node, schemaObject)) {
                     parsedExamples.add(node);
@@ -1070,7 +1071,7 @@ public abstract class AnnotationsUtils {
         }
         if (StringUtils.isBlank(existingSchemaObject.get$ref()) && StringUtils.isBlank(existingSchemaObject.getType())) {
             // default to string
-            existingSchemaObject.setType("string");
+            existingSchemaObject.setType(TYPE_STRING);
         }
         return existingSchemaObject;
     }
@@ -1700,7 +1701,7 @@ public abstract class AnnotationsUtils {
                 }
             case "boolean":
                 return Boolean.class;
-            case "string":
+            case TYPE_STRING:
                 return String.class;
             default:
                 if (nullIfNotFound) {
@@ -1935,25 +1936,27 @@ public abstract class AnnotationsUtils {
         } else {
             Optional<Schema> schemaFromAnnotation = AnnotationsUtils.getSchemaFromAnnotation(schemaAnnotation, components, jsonViewAnnotation, openapi31, null, context);
             if (schemaFromAnnotation.isPresent()) {
-                if (StringUtils.isBlank(schemaFromAnnotation.get().get$ref()) && StringUtils.isBlank(schemaFromAnnotation.get().getType()) && !(schemaFromAnnotation.get() instanceof ComposedSchema)) {
+                Schema schema = schemaFromAnnotation.get();
+                if (StringUtils.isBlank(schema.get$ref()) && StringUtils.isBlank(schema.getType()) && !(schema instanceof ComposedSchema)) {
                     // default to string
-                    schemaFromAnnotation.get().setType("string");
+                    schema.setType(TYPE_STRING);
                 }
-                return Optional.of(schemaFromAnnotation.get());
+                return Optional.of(schema);
             } else {
                 Optional<Schema> arraySchemaFromAnnotation = AnnotationsUtils.getArraySchema(arrayAnnotation, components, jsonViewAnnotation, openapi31, null, false, context);
                 if (arraySchemaFromAnnotation.isPresent()) {
-                    if (arraySchemaFromAnnotation.get().getItems() != null && StringUtils.isBlank(arraySchemaFromAnnotation.get().getItems().get$ref()) && StringUtils.isBlank(arraySchemaFromAnnotation.get().getItems().getType())) {
+                    Schema schema = arraySchemaFromAnnotation.get();
+                    Schema schemaItems = schema.getItems();
+                    if (schemaItems != null && StringUtils.isBlank(schemaItems.get$ref()) && StringUtils.isBlank(schemaItems.getType())) {
                         // default to string
-                        arraySchemaFromAnnotation.get().getItems().setType("string");
+                        schemaItems.setType(TYPE_STRING);
                     }
-                    return Optional.of(arraySchemaFromAnnotation.get());
+                    return Optional.of(schema);
                 }
             }
         }
         return Optional.empty();
     }
-
 
     public static void applyTypes(String[] classTypes, String[] methodTypes, Content content, MediaType mediaType) {
         if (methodTypes != null && methodTypes.length > 0) {
@@ -3076,14 +3079,34 @@ public abstract class AnnotationsUtils {
         return Schema.SchemaResolution.ALL_OF.equals(resolvedSchemaResolution) || Schema.SchemaResolution.ALL_OF_REF.equals(resolvedSchemaResolution) || openapi31;
     }
 
-    public static AnnotatedType addTypeWhenSiblingsAllowed(AnnotatedType aType, io.swagger.v3.oas.annotations.media.Schema ctxSchema, boolean areSiblingsAllowed) {
+    public static AnnotatedType addTypeWhenSiblingsAllowed(AnnotatedType aType,
+                                                           io.swagger.v3.oas.annotations.media.Schema ctxSchema,
+                                                           boolean openapi31,
+                                                           boolean areSiblingsAllowed) {
         if (areSiblingsAllowed && ctxSchema != null) {
             if (!Void.class.equals(ctxSchema.implementation())) {
                 aType.setType(ctxSchema.implementation());
+            } else if (openapi31) {
+                if (ctxSchema.types().length == 1) {
+                    setType(aType, ctxSchema.types()[0]);
+                }
             } else if (StringUtils.isNotBlank(ctxSchema.type())) {
-                aType.setType(ctxSchema.type().getClass());
+                setType(aType, ctxSchema.type());
             }
         }
         return aType;
+    }
+
+    /**
+     * Does a best-effort approach of attempting to change the type of {@code annotatedType} to {@code type}.
+     * If {@code type} cannot be interpreted to a {@link PrimitiveType}, then no change is made.
+     * @param annotatedType The {@link AnnotatedType} to change the type of
+     * @param type The new type
+     */
+    private static void setType(AnnotatedType annotatedType, String type) {
+        PrimitiveType primitiveType = PrimitiveType.fromName(type);
+        if (primitiveType != null) {
+            annotatedType.setType(primitiveType.getKeyClass());
+        }
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5055Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5055Test.java
@@ -109,10 +109,6 @@ public class Issue5055Test {
         assertNotNull(schema);
         String json = Json31.pretty(schema);
         
-        System.out.println("\n=== testTypeInferenceWithNoImplementation - Generated Spec ===");
-        System.out.println(json);
-        System.out.println("=== End Spec ===\n");
-        
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root = mapper.readTree(json);
         

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5061Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5061Test.java
@@ -142,16 +142,16 @@ public class Issue5061Test {
         @io.swagger.v3.oas.annotations.media.Schema(example = "5 lacs per annum")
         String stringFieldType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "string", example = "5 lacs per annum")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"string"}, example = "5 lacs per annum")
         String stringFieldTypeWithExplicitStringSchemaType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "number", example = "10")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"number"}, example = "10")
         String stringFieldTypeWithExplicitNumberSchemaType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "integer", example = "5")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"integer"}, example = "5")
         String stringFieldTypeWithExplicitIntegerSchemaType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "string", example = "13.37")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"string"}, example = "13.37")
         BigDecimal bigDecimalFieldTypeWithExplicitStringSchemaType;
 
         @io.swagger.v3.oas.annotations.media.Schema(example = "13.37")

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5168Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5168Test.java
@@ -55,10 +55,10 @@ public class Issue5168Test {
         @io.swagger.v3.oas.annotations.media.Schema(example = "true")
         String stringFieldType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "boolean", example = "true")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"boolean"}, example = "true")
         String stringFieldTypeWithExplicitBooleanSchemaType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "string", example = "true")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"string"}, example = "true")
         boolean booleanFieldTypeWithExplicitStringSchemaType;
 
         @io.swagger.v3.oas.annotations.media.Schema(example = "true")

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue5077Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue5077Test.java
@@ -65,7 +65,6 @@ public class Issue5077Test {
     @Test
     public void nullableSetOas31_onlyContainerIsNullable() {
         ResolvedSchema resolved = ModelConverters.getInstance(true).readAllAsResolvedSchema(NullableSetContainer.class);
-        System.out.println("nullableSetOas31_onlyContainerIsNullable:\n" + Json31.pretty(resolved));
         Map<String, Schema> schemas = resolved.referencedSchemas;
         Schema<?> container = schemas.get("NullableSetContainer");
         Schema<?> tags = (Schema<?>) container.getProperties().get("tags");
@@ -84,7 +83,6 @@ public class Issue5077Test {
     @Test
     public void nullableArrayOas31_onlyContainerIsNullable() {
         ResolvedSchema resolved = ModelConverters.getInstance(true).readAllAsResolvedSchema(NullableArrayContainer.class);
-        System.out.println("nullableArrayOas31_onlyContainerIsNullable:\n" + Json31.pretty(resolved));
         Map<String, Schema> schemas = resolved.referencedSchemas;
         Schema<?> container = schemas.get("NullableArrayContainer");
         Schema<?> names = (Schema<?>) container.getProperties().get("names");
@@ -103,7 +101,6 @@ public class Issue5077Test {
     @Test
     public void nullableMapOas31_onlyContainerIsNullable() {
         ResolvedSchema resolved = ModelConverters.getInstance(true).readAllAsResolvedSchema(NullableMapContainer.class);
-        System.out.println("nullableMapOas31_onlyContainerIsNullable:\n" + Json31.pretty(resolved));
         Map<String, Schema> schemas = resolved.referencedSchemas;
         Schema<?> container = schemas.get("NullableMapContainer");
         Schema<?> labels = (Schema<?>) container.getProperties().get("labels");
@@ -122,7 +119,6 @@ public class Issue5077Test {
     @Test
     public void nullableNestedListOas31_onlyOuterContainerIsNullable() {
         ResolvedSchema resolved = ModelConverters.getInstance(true).readAllAsResolvedSchema(NullableNestedListContainer.class);
-        System.out.println("nullableNestedListOas31_onlyOuterContainerIsNullable:\n" + Json31.pretty(resolved));
         Map<String, Schema> schemas = resolved.referencedSchemas;
         Schema<?> container = schemas.get("NullableNestedListContainer");
         Schema<?> matrix = (Schema<?>) container.getProperties().get("matrix");
@@ -147,7 +143,6 @@ public class Issue5077Test {
     @Test
     public void explicitItemNullabilityOas31_stillWorks() {
         ResolvedSchema resolved = ModelConverters.getInstance(true).readAllAsResolvedSchema(ExplicitNullableItemsContainer.class);
-        System.out.println("explicitItemNullabilityOas31_stillWorks:\n" + Json31.pretty(resolved));
         Map<String, Schema> schemas = resolved.referencedSchemas;
         Schema<?> container = schemas.get("ExplicitNullableItemsContainer");
         Schema<?> values = (Schema<?>) container.getProperties().get("values");
@@ -185,7 +180,6 @@ public class Issue5077Test {
     @Test
     public void nullableSetOas30_onlyContainerIsNullable() {
         ResolvedSchema resolved = ModelConverters.getInstance(false).readAllAsResolvedSchema(NullableSetContainer.class);
-        System.out.println("nullableSetOas30_onlyContainerIsNullable:\n" + Json.pretty(resolved));
         Map<String, Schema> schemas = resolved.referencedSchemas;
         Schema<?> container = schemas.get("NullableSetContainer");
         ArraySchema tags = (ArraySchema) container.getProperties().get("tags");
@@ -203,7 +197,6 @@ public class Issue5077Test {
     @Test
     public void nullableMapOas30_onlyContainerIsNullable() {
         ResolvedSchema resolved = ModelConverters.getInstance(false).readAllAsResolvedSchema(NullableMapContainer.class);
-        System.out.println("nullableMapOas30_onlyContainerIsNullable:\n" + Json.pretty(resolved));
         Map<String, Schema> schemas = resolved.referencedSchemas;
         Schema<?> container = schemas.get("NullableMapContainer");
         Schema<?> labels = (Schema<?>) container.getProperties().get("labels");

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4679Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4679Test.java
@@ -2,17 +2,31 @@ package io.swagger.v3.core.resolving;
 
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.matchers.SerializationMatchers;
-import io.swagger.v3.core.util.Yaml;
-import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
-public class Ticket4679Test extends SwaggerTestBase{
+public class Ticket4679Test extends SwaggerTestBase {
 
     @Test(description = "Custom schema implementation in property overrides type value")
     public void testCustomSchemaImplementation() {
+
+        String expectedYaml = "ModelWithCustomSchemaImplementationInProperty:\n" +
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    exampleField:\n" +
+                              "      type: integer\n" +
+                              "      format: int32\n" +
+                              "    secondExampleField:\n" +
+                              "      type: string\n";
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance().readAll(ModelWithCustomSchemaImplementationInProperty.class);
+        SerializationMatchers.assertEqualsToYaml(stringSchemaMap, expectedYaml);
+    }
+
+    @Test(description = "Custom schema implementation in property overrides type value")
+    public void testCustomSchemaImplementationOAS31() {
 
         String expectedYaml = "ModelWithCustomSchemaImplementationInProperty:\n" +
                 "  type: object\n" +
@@ -32,7 +46,7 @@ public class Ticket4679Test extends SwaggerTestBase{
         @Schema(implementation = Integer.class)
         private String exampleField;
 
-        @Schema(type = "string")
+        @Schema(type = "string", types = {"string"})
         private Integer secondExampleField;
 
         public String getExampleField() {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4800Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4800Test.java
@@ -7,27 +7,58 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 
-public class Ticket4800Test extends SwaggerTestBase{
+public class Ticket4800Test extends SwaggerTestBase {
 
     @Test(description = "Custom schema implementation in property and enum as ref type value")
     public void testCustomSchemaImplementation() {
+        try {
+            String expectedYaml = "ModelWithCustomSchemaImplementationInProperty:\n" +
+                              "  properties:\n" +
+                              "    enumExampleFieldWithImplementationProp:\n" +
+                              "      allOf:\n" +
+                              "      - default: \"yes\"\n" +
+                              "        description: Prop description\n" +
+                              "      - $ref: \"#/components/schemas/MyEnum\"\n" +
+                              "    secondExampleFieldWithTypeProp:\n" +
+                              "      type: string\n" +
+                              "    thirdExampleFieldWithTypeProp:\n" +
+                              "      type: boolean\n" +
+                              "MyEnum:\n" +
+                              "  type: string\n" +
+                              "  enum:\n" +
+                              "  - \"yes\"\n" +
+                              "  - \"no\"\n";
 
-        String expectedYaml = "ModelWithCustomSchemaImplementationInProperty:\n" +
-                "  type: object\n" +
-                "  properties:\n" +
-                "    enumExampleFieldWithImplementationProp:\n" +
-                "      $ref: \"#/components/schemas/MyEnum\"\n" +
-                "      default: \"yes\"\n" +
-                "      description: Prop description\n" +
-                "    secondExampleFieldWithTypeProp:\n" +
-                "      type: string\n" +
-                "MyEnum:\n" +
-                "  type: string\n" +
-                "  enum:\n" +
-                "  - \"yes\"\n" +
-                "  - \"no\"";
+            Map<String, Schema> stringSchemaMap = ModelConverters.getInstance(false, Schema.SchemaResolution.ALL_OF)
+                    .readAll(Ticket4800Test.ModelWithCustomSchemaImplementationInProperty.class);
+            SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
+        } finally {
+            // Always clear global converter state (cause by Schema.SchemaResolution.ALL_OF), even if assertion/setup throws
+            ModelConverters.reset();
+        }
+    }
 
-        Map<String, Schema> stringSchemaMap = ModelConverters.getInstance(true).readAll(Ticket4800Test.ModelWithCustomSchemaImplementationInProperty.class);
+    @Test(description = "Custom schema implementation in property and enum as ref type value")
+    public void testCustomSchemaImplementationOAS31() {
+        String expectedYaml = "ModelWithCustomSchemaImplementationInPropertyOAS31:\n" +
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    enumExampleFieldWithImplementationProp:\n" +
+                              "      $ref: \"#/components/schemas/MyEnum\"\n" +
+                              "      default: \"yes\"\n" +
+                              "      description: Prop description\n" +
+                              "    secondExampleFieldWithTypeProp:\n" +
+                              "      type: string\n" +
+                              "    thirdExampleFieldWithTypeProp:\n" +
+                              "      type: boolean\n" +
+                              "MyEnum:\n" +
+                              "  type: string\n" +
+                              "  enum:\n" +
+                              "  - \"yes\"\n" +
+                              "  - \"no\"";
+
+        Map<String, Schema> stringSchemaMap = ModelConverters.getInstance(true)
+                .readAll(Ticket4800Test.ModelWithCustomSchemaImplementationInPropertyOAS31.class);
         SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
     }
 
@@ -38,6 +69,9 @@ public class Ticket4800Test extends SwaggerTestBase{
 
         @io.swagger.v3.oas.annotations.media.Schema(type = "string", enumAsRef = true)
         private MyEnum2 secondExampleFieldWithTypeProp;
+
+        @io.swagger.v3.oas.annotations.media.Schema(type = "boolean")
+        private MyEnum3 thirdExampleFieldWithTypeProp;
 
         public MyEnum getEnumExampleFieldWithImplementationProp() {
             return enumExampleFieldWithImplementationProp;
@@ -55,6 +89,14 @@ public class Ticket4800Test extends SwaggerTestBase{
             this.secondExampleFieldWithTypeProp = secondExampleFieldWithTypeProp;
         }
 
+        public MyEnum3 getThirdExampleFieldWithTypeProp() {
+            return thirdExampleFieldWithTypeProp;
+        }
+
+        public void setThirdExampleFieldWithTypeProp(MyEnum3 thirdExampleFieldWithTypeProp) {
+            this.thirdExampleFieldWithTypeProp = thirdExampleFieldWithTypeProp;
+        }
+
         enum MyEnum {
             yes, no
         }
@@ -62,6 +104,61 @@ public class Ticket4800Test extends SwaggerTestBase{
         //Should not be included in the model definitions
         enum MyEnum2 {
             si, no
+        }
+
+        //Should not be included in the model definitions
+        enum MyEnum3 {
+            tru, fals
+        }
+    }
+
+    static class ModelWithCustomSchemaImplementationInPropertyOAS31 {
+
+        @io.swagger.v3.oas.annotations.media.Schema(implementation = MyEnum.class, description = "Prop description", defaultValue = "yes", enumAsRef = true)
+        private MyEnum enumExampleFieldWithImplementationProp;
+
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"string"})
+        private MyEnum2 secondExampleFieldWithTypeProp;
+
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"boolean"})
+        private MyEnum3 thirdExampleFieldWithTypeProp;
+
+        public MyEnum getEnumExampleFieldWithImplementationProp() {
+            return enumExampleFieldWithImplementationProp;
+        }
+
+        public void setEnumExampleFieldWithImplementationProp(MyEnum enumExampleFieldWithImplementationProp) {
+            this.enumExampleFieldWithImplementationProp = enumExampleFieldWithImplementationProp;
+        }
+
+        public MyEnum2 getSecondExampleFieldWithTypeProp() {
+            return secondExampleFieldWithTypeProp;
+        }
+
+        public void setSecondExampleFieldWithTypeProp(MyEnum2 secondExampleFieldWithTypeProp) {
+            this.secondExampleFieldWithTypeProp = secondExampleFieldWithTypeProp;
+        }
+
+        public MyEnum3 getThirdExampleFieldWithTypeProp() {
+            return thirdExampleFieldWithTypeProp;
+        }
+
+        public void setThirdExampleFieldWithTypeProp(MyEnum3 thirdExampleFieldWithTypeProp) {
+            this.thirdExampleFieldWithTypeProp = thirdExampleFieldWithTypeProp;
+        }
+
+        enum MyEnum {
+            yes, no
+        }
+
+        //Should not be included in the model definitions
+        enum MyEnum2 {
+            si, no
+        }
+
+        //Should not be included in the model definitions
+        enum MyEnum3 {
+            tru, fals
         }
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ModelResolverOAS31Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/ModelResolverOAS31Test.java
@@ -21,6 +21,7 @@ import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 
@@ -443,6 +444,104 @@ public class ModelResolverOAS31Test extends SwaggerTestBase {
         SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
     }
 
+    @Test(description = "Setting type in @Schema is applied for OAS 3.0")
+    public void testTypeInSchemaAnnotationIsAppliedForOAS30() {
+        String expectedYaml = "ClassWithFieldsUsingOAS30Type:\n" +
+                              "  properties:\n" +
+                              "    inferred:\n" +
+                              "      type: number\n" +
+                              "    amount:\n" +
+                              "      type: boolean\n" +
+                              "    count:\n" +
+                              "      type: boolean\n" +
+                              "    flag:\n" +
+                              "      type: integer\n" +
+                              "      format: int32\n" +
+                              "    unit:\n" +
+                              "      type: string\n" +
+                              "      enum:\n" +
+                              "      - DAY\n" +
+                              "      - WEEK\n" +
+                              "      - MONTH";
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance().readAll(ClassWithFieldsUsingOAS30Type.class);
+        SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
+    }
+
+    @Test(description = "Setting types in @Schema is ignored for OAS 3.0")
+    public void testTypesInSchemaAnnotationIsIgnoredForOAS30() {
+        String expectedYaml = "ClassWithFieldsUsingOAS31Types:\n" +
+                              "  properties:\n" +
+                              "    inferred:\n" +
+                              "      type: number\n" +
+                              "    amount:\n" +
+                              "      type: number\n" +
+                              "    count:\n" +
+                              "      type: integer\n" +
+                              "      format: int32\n" +
+                              "    flag:\n" +
+                              "      type: boolean\n" +
+                              "    unit:\n" +
+                              "      type: string\n" +
+                              "      enum:\n" +
+                              "      - DAY\n" +
+                              "      - WEEK\n" +
+                              "      - MONTH";
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance().readAll(ClassWithFieldsUsingOAS31Types.class);
+        SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
+    }
+
+    @Test(description = "Setting type in @Schema is ignored for OAS 3.1")
+    public void testTypeInSchemaAnnotationIsIgnoredForOAS31() {
+        String expectedYaml = "ClassWithFieldsUsingOAS30Type:\n" +
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    inferred:\n" +
+                              "      type: number\n" +
+                              "    amount:\n" +
+                              "      type: number\n" +
+                              "    count:\n" +
+                              "      type: integer\n" +
+                              "      format: int32\n" +
+                              "    flag:\n" +
+                              "      type: boolean\n" +
+                              "    unit:\n" +
+                              "      type: string\n" +
+                              "      enum:\n" +
+                              "      - DAY\n" +
+                              "      - WEEK\n" +
+                              "      - MONTH";
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance(true).readAll(ClassWithFieldsUsingOAS30Type.class);
+        SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
+    }
+
+    @Test(description = "Setting types in @Schema is applied for OAS 3.1")
+    public void testTypesInSchemaAnnotationIsAppliedForOAS31() {
+        String expectedYaml = "ClassWithFieldsUsingOAS31Types:\n" +
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    inferred:\n" +
+                              "      type: number\n" +
+                              "    amount:\n" +
+                              "      type: boolean\n" +
+                              "    count:\n" +
+                              "      type: boolean\n" +
+                              "    flag:\n" +
+                              "      type: integer\n" +
+                              "      format: int32\n" +
+                              "    unit:\n" +
+                              "      type: string\n" +
+                              "      enum:\n" +
+                              "      - DAY\n" +
+                              "      - WEEK\n" +
+                              "      - MONTH";
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance(true).readAll(ClassWithFieldsUsingOAS31Types.class);
+        SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
+    }
+
     private static class ClassWithUsingDecimalAnnotationsOnField {
         @DecimalMin("1")
         @DecimalMax("100")
@@ -455,5 +554,35 @@ public class ModelResolverOAS31Test extends SwaggerTestBase {
         public void setMyField(Number myField) {
             this.myField = myField;
         }
+    }
+
+    private static class ClassWithFieldsUsingOAS30Type {
+        @io.swagger.v3.oas.annotations.media.Schema
+        public BigDecimal inferred;
+        @io.swagger.v3.oas.annotations.media.Schema(type = "boolean")
+        public BigDecimal amount;
+        @io.swagger.v3.oas.annotations.media.Schema(type = "boolean")
+        public Integer count;
+        @io.swagger.v3.oas.annotations.media.Schema(type = "integer")
+        public Boolean flag;
+        @io.swagger.v3.oas.annotations.media.Schema
+        public Frequency unit;
+
+        enum Frequency { DAY, WEEK, MONTH }
+    }
+
+    private static class ClassWithFieldsUsingOAS31Types {
+        @io.swagger.v3.oas.annotations.media.Schema
+        public BigDecimal inferred;
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"boolean"})
+        public BigDecimal amount;
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"boolean"})
+        public Integer count;
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"integer"})
+        public Boolean flag;
+        @io.swagger.v3.oas.annotations.media.Schema
+        public Frequency unit;
+
+        enum Frequency { DAY, WEEK, MONTH }
     }
 }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/Address.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/Address.java
@@ -71,7 +71,7 @@ public class Address {
 
         @Schema(
                 _const = "United States",
-                type = "string"
+                types = {"string"}
 
         )
         public Object getCountry() {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodeNumberPattern.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodeNumberPattern.java
@@ -9,7 +9,7 @@ public class PostalCodeNumberPattern {
 
     @Schema(
             pattern = "[0-9]{5}(-[0-9]{4})?",
-            type = "string"
+            types = {"string"}
     )
     public Object getPostalCode() {
         return postalCode;

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodePattern.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodePattern.java
@@ -8,7 +8,7 @@ public class PostalCodePattern {
 
     @Schema(
             pattern = "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]",
-            type = "string"
+            types = {"string"}
     )
     public Object getPostalCode() {
         return postalCode;


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

Introduces an intermediate fix for the issue reported in https://github.com/swagger-api/swagger-core/issues/5235. It does not solve the sibling handling in its entirety, since it only adjusts the type if `types` contains a single value (this is aimed to give a fallback for the logic implemented for OAS 3.0. This since `type` and `types` are now better isolated from each other, and the resolver expect the user to use the right field for the right OAS version). 

For OAS 3.1 it is currently not possible to entirely handle `types` since it is converted into a single type that is fed into `AnnotatedType`. For a real scenario the entire type array should be utilized and passed along.

This also comes with the behavior of coercing the string value for the `type` into a `PrimitiveType`. This might in turn lead to `format` or similar being calculated for `integer`, which might not always be what one expects when using `@Schema(types = {"integer"})`.

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->

Fixes: https://github.com/swagger-api/swagger-core/issues/5235

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->