### PR TITLE
chore: update jackson to 2.22

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -476,6 +476,11 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
+                <version>${jackson-annotations-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
                 <version>${jackson-version}</version>
             </dependency>
             <dependency>
@@ -591,8 +596,9 @@
         <servlet-api-version>2.5</servlet-api-version>
         <jersey-version>1.19.4</jersey-version>
         <jersey2-version>2.48</jersey2-version>
-        <jackson-version>2.19.0</jackson-version>
-        <jackson-databind-version>2.19.0</jackson-databind-version>
+        <jackson-version>2.22.0</jackson-version>
+        <jackson-annotations-version>2.22</jackson-annotations-version>
+        <jackson-databind-version>2.22.1</jackson-databind-version>
         <snakeyaml-version>2.6</snakeyaml-version>
         <logback-version>1.5.34</logback-version>
         <reflections-version>0.10.2</reflections-version>


### PR DESCRIPTION
This PR now mirrors the split needed for Jackson 2.20+ versioning:

  - `jackson-annotations`: `2.22`
  - `jackson-core`: `2.22.0`
  - `jackson-dataformat-yaml`: `2.22.0`
  - `jackson-module-jaxb-annotations`: `2.22.0`
  - `jackson-databind`: `2.22.1`

 `jackson-annotations` now has its own property because Jackson intentionally uses a patchless annotations version, while the other Jackson components stay on the patch version. `jackson-core` is also explicitly managed so Maven cannot select an older version through another path.

## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [x] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [ ] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [ ] The PR title is descriptive
- [ ] The code builds and passes tests locally
- [ ] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->