### PR TITLE
refactor: add DiscriminatorResolver for handling discriminator properties in schemas

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/DiscriminatorResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/DiscriminatorResolver.java
@@ -1,0 +1,79 @@
+package io.swagger.v3.core.jackson;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.JavaType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.AnnotationsUtils;
+import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
+import io.swagger.v3.oas.models.media.Discriminator;
+import io.swagger.v3.oas.models.media.JsonSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import org.apache.commons.lang3.StringUtils;
+
+import static io.swagger.v3.core.util.RefUtils.constructRef;
+
+class DiscriminatorResolver {
+
+    private DiscriminatorResolver() {
+    }
+
+    private static final int SCHEMA_COMPONENT_PREFIX = "#/components/schemas/".length();
+    private static final String TYPE_STRING = "string";
+
+    public static void resolveDiscriminatorProperty(JavaType type,
+                                                    ModelConverterContext context,
+                                                    Schema model,
+                                                    boolean openapi31) {
+        // add JsonTypeInfo.property if not member of bean
+        JsonTypeInfo typeInfo = type.getRawClass().getDeclaredAnnotation(JsonTypeInfo.class);
+        if (typeInfo != null) {
+            String typeInfoProp = typeInfo.property();
+            if (StringUtils.isNotBlank(typeInfoProp)) {
+                Schema modelToUpdate = model;
+                if (StringUtils.isNotBlank(model.get$ref())) {
+                    modelToUpdate = context.getDefinedModels().get(model.get$ref().substring(SCHEMA_COMPONENT_PREFIX));
+                }
+                if (modelToUpdate.getProperties() == null || !modelToUpdate.getProperties().keySet().contains(typeInfoProp)) {
+                    Schema discriminatorSchema = openapi31 ? new JsonSchema().typesItem(TYPE_STRING).name(typeInfoProp) : new StringSchema().name(typeInfoProp);
+                    modelToUpdate.addProperties(typeInfoProp, discriminatorSchema);
+                    if (modelToUpdate.getRequired() == null || !modelToUpdate.getRequired().contains(typeInfoProp)) {
+                        modelToUpdate.addRequiredItem(typeInfoProp);
+                    }
+                }
+            }
+        }
+    }
+
+    public static Discriminator resolveDiscriminator(JavaType type, ModelConverterContext context) {
+        io.swagger.v3.oas.annotations.media.Schema declaredSchemaAnnotation = AnnotationsUtils.getSchemaDeclaredAnnotation(type.getRawClass());
+
+        String disc = (declaredSchemaAnnotation == null) ? "" : declaredSchemaAnnotation.discriminatorProperty();
+
+        if (disc.isEmpty()) {
+            // longer method would involve AnnotationIntrospector.findTypeResolver(...) but:
+            JsonTypeInfo typeInfo = type.getRawClass().getDeclaredAnnotation(JsonTypeInfo.class);
+            if (typeInfo != null) {
+                disc = typeInfo.property();
+            }
+        }
+        if (!disc.isEmpty()) {
+            Discriminator discriminator = new Discriminator()
+                    .propertyName(disc);
+            if (declaredSchemaAnnotation != null) {
+                DiscriminatorMapping[] mappings = declaredSchemaAnnotation.discriminatorMapping();
+                if (mappings != null && mappings.length > 0) {
+                    for (DiscriminatorMapping mapping : mappings) {
+                        if (!mapping.value().isEmpty() && !mapping.schema().equals(Void.class)) {
+                            discriminator.mapping(mapping.value(), constructRef(context.resolve(new AnnotatedType().type(mapping.schema())).getName()));
+                        }
+                    }
+                }
+            }
+
+            return discriminator;
+        }
+        return null;
+    }
+}

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -40,7 +40,6 @@ import io.swagger.v3.oas.annotations.StringToClassMapItem;
 import io.swagger.v3.oas.annotations.media.DependentRequired;
 import io.swagger.v3.oas.annotations.media.DependentSchema;
 import io.swagger.v3.oas.annotations.media.DependentSchemas;
