### PR TITLE
fix: correct sibling logic when reading type from schema annotation

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -808,7 +808,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 });
 
                 boolean areSiblingsAllowed = AnnotationsUtils.areSiblingsAllowed(resolvedSchemaResolution, openapi31);
-                aType = AnnotationsUtils.addTypeWhenSiblingsAllowed(aType, ctxSchema, areSiblingsAllowed);
+                aType = AnnotationsUtils.addTypeWhenSiblingsAllowed(aType, ctxSchema, openapi31, areSiblingsAllowed);
                 property = context.resolve(aType);
                 property = clone(property);
                 Schema ctxProperty = null;

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -3125,14 +3125,32 @@ public abstract class AnnotationsUtils {
         return Schema.SchemaResolution.ALL_OF.equals(resolvedSchemaResolution) || Schema.SchemaResolution.ALL_OF_REF.equals(resolvedSchemaResolution) || openapi31;
     }
 
-    public static AnnotatedType addTypeWhenSiblingsAllowed(AnnotatedType aType, io.swagger.v3.oas.annotations.media.Schema ctxSchema, boolean areSiblingsAllowed) {
+    public static AnnotatedType addTypeWhenSiblingsAllowed(AnnotatedType aType,
+                                                           io.swagger.v3.oas.annotations.media.Schema ctxSchema,
+                                                           boolean openapi31,
+                                                           boolean areSiblingsAllowed) {
         if (areSiblingsAllowed && ctxSchema != null) {
             if (!Void.class.equals(ctxSchema.implementation())) {
                 aType.setType(ctxSchema.implementation());
-            } else if (StringUtils.isNotBlank(ctxSchema.type())) {
-                aType.setType(ctxSchema.type().getClass());
+            } else if (openapi31) {
+                if (isOas31SingleTypeIncludingNull(ctxSchema) && Arrays.asList(ctxSchema.types()).contains(STRING_TYPE)) {
+                    aType.setType(String.class);
+                }
+            } else if(StringUtils.isNotBlank(ctxSchema.type()) && STRING_TYPE.equals(ctxSchema.type())) {
+                aType.setType(String.class);
             }
         }
         return aType;
+    }
+
+    /**
+     * Returns whether the schema annotation defines a single type in {@code types}.
+     * Two types where one of them is {@code null} is counted as one type to support defining nullability
+     * @param schema the schema annotation
+     * @return whether the annotation defines a single type
+     */
+    public static boolean isOas31SingleTypeIncludingNull(io.swagger.v3.oas.annotations.media.Schema schema) {
+        String[] types = schema.types();
+        return types.length == 1 || types.length == 2 && Arrays.asList(types).contains(NULL_TYPE);
     }
 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/AnnotationsUtils.java
@@ -61,6 +61,8 @@ import java.util.Set;
 public abstract class AnnotationsUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationsUtils.class);
