### PR TITLE
fix: Stabilize CI Maven and Gradle builds

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,14 +50,25 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-jdk11-maven-v2-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
-    - name: Build with Maven and Gradle
-      run: |
-        ./mvnw --no-transfer-progress -B install --file pom.xml
-        cd ./modules/swagger-gradle-plugin
-        ./gradlew build --info
-        cd ../..
+          ${{ runner.os }}-jdk11-maven-v2-
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-provider: basic
+    - name: Build with Maven
+      run: ./mvnw --no-transfer-progress -B -e install --file pom.xml
+    - name: Upload Maven test reports
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: surefire-reports-codeql
+        path: |
+          **/target/surefire-reports/**
+          **/target/failsafe-reports/**
+    - name: Build Gradle plugin
+      working-directory: modules/swagger-gradle-plugin
+      run: ./gradlew build --info --stacktrace --no-daemon
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/maven-pulls.yml
+++ b/.github/workflows/maven-pulls.yml
@@ -26,9 +26,13 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-jdk${{ matrix.java }}-maven-v2-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-jdk${{ matrix.java }}-maven-v2-
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-provider: basic
     - name: Check swagger-bom version matches root version
       run: |
         ROOT_VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
@@ -39,11 +43,18 @@ jobs:
           echo "ERROR: swagger-bom version (${BOM_VERSION}) does not match root version (${ROOT_VERSION}). Update modules/swagger-bom/pom.xml."
           exit 1
         fi
-    - name: Build with Maven and Gradle
-      run: |
-        ./mvnw --no-transfer-progress -B install --file pom.xml
-        cd ./modules/swagger-gradle-plugin
-        ./gradlew build --info
-        cd ../..
+    - name: Build with Maven
+      run: ./mvnw --no-transfer-progress -B -e install --file pom.xml
+    - name: Upload Maven test reports
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: surefire-reports-java-${{ matrix.java }}
+        path: |
+          **/target/surefire-reports/**
+          **/target/failsafe-reports/**
+    - name: Build Gradle plugin
+      working-directory: modules/swagger-gradle-plugin
+      run: ./gradlew build --info --stacktrace --no-daemon
     - name: Verify BOM integration test
       run: ./mvnw --no-transfer-progress -B validate -Pbom-it

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,9 +26,13 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-jdk${{ matrix.java }}-maven-v2-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-maven-
+          ${{ runner.os }}-jdk${{ matrix.java }}-maven-v2-
+    - name: Set up Gradle
+      uses: gradle/actions/setup-gradle@v6
+      with:
+        cache-provider: basic
     - name: Check swagger-bom version matches root version
       run: |
         ROOT_VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec)
@@ -39,29 +43,36 @@ jobs:
           echo "ERROR: swagger-bom version (${BOM_VERSION}) does not match root version (${ROOT_VERSION}). Update modules/swagger-bom/pom.xml."
           exit 1
         fi
-    - name: Build with Maven and Gradle, Deploy snapshot to maven central
+    - name: Check project snapshot version
+      id: project-version
       run: |
-        export MY_POM_VERSION=`./mvnw -q -Dexec.executable="echo" -Dexec.args='${projects.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
+        export MY_POM_VERSION=`./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
         echo "POM VERSION" ${MY_POM_VERSION}
         if [[ $MY_POM_VERSION =~ ^.*SNAPSHOT$ ]];
         then
-          ./mvnw --no-transfer-progress -B install --file pom.xml
-          cd ./modules/swagger-gradle-plugin
-          ./gradlew build --info
-          cd ../..
-          export MY_JAVA_VERSION=`java -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1`
-          echo "JAVA VERSION" ${MY_JAVA_VERSION}
-          if [[ ${MY_JAVA_VERSION} == "11" ]];
-          then
-            export MY_POM_VERSION=`./mvnw -q -Dexec.executable="echo" -Dexec.args='${projects.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.3.1:exec`
-            echo "POM VERSION" ${MY_POM_VERSION}
-            ./mvnw --no-transfer-progress -B clean deploy -e
-          else
-            echo "not deploying on java version: " ${MY_JAVA_VERSION}
-          fi
+          echo "is_snapshot=true" >> $GITHUB_OUTPUT
         else
-          echo "not building and maven publishing project as it is a release version: " ${MY_JAVA_VERSION}
+          echo "is_snapshot=false" >> $GITHUB_OUTPUT
+          echo "not building and maven publishing project as it is a release version: " ${MY_POM_VERSION}
         fi
+    - name: Build with Maven
+      if: steps.project-version.outputs.is_snapshot == 'true'
+      run: ./mvnw --no-transfer-progress -B -e install --file pom.xml
+    - name: Upload Maven test reports
+      if: failure()
+      uses: actions/upload-artifact@v6
+      with:
+        name: surefire-reports-java-${{ matrix.java }}
+        path: |
+          **/target/surefire-reports/**
+          **/target/failsafe-reports/**
+    - name: Build Gradle plugin
+      if: steps.project-version.outputs.is_snapshot == 'true'
+      working-directory: modules/swagger-gradle-plugin
+      run: ./gradlew build --info --stacktrace --no-daemon
+    - name: Deploy snapshot to maven central
+      if: steps.project-version.outputs.is_snapshot == 'true' && matrix.java == 11
+      run: ./mvnw --no-transfer-progress -B clean deploy -e
       env:
         MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/CI/post-release.sh
+++ b/CI/post-release.sh
@@ -41,14 +41,6 @@ sc_find="version=$SC_VERSION"
 sc_replace="version=$SC_NEXT_VERSION-SNAPSHOT"
 sed -i -e "s/$sc_find/$sc_replace/g" $CUR/modules/swagger-gradle-plugin/gradle.properties
 
-sc_find="io.swagger.core.v3:swagger-jaxrs2:$SC_VERSION"
-sc_replace="io.swagger.core.v3:swagger-jaxrs2:$SC_NEXT_VERSION-SNAPSHOT"
-sed -i -e "s/$sc_find/$sc_replace/g" $CUR/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/SwaggerPlugin.java
-
-sc_find="io.swagger.core.v3:swagger-jaxrs2:$SC_VERSION"
-sc_replace="io.swagger.core.v3:swagger-jaxrs2:$SC_NEXT_VERSION-SNAPSHOT"
-sed -i -e "s/$sc_find/$sc_replace/g" $CUR/modules/swagger-gradle-plugin/src/test/java/io/swagger/v3/plugins/gradle/SwaggerResolveTest.java
-
 sc_find="<version>$SC_VERSION<\/version>"
 sc_replace="<version>$SC_NEXT_VERSION-SNAPSHOT<\/version>"
 sed -i -e "s/$sc_find/$sc_replace/g" $CUR/modules/swagger-java17-support/pom.xml

--- a/modules/swagger-gradle-plugin/build.gradle
+++ b/modules/swagger-gradle-plugin/build.gradle
@@ -22,6 +22,14 @@ compileJava {
     options.release = 8
 }
 
+processResources {
+    inputs.property 'pluginVersion', project.version
+    filteringCharset = 'UTF-8'
+    filesMatching('swagger-gradle-plugin.properties') {
+        expand(pluginVersion: project.version)
+    }
+}
+
 dependencies {
     implementation gradleApi()
     implementation 'org.apache.commons:commons-lang3:3.20.0'
@@ -103,6 +111,7 @@ pluginBundle {
 
 test {
     useTestNG()
+    systemProperty 'swagger.plugin.version', project.version
 }
 
 publishing {

--- a/modules/swagger-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/modules/swagger-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-bin.zip
-networkTimeout=10000
+networkTimeout=60000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/SwaggerPlugin.java
+++ b/modules/swagger-gradle-plugin/src/main/java/io/swagger/v3/plugins/gradle/SwaggerPlugin.java
@@ -1,6 +1,9 @@
 package io.swagger.v3.plugins.gradle;
 
 import io.swagger.v3.plugins.gradle.tasks.ResolveTask;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -10,6 +13,9 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
 
 public class SwaggerPlugin implements Plugin<Project> {
+    private static final String PLUGIN_PROPERTIES = "/swagger-gradle-plugin.properties";
+    private static final String PLUGIN_VERSION = loadPluginVersion();
+
     public void apply(Project project) {
         final Configuration config = project.getConfigurations().create("swaggerDeps")
                 .setVisible(false);
@@ -17,7 +23,7 @@ public class SwaggerPlugin implements Plugin<Project> {
         config.defaultDependencies(new Action<DependencySet>() {
             public void execute(DependencySet dependencies) {
                 dependencies.add(project.getDependencies().create("org.apache.commons:commons-lang3:3.20.0"));
-                dependencies.add(project.getDependencies().create("io.swagger.core.v3:swagger-jaxrs2:2.2.53-SNAPSHOT"));
+                dependencies.add(project.getDependencies().create("io.swagger.core.v3:swagger-jaxrs2:" + PLUGIN_VERSION));
                 dependencies.add(project.getDependencies().create("javax.ws.rs:javax.ws.rs-api:2.1"));
                 dependencies.add(project.getDependencies().create("javax.servlet:javax.servlet-api:3.1.0"));
             }
@@ -37,5 +43,29 @@ public class SwaggerPlugin implements Plugin<Project> {
             task.convertToOpenAPI31.convention(false);
             task.outputDir.convention(project.getLayout().getBuildDirectory().dir("swagger"));
         });
+    }
+
+    private static String loadPluginVersion() {
+        Properties properties = new Properties();
+        try (InputStream stream = SwaggerPlugin.class.getResourceAsStream(PLUGIN_PROPERTIES)) {
+            if (stream == null) {
+                throw new IllegalStateException("Missing " + PLUGIN_PROPERTIES);
+            }
+            properties.load(stream);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to load " + PLUGIN_PROPERTIES, e);
+        }
+        String pluginVersion = properties.getProperty("plugin.version");
+        validatePluginVersion(pluginVersion);
+        return pluginVersion;
+    }
+
+    static void validatePluginVersion(String pluginVersion) {
+        if (pluginVersion == null || pluginVersion.trim().isEmpty()) {
+            throw new IllegalStateException("Missing plugin.version in " + PLUGIN_PROPERTIES);
+        }
+        if (pluginVersion.trim().startsWith("${") && pluginVersion.trim().endsWith("}")) {
+            throw new IllegalStateException("Unresolved plugin.version in " + PLUGIN_PROPERTIES + ": " + pluginVersion);
+        }
     }
 }

--- a/modules/swagger-gradle-plugin/src/main/resources/swagger-gradle-plugin.properties
+++ b/modules/swagger-gradle-plugin/src/main/resources/swagger-gradle-plugin.properties
@@ -1,0 +1,1 @@
+plugin.version=${pluginVersion}

--- a/modules/swagger-gradle-plugin/src/test/java/io/swagger/v3/plugins/gradle/SwaggerResolveTest.java
+++ b/modules/swagger-gradle-plugin/src/test/java/io/swagger/v3/plugins/gradle/SwaggerResolveTest.java
@@ -2,16 +2,21 @@ package io.swagger.v3.plugins.gradle;
 
 import static java.lang.String.format;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.Properties;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
@@ -19,6 +24,13 @@ import org.testng.annotations.Test;
 import org.testng.annotations.BeforeMethod;
 
 public class SwaggerResolveTest {
+
+    private static final String PROJECT_VERSION = Objects.requireNonNull(
+            System.getProperty("swagger.plugin.version"),
+            "Missing swagger.plugin.version test system property"
+    );
+    private static final String SWAGGER_JAXRS2_DEPENDENCY = "io.swagger.core.v3:swagger-jaxrs2:" +
+            PROJECT_VERSION;
 
     private Path testProjectDir;
     private Path buildFile;
@@ -53,6 +65,27 @@ public class SwaggerResolveTest {
     }
 
     @Test
+    public void pluginVersionResourceMatchesProjectVersion() throws IOException {
+        Properties properties = new Properties();
+        try (InputStream stream = SwaggerPlugin.class.getResourceAsStream("/swagger-gradle-plugin.properties")) {
+            assertNotNull(stream, "Missing swagger-gradle-plugin.properties");
+            properties.load(stream);
+        }
+        assertEquals(properties.getProperty("plugin.version"), PROJECT_VERSION);
+    }
+
+    @Test
+    public void pluginVersionRejectsUnresolvedPlaceholder() {
+        try {
+            SwaggerPlugin.validatePluginVersion("${pluginVersion}");
+        } catch (IllegalStateException e) {
+            assertTrue(e.getMessage().contains("Unresolved plugin.version"));
+            return;
+        }
+        throw new AssertionError("Expected unresolved plugin.version to fail fast");
+    }
+
+    @Test
     public void testSwaggerResolveTask() throws IOException {
         outputDir = testProjectDir.toString() + "/target";
         outputFile = testProjectDir.toString() + "/testAPI.json";
@@ -77,7 +110,7 @@ public class SwaggerResolveTest {
                 "    mavenCentral()\n" +
                 "}\n" +
                 "dependencies {  \n" +
-                "    implementation 'io.swagger.core.v3:swagger-jaxrs2:2.2.53-SNAPSHOT'\n" +
+                "    implementation '" + SWAGGER_JAXRS2_DEPENDENCY + "'\n" +
                 "    implementation 'javax.ws.rs:javax.ws.rs-api:2.1'\n" +
                 "    implementation 'javax.servlet:javax.servlet-api:3.1.0'\n" +
                 "    testImplementation 'com.github.tomakehurst:wiremock:2.27.2'\n" +
@@ -150,7 +183,7 @@ public class SwaggerResolveTest {
                 "    mavenCentral()\n" +
                 "}\n" +
                 "dependencies {  \n" +
-                "    implementation 'io.swagger.core.v3:swagger-jaxrs2:2.2.53-SNAPSHOT'\n" +
+                "    implementation '" + SWAGGER_JAXRS2_DEPENDENCY + "'\n" +
                 "    implementation 'javax.ws.rs:javax.ws.rs-api:2.1'\n" +
                 "    implementation 'javax.servlet:javax.servlet-api:3.1.0'\n" +
                 "    testImplementation 'com.github.tomakehurst:wiremock:2.27.2'\n" +
@@ -234,7 +267,7 @@ public class SwaggerResolveTest {
                 "    mavenCentral()\n" +
                 "}\n" +
                 "dependencies {  \n" +
-                "    implementation 'io.swagger.core.v3:swagger-jaxrs2:2.2.47-SNAPSHOT'\n" +
+                "    implementation '" + SWAGGER_JAXRS2_DEPENDENCY + "'\n" +
                 "    implementation 'javax.ws.rs:javax.ws.rs-api:2.1'\n" +
                 "    implementation 'javax.servlet:javax.servlet-api:3.1.0'\n" +
                 "}\n" +
@@ -303,7 +336,7 @@ public class SwaggerResolveTest {
                 "    mavenCentral()\n" +
                 "}\n" +
                 "dependencies {\n" +
-                "    implementation 'io.swagger.core.v3:swagger-jaxrs2:2.2.53-SNAPSHOT'\n" +
+                "    implementation '" + SWAGGER_JAXRS2_DEPENDENCY + "'\n" +
                 "    implementation 'javax.ws.rs:javax.ws.rs-api:2.1'\n" +
                 "    implementation 'javax.servlet:javax.servlet-api:3.1.0'\n" +
                 "    testImplementation 'org.testng:testng:7.10.2'\n" +

--- a/modules/swagger-jaxrs2/pom.xml
+++ b/modules/swagger-jaxrs2/pom.xml
@@ -96,8 +96,9 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire-version}</version>
                 <configuration>
-                    <argLine>-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-                    <forkCount>0</forkCount>
+                    <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
                 </configuration>
             </plugin>
             <plugin>

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/PetResourceTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/PetResourceTest.java
@@ -56,8 +56,10 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Enumeration;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -191,7 +193,7 @@ public class PetResourceTest extends AbstractAnnotationTest {
      * @return Set<Class>
      */
     private Set<Class<?>> getSetOfClassesFromPackage(final String packageName) {
-        final Set<Class<?>> classSet = new HashSet<>();
+        final Set<Class<?>> classSet = new LinkedHashSet<>();
         try {
             final Class[] classes = getClasses(packageName);
             for (final Class aClass : classes) {
@@ -220,6 +222,7 @@ public class PetResourceTest extends AbstractAnnotationTest {
             final URL resource = resources.nextElement();
             dirs.add(new File(resource.getFile()));
         }
+        dirs.sort(Comparator.comparing(File::getAbsolutePath));
         final ArrayList<Class> classes = new ArrayList<>();
         for (final File directory : dirs) {
             classes.addAll(findClasses(directory, packageName));
@@ -241,6 +244,7 @@ public class PetResourceTest extends AbstractAnnotationTest {
         }
         final File[] files = directory.listFiles();
         if (files != null) {
+            Arrays.sort(files, Comparator.comparing(File::getName));
             for (final File file : files) {
                 if (file.isDirectory()) {
                     assert !file.getName().contains(".");

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/AbstractAnnotationTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/annotations/AbstractAnnotationTest.java
@@ -2,6 +2,7 @@ package io.swagger.v3.jaxrs2.annotations;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.jaxrs2.Reader;
 import io.swagger.v3.jaxrs2.matchers.SerializationMatchers;
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.models.OpenAPI;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,6 +22,12 @@ import static org.testng.Assert.fail;
 
 public abstract class AbstractAnnotationTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAnnotationTest.class);
+
+    @BeforeMethod(alwaysRun = true)
+    @AfterMethod(alwaysRun = true)
+    public void resetModelConverters() {
+        ModelConverters.reset();
+    }
 
     public String readIntoYaml(final Class<?> cls) {
         Reader reader = new Reader(new OpenAPI());


### PR DESCRIPTION
# Pull Request
It changes the GitHub Actions CI jobs so Maven and Gradle are set up more clearly, cached separately, and run in separate steps. 

When Maven tests fail, CI now uploads the test reports, which should make failures easier to debug.

It also fixes the Gradle plugin so it no longer contains a hard-coded `swagger-jaxrs2` version. Instead, the plugin reads its own project version from a generated properties file and uses that version for its default Swagger dependency. This keeps the plugin dependency in sync during normal builds and release version bumps.

The Gradle wrapper timeout was increased, which gives Gradle more time to download its distribution on slower CI runs.

The JAX-RS test setup was cleaned up so tests run in a normal forked JVM without opening a debug port. 
Some classpath scanning in tests was made deterministic by sorting files and directories before processing them. That should reduce random test differences between machines or CI runs.

In short:
- CI is easier to debug.
- Maven and Gradle builds are separated into clearer steps.
- Snapshot deployment only happens for snapshot builds on Java 11.
- The Gradle plugin version is no longer hard-coded in Java test/plugin code.
- Some tests should be more stable and predictable.


## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [x] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [ ] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [ ] The PR title is descriptive
- [ ] The code builds and passes tests locally
- [ ] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->