### PR TITLE
chore(build): manage maven plugin versions via properties

### DIFF
--- a/modules/swagger-java17-support/pom.xml
+++ b/modules/swagger-java17-support/pom.xml
@@ -77,7 +77,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>${maven-compiler-plugin-version}</version>
                 <configuration>
                     <release>17</release>
                 </configuration>

--- a/modules/swagger-project-jakarta/pom.xml
+++ b/modules/swagger-project-jakarta/pom.xml
@@ -58,7 +58,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>${maven-compiler-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -234,7 +234,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
+                <version>${maven-javadoc-plugin-version}</version>
                 <configuration>
                     <aggregate>true</aggregate>
                     <source>1.8</source>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>${maven-compiler-plugin-version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
+                <version>${maven-javadoc-plugin-version}</version>
                 <configuration>
                     <aggregate>true</aggregate>
                     <source>1.8</source>
@@ -326,7 +326,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.6</version>
+                    <version>${jacoco-maven-plugin-version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -419,7 +419,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
+                <version>${maven-javadoc-plugin-version}</version>
                 <configuration>
                     <aggregate>true</aggregate>
                     <source>1.8</source>
@@ -655,6 +655,9 @@
         <surefire-version>3.5.6</surefire-version>
         <enforcer-plugin-version>3.2.1</enforcer-plugin-version>
         <failsafe-plugin-version>2.22.2</failsafe-plugin-version>
+        <maven-javadoc-plugin-version>3.12.0</maven-javadoc-plugin-version>
+        <maven-compiler-plugin-version>3.14.1</maven-compiler-plugin-version>
+        <jacoco-maven-plugin-version>0.8.14</jacoco-maven-plugin-version>
 
         <coverage.complexity.minimum>0.90</coverage.complexity.minimum>
         <coverage.line.minimum>0.90</coverage.line.minimum>


### PR DESCRIPTION
## Description

Introduce version properties for the build plugins so they can be bumped from a single place. This keeps the plugin version updates separate from the Java 17 migration (#5031), reducing the diff of the follow-up migration PR.

Changes:
- `maven-compiler-plugin` 3.11.0 -> 3.14.1 (new `maven-compiler-plugin-version` property)
- `jacoco-maven-plugin` 0.8.6 -> 0.8.14 (new `jacoco-maven-plugin-version` property)
- `maven-javadoc-plugin` 3.12.0 referenced via `maven-javadoc-plugin-version` property

Applies to the root POM and the `swagger-project-jakarta` and `swagger-java17-support` modules.

Note: `maven.compiler.release` and the javadoc `<source>` remain at Java 8; the Java 17 switch is intentionally out of scope for this PR.

## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [x] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [ ] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [ ] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->