-import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.PatternProperties;
 import io.swagger.v3.oas.annotations.media.PatternProperty;
 import io.swagger.v3.oas.annotations.media.SchemaProperties;
@@ -2694,24 +2693,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     }
 
     protected void resolveDiscriminatorProperty(JavaType type, ModelConverterContext context, Schema model) {
-        // add JsonTypeInfo.property if not member of bean
-        JsonTypeInfo typeInfo = type.getRawClass().getDeclaredAnnotation(JsonTypeInfo.class);
-        if (typeInfo != null) {
-            String typeInfoProp = typeInfo.property();
-            if (StringUtils.isNotBlank(typeInfoProp)) {
-                Schema modelToUpdate = model;
-                if (StringUtils.isNotBlank(model.get$ref())) {
-                    modelToUpdate = context.getDefinedModels().get(model.get$ref().substring(SCHEMA_COMPONENT_PREFIX));
-                }
-                if (modelToUpdate.getProperties() == null || !modelToUpdate.getProperties().keySet().contains(typeInfoProp)) {
-                    Schema discriminatorSchema = openapi31 ? new JsonSchema().typesItem("string").name(typeInfoProp) : new StringSchema().name(typeInfoProp);
-                    modelToUpdate.addProperties(typeInfoProp, discriminatorSchema);
-                    if (modelToUpdate.getRequired() == null || !modelToUpdate.getRequired().contains(typeInfoProp)) {
-                        modelToUpdate.addRequiredItem(typeInfoProp);
-                    }
-                }
-            }
-        }
+        DiscriminatorResolver.resolveDiscriminatorProperty(type, context, model, openapi31);
     }
 
     /*
@@ -2748,35 +2730,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
     }
 
     protected Discriminator resolveDiscriminator(JavaType type, ModelConverterContext context) {
-
-        io.swagger.v3.oas.annotations.media.Schema declaredSchemaAnnotation = AnnotationsUtils.getSchemaDeclaredAnnotation(type.getRawClass());
-
-        String disc = (declaredSchemaAnnotation == null) ? "" : declaredSchemaAnnotation.discriminatorProperty();
-
-        if (disc.isEmpty()) {
-            // longer method would involve AnnotationIntrospector.findTypeResolver(...) but:
-            JsonTypeInfo typeInfo = type.getRawClass().getDeclaredAnnotation(JsonTypeInfo.class);
-            if (typeInfo != null) {
-                disc = typeInfo.property();
-            }
-        }
-        if (!disc.isEmpty()) {
-            Discriminator discriminator = new Discriminator()
-                    .propertyName(disc);
-            if (declaredSchemaAnnotation != null) {
-                DiscriminatorMapping[] mappings = declaredSchemaAnnotation.discriminatorMapping();
-                if (mappings != null && mappings.length > 0) {
-                    for (DiscriminatorMapping mapping : mappings) {
-                        if (!mapping.value().isEmpty() && !mapping.schema().equals(Void.class)) {
-                            discriminator.mapping(mapping.value(), constructRef(context.resolve(new AnnotatedType().type(mapping.schema())).getName()));
-                        }
-                    }
-                }
-            }
-
-            return discriminator;
-        }
-        return null;
+        return DiscriminatorResolver.resolveDiscriminator(type, context);
     }
 
     protected XML resolveXml(Annotated a, Annotation[] annotations, io.swagger.v3.oas.annotations.media.Schema schema) {


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->

Moves Discriminator resolving logic into a separate `Utils` class.

A commonly requested feature is to [extend the discriminator introspection](https://github.com/swagger-api/swagger-core/issues/3411). There [exists a PR](https://github.com/swagger-api/swagger-core/issues/3411) for this, but I would find it easier to reason about any change if the logic was isolated from the larger monster that is `ModelResolver`. This so that `ModelResolver` is not cluttered with more subdomain (managing discriminators) logic, and that the `ModelResolver` is instead only responsible for exposing an area of these subdomains if there is a reason to provide a helpful extension point.

I.e., `Utils` provide stateless logic for subdomains of handling specifications, and the `ModelResolver` mainly combine these smaller parts into something larger.

## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)