+    private static final String NULL_TYPE = "null";
+    private static final String STRING_TYPE = "string";
     public static final String COMPONENTS_REF = Components.COMPONENTS_SCHEMAS_REF;
 
     public static boolean hasSchemaAnnotation(io.swagger.v3.oas.annotations.media.Schema schema) {
@@ -1003,7 +1005,7 @@ public abstract class AnnotationsUtils {
                 // Only parse "null" as null value when nullable=true
                 if (node.isNull() && schema.nullable()) {
                     parsedExamples.add(null);
-                } else if (schemaObject == null && "string".equals(schema.type())) {
+                } else if (schemaObject == null && STRING_TYPE.equals(schema.type())) {
                     parsedExamples.add(trimmed);
                 } else if (shouldUseNodeAsExample(node, schemaObject)) {
                     parsedExamples.add(node);
@@ -1081,7 +1083,7 @@ public abstract class AnnotationsUtils {
         }
         if (StringUtils.isBlank(existingSchemaObject.get$ref()) && StringUtils.isBlank(existingSchemaObject.getType())) {
             // default to string
-            existingSchemaObject.setType("string");
+            existingSchemaObject.setType(STRING_TYPE);
         }
         return existingSchemaObject;
     }
@@ -1711,7 +1713,7 @@ public abstract class AnnotationsUtils {
                 }
             case "boolean":
                 return Boolean.class;
-            case "string":
+            case STRING_TYPE:
                 return String.class;
             default:
                 if (nullIfNotFound) {
@@ -1949,25 +1951,27 @@ public abstract class AnnotationsUtils {
         } else {
             Optional<Schema> schemaFromAnnotation = AnnotationsUtils.getSchemaFromAnnotation(schemaAnnotation, components, jsonViewAnnotation, openapi31, null, context);
             if (schemaFromAnnotation.isPresent()) {
-                if (StringUtils.isBlank(schemaFromAnnotation.get().get$ref()) && StringUtils.isBlank(schemaFromAnnotation.get().getType()) && !(schemaFromAnnotation.get() instanceof ComposedSchema)) {
+                Schema schema = schemaFromAnnotation.get();
+                if (StringUtils.isBlank(schema.get$ref()) && StringUtils.isBlank(schema.getType()) && !(schema instanceof ComposedSchema)) {
                     // default to string
-                    schemaFromAnnotation.get().setType("string");
+                    schema.setType(STRING_TYPE);
                 }
-                return Optional.of(schemaFromAnnotation.get());
+                return Optional.of(schema);
             } else {
                 Optional<Schema> arraySchemaFromAnnotation = AnnotationsUtils.getArraySchema(arrayAnnotation, components, jsonViewAnnotation, openapi31, null, false, context);
                 if (arraySchemaFromAnnotation.isPresent()) {
-                    if (arraySchemaFromAnnotation.get().getItems() != null && StringUtils.isBlank(arraySchemaFromAnnotation.get().getItems().get$ref()) && StringUtils.isBlank(arraySchemaFromAnnotation.get().getItems().getType())) {
+                    Schema schema = arraySchemaFromAnnotation.get();
+                    Schema schemaItems = schema.getItems();
+                    if (schemaItems != null && StringUtils.isBlank(schemaItems.get$ref()) && StringUtils.isBlank(schemaItems.getType())) {
                         // default to string
-                        arraySchemaFromAnnotation.get().getItems().setType("string");
+                        schemaItems.setType(STRING_TYPE);
                     }
-                    return Optional.of(arraySchemaFromAnnotation.get());
+                    return Optional.of(schema);
                 }
             }
         }
         return Optional.empty();
     }
-
 
     public static void applyTypes(String[] classTypes, String[] methodTypes, Content content, MediaType mediaType) {
         if (methodTypes != null && methodTypes.length > 0) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5061Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5061Test.java
@@ -142,16 +142,16 @@ public class Issue5061Test {
         @io.swagger.v3.oas.annotations.media.Schema(example = "5 lacs per annum")
         String stringFieldType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "string", example = "5 lacs per annum")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"string"}, example = "5 lacs per annum")
         String stringFieldTypeWithExplicitStringSchemaType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "number", example = "10")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"number"}, example = "10")
         String stringFieldTypeWithExplicitNumberSchemaType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "integer", example = "5")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"integer"}, example = "5")
         String stringFieldTypeWithExplicitIntegerSchemaType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "string", example = "13.37")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"string"}, example = "13.37")
         BigDecimal bigDecimalFieldTypeWithExplicitStringSchemaType;
 
         @io.swagger.v3.oas.annotations.media.Schema(example = "13.37")

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5168Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/Issue5168Test.java
@@ -55,10 +55,10 @@ public class Issue5168Test {
         @io.swagger.v3.oas.annotations.media.Schema(example = "true")
         String stringFieldType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "boolean", example = "true")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"boolean"}, example = "true")
         String stringFieldTypeWithExplicitBooleanSchemaType;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "string", example = "true")
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"string"}, example = "true")
         boolean booleanFieldTypeWithExplicitStringSchemaType;
 
         @io.swagger.v3.oas.annotations.media.Schema(example = "true")

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/SchemaAnnotationSetsTypeTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/SchemaAnnotationSetsTypeTest.java
@@ -1,0 +1,192 @@
+package io.swagger.v3.core.resolving;
+
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.matchers.SerializationMatchers;
+import io.swagger.v3.oas.models.media.Schema;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class SchemaAnnotationSetsTypeTest {
+
+    @Test(description = "Setting type in @Schema is applied for OAS 3.0")
+    public void testTypeInSchemaAnnotationIsAppliedForOAS30() {
+        String expectedYaml = "ClassWithFieldsUsingOAS30Type:\n" +
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    inferred:\n" +
+                              "      type: number\n" +
+                              "    amount:\n" +
+                              "      type: boolean\n" +
+                              "    count:\n" +
+                              "      type: boolean\n" +
+                              "    flag:\n" +
+                              "      type: integer\n" +
+                              "      format: int32\n" +
+                              "    unit:\n" +
+                              "      type: string\n" +
+                              "      enum:\n" +
+                              "      - DAY\n" +
+                              "      - WEEK\n" +
+                              "      - MONTH";
+
+        Map<String, Schema> stringSchemaMap = ModelConverters.getInstance().readAll(ClassWithFieldsUsingOAS30Type.class);
+        SerializationMatchers.assertEqualsToYaml(stringSchemaMap, expectedYaml);
+    }
+
+    @Test(description = "Setting types in @Schema is ignored for OAS 3.0")
+    public void testTypesInSchemaAnnotationIsIgnoredForOAS30() {
+        String expectedYaml = "ClassWithFieldsUsingOAS31Types:\n" +
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    inferred:\n" +
+                              "      type: number\n" +
+                              "    amount:\n" +
+                              "      type: number\n" +
+                              "    count:\n" +
+                              "      type: integer\n" +
+                              "      format: int32\n" +
+                              "    flag:\n" +
+                              "      type: boolean\n" +
+                              "    unit:\n" +
+                              "      type: string\n" +
+                              "      enum:\n" +
+                              "      - DAY\n" +
+                              "      - WEEK\n" +
+                              "      - MONTH";
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance().readAll(ClassWithFieldsUsingOAS31Types.class);
+        SerializationMatchers.assertEqualsToYaml(stringSchemaMap, expectedYaml);
+    }
+
+    @Test(description = "Setting type in @Schema is ignored for OAS 3.1")
+    public void testTypeInSchemaAnnotationIsIgnoredForOAS31() {
+        String expectedYaml = "ClassWithFieldsUsingOAS30Type:\n" +
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    inferred:\n" +
+                              "      type: number\n" +
+                              "    amount:\n" +
+                              "      type: number\n" +
+                              "    count:\n" +
+                              "      type: integer\n" +
+                              "      format: int32\n" +
+                              "    flag:\n" +
+                              "      type: boolean\n" +
+                              "    unit:\n" +
+                              "      type: string\n" +
+                              "      enum:\n" +
+                              "      - DAY\n" +
+                              "      - WEEK\n" +
+                              "      - MONTH";
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance(true)
+                .readAll(ClassWithFieldsUsingOAS30Type.class);
+        SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
+    }
+
+    @Test(description = "Setting types in @Schema is applied for OAS 3.1")
+    public void testTypesInSchemaAnnotationIsAppliedForOAS31() {
+        String expectedYaml = "ClassWithFieldsUsingOAS31Types:\n" +
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    inferred:\n" +
+                              "      type: number\n" +
+                              "    amount:\n" +
+                              "      type: boolean\n" +
+                              "    count:\n" +
+                              "      type: boolean\n" +
+                              "      format: int32\n" +
+                              "    flag:\n" +
+                              "      type: integer\n" +
+                              "    unit:\n" +
+                              "      type: string\n" +
+                              "      enum:\n" +
+                              "      - DAY\n" +
+                              "      - WEEK\n" +
+                              "      - MONTH";
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance(true)
+                .readAll(ClassWithFieldsUsingOAS31Types.class);
+        SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
+    }
+
+    @Test(description = "Setting several types in @Schema is applied for OAS 3.1")
+    public void testSeveralTypesInSchemaAnnotationIsAppliedForOAS31() {
+        String expectedYaml = "ClassWithFieldsUsingOAS31TypesDefiningSeveralTypes:\n" +
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    inferred:\n" +
+                              "      type: number\n" +
+                              "    amount:\n" +
+                              "      type:\n" +
+                              "      - boolean\n" +
+                              "      - number\n" +
+                              "    count:\n" +
+                              "      type:\n" +
+                              "      - boolean\n" +
+                              "      - number\n" +
+                              "      format: int32\n" +
+                              "    flag:\n" +
+                              "      type:\n" +
+                              "      - integer\n" +
+                              "      - number\n" +
+                              "    unit:\n" +
+                              "      type: string\n" +
+                              "      enum:\n" +
+                              "      - DAY\n" +
+                              "      - WEEK\n" +
+                              "      - MONTH";
+
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance(true)
+                .readAll(ClassWithFieldsUsingOAS31TypesDefiningSeveralTypes.class);
+        SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
+    }
+
+    private static class ClassWithFieldsUsingOAS30Type {
+        @io.swagger.v3.oas.annotations.media.Schema
+        public BigDecimal inferred;
+        @io.swagger.v3.oas.annotations.media.Schema(type = "boolean")
+        public BigDecimal amount;
+        @io.swagger.v3.oas.annotations.media.Schema(type = "boolean")
+        public Integer count;
+        @io.swagger.v3.oas.annotations.media.Schema(type = "integer")
+        public Boolean flag;
+        @io.swagger.v3.oas.annotations.media.Schema
+        public Frequency unit;
+
+        enum Frequency { DAY, WEEK, MONTH }
+    }
+
+    private static class ClassWithFieldsUsingOAS31Types {
+        @io.swagger.v3.oas.annotations.media.Schema
+        public BigDecimal inferred;
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"boolean"})
+        public BigDecimal amount;
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"boolean"})
+        public Integer count;
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"integer"})
+        public Boolean flag;
+        @io.swagger.v3.oas.annotations.media.Schema
+        public Frequency unit;
+
+        enum Frequency { DAY, WEEK, MONTH }
+    }
+
+    private static class ClassWithFieldsUsingOAS31TypesDefiningSeveralTypes {
+        @io.swagger.v3.oas.annotations.media.Schema
+        public BigDecimal inferred;
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"boolean", "number"})
+        public BigDecimal amount;
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"boolean", "number"})
+        public Integer count;
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"integer", "number"})
+        public Boolean flag;
+        @io.swagger.v3.oas.annotations.media.Schema
+        public Frequency unit;
+
+        enum Frequency { DAY, WEEK, MONTH }
+    }
+
+}

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4679Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4679Test.java
@@ -2,28 +2,27 @@ package io.swagger.v3.core.resolving;
 
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.matchers.SerializationMatchers;
-import io.swagger.v3.core.util.Yaml;
-import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.testng.annotations.Test;
 
 import java.util.Map;
 
-public class Ticket4679Test extends SwaggerTestBase{
+public class Ticket4679Test extends SwaggerTestBase {
 
     @Test(description = "Custom schema implementation in property overrides type value")
-    public void testCustomSchemaImplementation() {
+    public void testCustomSchemaImplementationOAS31() {
 
         String expectedYaml = "ModelWithCustomSchemaImplementationInProperty:\n" +
-                "  type: object\n" +
-                "  properties:\n" +
-                "    exampleField:\n" +
-                "      type: integer\n" +
-                "      format: int32\n" +
-                "    secondExampleField:\n" +
-                "      type: string\n";
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    exampleField:\n" +
+                              "      type: integer\n" +
+                              "      format: int32\n" +
+                              "    secondExampleField:\n" +
+                              "      type: string\n";
 
-        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance(true).readAll(ModelWithCustomSchemaImplementationInProperty.class);
+        Map<String, io.swagger.v3.oas.models.media.Schema> stringSchemaMap = ModelConverters.getInstance(true)
+                .readAll(ModelWithCustomSchemaImplementationInProperty.class);
         SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
     }
 
@@ -32,7 +31,7 @@ public class Ticket4679Test extends SwaggerTestBase{
         @Schema(implementation = Integer.class)
         private String exampleField;
 
-        @Schema(type = "string")
+        @Schema(types = {"string"})
         private Integer secondExampleField;
 
         public String getExampleField() {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4800Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/Ticket4800Test.java
@@ -7,27 +7,31 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 
-public class Ticket4800Test extends SwaggerTestBase{
+public class Ticket4800Test extends SwaggerTestBase {
 
     @Test(description = "Custom schema implementation in property and enum as ref type value")
-    public void testCustomSchemaImplementation() {
-
+    public void testCustomSchemaImplementationOAS31() {
         String expectedYaml = "ModelWithCustomSchemaImplementationInProperty:\n" +
-                "  type: object\n" +
-                "  properties:\n" +
-                "    enumExampleFieldWithImplementationProp:\n" +
-                "      $ref: \"#/components/schemas/MyEnum\"\n" +
-                "      default: \"yes\"\n" +
-                "      description: Prop description\n" +
-                "    secondExampleFieldWithTypeProp:\n" +
-                "      type: string\n" +
-                "MyEnum:\n" +
-                "  type: string\n" +
-                "  enum:\n" +
-                "  - \"yes\"\n" +
-                "  - \"no\"";
+                              "  type: object\n" +
+                              "  properties:\n" +
+                              "    enumExampleFieldWithImplementationProp:\n" +
+                              "      $ref: \"#/components/schemas/MyEnum\"\n" +
+                              "      default: \"yes\"\n" +
+                              "      description: Prop description\n" +
+                              "    secondExampleFieldWithTypeProp:\n" +
+                              "      type: string\n" +
+                              "    thirdExampleFieldWithTypeProp:\n" +
+                              "      type:\n" +
+                              "      - string\n" +
+                              "      - \"null\"\n" +
+                              "MyEnum:\n" +
+                              "  type: string\n" +
+                              "  enum:\n" +
+                              "  - \"yes\"\n" +
+                              "  - \"no\"";
 
-        Map<String, Schema> stringSchemaMap = ModelConverters.getInstance(true).readAll(Ticket4800Test.ModelWithCustomSchemaImplementationInProperty.class);
+        Map<String, Schema> stringSchemaMap = ModelConverters.getInstance(true)
+                .readAll(ModelWithCustomSchemaImplementationInProperty.class);
         SerializationMatchers.assertEqualsToYaml31(stringSchemaMap, expectedYaml);
     }
 
@@ -36,8 +40,11 @@ public class Ticket4800Test extends SwaggerTestBase{
         @io.swagger.v3.oas.annotations.media.Schema(implementation = MyEnum.class, description = "Prop description", defaultValue = "yes", enumAsRef = true)
         private MyEnum enumExampleFieldWithImplementationProp;
 
-        @io.swagger.v3.oas.annotations.media.Schema(type = "string", enumAsRef = true)
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"string"}, enumAsRef = true)
         private MyEnum2 secondExampleFieldWithTypeProp;
+
+        @io.swagger.v3.oas.annotations.media.Schema(types = {"string", "null"}, enumAsRef = true)
+        private MyEnum2 thirdExampleFieldWithTypeProp;
 
         public MyEnum getEnumExampleFieldWithImplementationProp() {
             return enumExampleFieldWithImplementationProp;
@@ -53,6 +60,14 @@ public class Ticket4800Test extends SwaggerTestBase{
 
         public void setSecondExampleFieldWithTypeProp(MyEnum2 secondExampleFieldWithTypeProp) {
             this.secondExampleFieldWithTypeProp = secondExampleFieldWithTypeProp;
+        }
+
+        public MyEnum2 getThirdExampleFieldWithTypeProp() {
+            return thirdExampleFieldWithTypeProp;
+        }
+
+        public void setThirdExampleFieldWithTypeProp(MyEnum2 thirdExampleFieldWithTypeProp) {
+            this.thirdExampleFieldWithTypeProp = thirdExampleFieldWithTypeProp;
         }
 
         enum MyEnum {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/Address.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/Address.java
@@ -71,7 +71,7 @@ public class Address {
 
         @Schema(
                 _const = "United States",
-                type = "string"
+                types = {"string"}
 
         )
         public Object getCountry() {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodeNumberPattern.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodeNumberPattern.java
@@ -9,7 +9,7 @@ public class PostalCodeNumberPattern {
 
     @Schema(
             pattern = "[0-9]{5}(-[0-9]{4})?",
-            type = "string"
+            types = {"string"}
     )
     public Object getPostalCode() {
         return postalCode;

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodePattern.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/v31/model/PostalCodePattern.java
@@ -8,7 +8,7 @@ public class PostalCodePattern {
 
     @Schema(
             pattern = "[A-Z][0-9][A-Z] [0-9][A-Z][0-9]",
-            type = "string"
+            types = {"string"}
     )
     public Object getPostalCode() {
         return postalCode;


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

Introduces an intermediate fix for the issue reported in https://github.com/swagger-api/swagger-core/issues/5235. It does not implement fully fleshed type handling (overriding), but rather implements the smallest change possible while still keeping the previous behavior of being able to set `AnnotationType`'s type to `String`.

Since this changes how `@Schema(type = )` is read (the `type` is now not taken into consideration when resolving to OAS 3.1 in certain scenarios) it could be considered a breaking change. The fallback is to use `@Schema(types = )` when resolving to OAS 3.1. See later parts of [comment](https://github.com/swagger-api/swagger-core/issues/5233#issuecomment-4981108504) for a reasoning regarding why the application should not try to coerce the types into each other between OAS 3.0 and OAS 3.1, and that they should instead be unaware about each other.

A more extensive fix would be to clarify that this branching is not tied to sibling logic, but rather type coercion. But in order to implement that one would need to reason alot of what is the sought after behavior, especially for OAS 3.1 where there is several types with `@Schema(types = {"boolean", "string"})`. But all of this is considered out of scope for an immediate fix.

A known "bug" (that exists since before too) is that the underlying type might still leak data. For example with 
```java
@Schema(type = "boolean")
public Integer count;
```
becoming
```json
{
  "count": {
    "type": "boolean",
    "format": "int32"
  }
}
```
. This occurs since the `AnnotatedType` does not release the field `Integer` type when the user specifies `boolean`. And thus the `format` is still derived and present from resolving the schema-primitive `Integer`. But this is as previously stated more so tied to introducing full type overriding functionality.

Fixes: https://github.com/swagger-api/swagger-core/issues/5235

## Type of Change

<!-- Check all that apply: -->

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)