### PR TITLE
refactor: replace `writer(new DefaultPrettyPrinter())` with `writerWithDefaultPrettyPrinter()`

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Json.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Json.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.core.util;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import org.slf4j.Logger;
@@ -19,7 +18,7 @@ public class Json {
     }
 
     public static ObjectWriter pretty() {
-        return mapper().writer(new DefaultPrettyPrinter());
+        return mapper().writerWithDefaultPrettyPrinter();
     }
 
     public static String pretty(Object o) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Json31.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Json31.java
@@ -1,7 +1,6 @@
 package io.swagger.v3.core.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -32,7 +31,7 @@ public class Json31 {
     }
 
     public static ObjectWriter pretty() {
-        return mapper().writer(new DefaultPrettyPrinter());
+        return mapper().writerWithDefaultPrettyPrinter();
     }
 
     public static String pretty(Object o) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Yaml.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Yaml.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.core.util;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import org.slf4j.Logger;
@@ -19,7 +18,7 @@ public class Yaml {
     }
 
     public static ObjectWriter pretty() {
-        return mapper().writer(new DefaultPrettyPrinter());
+        return mapper().writerWithDefaultPrettyPrinter();
     }
 
     public static String pretty(Object o) {

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Yaml31.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/Yaml31.java
@@ -1,7 +1,6 @@
 package io.swagger.v3.core.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import io.swagger.v3.oas.models.media.Schema;
@@ -24,7 +23,7 @@ public class Yaml31 {
     }
 
     public static ObjectWriter pretty() {
-        return mapper().writer(new DefaultPrettyPrinter());
+        return mapper().writerWithDefaultPrettyPrinter();
     }
 
     public static String pretty(Object o) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/SwaggerTestBase.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/resolving/SwaggerTestBase.java
@@ -1,7 +1,6 @@
 package io.swagger.v3.core.resolving;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -29,7 +28,7 @@ public abstract class SwaggerTestBase {
 
     protected void prettyPrint(Object o) {
         try {
-            LOGGER.debug(mapper().writer(new DefaultPrettyPrinter()).writeValueAsString(o));
+            LOGGER.debug(mapper().writerWithDefaultPrettyPrinter().writeValueAsString(o));
         } catch (Exception e) {
             LOGGER.error("Failed to pretty print object", e);
         }

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/JsonSerializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/JsonSerializationTest.java
@@ -1,6 +1,8 @@
 package io.swagger.v3.core.serialization;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.dataformat.yaml.JacksonYAMLParseException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.swagger.v3.core.matchers.SerializationMatchers;
@@ -23,6 +25,7 @@ import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class JsonSerializationTest {
 
@@ -153,5 +156,34 @@ public class JsonSerializationTest {
         OpenAPI deser = ObjectMapperFactory.createYaml(yamlFactory).readValue(yaml, OpenAPI.class);
 
         // then - Throw JacksonYAMLParseException
+    }
+
+    @Test
+    public void testCustomPrettyPrinterIsHonored() {
+        //given
+        DefaultPrettyPrinter originalPrinter = (DefaultPrettyPrinter) Json.mapper().getSerializationConfig().getDefaultPrettyPrinter();
+        
+        try {
+            DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
+            printer.indentObjectsWith(new DefaultIndenter("    ", "\n"));
+            Json.mapper().setDefaultPrettyPrinter(printer);
+
+            //when
+            OpenAPI openAPI = new OpenAPI()
+                    .info(new Info().title("Pet Store"));
+
+            String json = Json.pretty(openAPI);
+
+            //then
+            assertTrue(json.contains("{\n    \"openapi\""),
+                    "Custom four-space indentation should be honored");
+            assertTrue(json.contains("    \"info\" : {"), 
+                    "Nested objects should use four-space indentation");
+            assertTrue(json.contains("        \"title\" : \"Pet Store\""), 
+                    "Doubly-nested properties should use eight-space indentation");
+        } finally {
+            // Restore original pretty printer to avoid affecting other tests
+            Json.mapper().setDefaultPrettyPrinter(originalPrinter);
+        }
     }
 }

--- a/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/SwaggerTestBase.java
+++ b/modules/swagger-java17-support/src/test/java/io/swagger/v3/java17/resolving/SwaggerTestBase.java
@@ -1,7 +1,6 @@
 package io.swagger.v3.java17.resolving;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -29,7 +28,7 @@ public abstract class SwaggerTestBase {
 
     protected void prettyPrint(Object o) {
         try {
-            LOGGER.debug(mapper().writer(new DefaultPrettyPrinter()).writeValueAsString(o));
+            LOGGER.debug(mapper().writerWithDefaultPrettyPrinter().writeValueAsString(o));
         } catch (Exception e) {
             LOGGER.error("Failed to pretty print object", e);
         }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/OpenApiServlet.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/OpenApiServlet.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.jaxrs2.integration;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import io.swagger.v3.core.filter.OpenAPISpecFilter;
 import io.swagger.v3.core.filter.SpecFilter;
 import io.swagger.v3.jaxrs2.util.ServletUtils;
@@ -86,12 +85,12 @@ public class OpenApiServlet extends HttpServlet {
         if (type.equalsIgnoreCase("yaml")) {
             resp.setContentType(APPLICATION_YAML);
             try (PrintWriter pw = resp.getWriter()) {
-                pw.write(pretty ? ctx.getOutputYamlMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(oas) : ctx.getOutputYamlMapper().writeValueAsString(oas));
+                pw.write(pretty ? ctx.getOutputYamlMapper().writerWithDefaultPrettyPrinter().writeValueAsString(oas) : ctx.getOutputYamlMapper().writeValueAsString(oas));
             }
         } else {
             resp.setContentType(APPLICATION_JSON);
             try (PrintWriter pw = resp.getWriter()) {
-                pw.write(pretty ? ctx.getOutputJsonMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(oas) : ctx.getOutputJsonMapper().writeValueAsString(oas));
+                pw.write(pretty ? ctx.getOutputJsonMapper().writerWithDefaultPrettyPrinter().writeValueAsString(oas) : ctx.getOutputJsonMapper().writeValueAsString(oas));
             }
         }
 

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/SwaggerLoader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/SwaggerLoader.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.jaxrs2.integration;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import io.swagger.v3.core.filter.OpenAPISpecFilter;
 import io.swagger.v3.core.filter.SpecFilter;
 import io.swagger.v3.core.util.Configuration;
@@ -401,14 +400,14 @@ public class SwaggerLoader {
             String openapiYaml = null;
             if ("JSON".equals(outputFormat) || "JSONANDYAML".equals(outputFormat)) {
                 if (prettyPrint != null && prettyPrint) {
-                    openapiJson = context.getOutputJsonMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(openAPI);
+                    openapiJson = context.getOutputJsonMapper().writerWithDefaultPrettyPrinter().writeValueAsString(openAPI);
                 } else {
                     openapiJson = context.getOutputJsonMapper().writeValueAsString(openAPI);
                 }
             }
             if ("YAML".equals(outputFormat) || "JSONANDYAML".equals(outputFormat)) {
                 if (prettyPrint != null && prettyPrint) {
-                    openapiYaml = context.getOutputYamlMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(openAPI);
+                    openapiYaml = context.getOutputYamlMapper().writerWithDefaultPrettyPrinter().writeValueAsString(openAPI);
                 } else {
                     openapiYaml = context.getOutputYamlMapper().writeValueAsString(openAPI);
                 }

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/resources/BaseOpenApiResource.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/integration/resources/BaseOpenApiResource.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.jaxrs2.integration.resources;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import io.swagger.v3.core.filter.OpenAPISpecFilter;
 import io.swagger.v3.core.filter.SpecFilter;
 import io.swagger.v3.jaxrs2.integration.JaxrsOpenApiContextBuilder;
@@ -71,14 +70,14 @@ public abstract class BaseOpenApiResource {
         if (StringUtils.isNotBlank(type) && type.trim().equalsIgnoreCase("yaml")) {
             return Response.status(Response.Status.OK)
                     .entity(pretty ?
-                            ctx.getOutputYamlMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(oas) :
+                            ctx.getOutputYamlMapper().writerWithDefaultPrettyPrinter().writeValueAsString(oas) :
                             ctx.getOutputYamlMapper().writeValueAsString(oas))
                     .type("application/yaml")
                     .build();
         } else {
             return Response.status(Response.Status.OK)
                     .entity(pretty ?
-                            ctx.getOutputJsonMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(oas) :
+                            ctx.getOutputJsonMapper().writerWithDefaultPrettyPrinter().writeValueAsString(oas) :
                             ctx.getOutputJsonMapper().writeValueAsString(oas))
                     .type(MediaType.APPLICATION_JSON_TYPE)
                     .build();

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/BootstrapServlet.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/BootstrapServlet.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.jaxrs2;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import io.swagger.v3.jaxrs2.integration.JaxrsOpenApiContextBuilder;
 import io.swagger.v3.oas.integration.OpenApiConfigurationException;
 import io.swagger.v3.oas.integration.OpenApiContextLocator;
@@ -68,7 +67,7 @@ public class BootstrapServlet extends HttpServlet {
 
         resp.setContentType("application/yaml");
         try (PrintWriter pw = resp.getWriter()) {
-            pw.write(ctx.getOutputYamlMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(oas));
+            pw.write(ctx.getOutputYamlMapper().writerWithDefaultPrettyPrinter().writeValueAsString(oas));
         }
     }
 }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/SortedOutputTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/integration/SortedOutputTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -71,7 +70,7 @@ public class SortedOutputTest {
                 .init();
 
         OpenAPI openApi = ctx.read();
-        String sorted = ctx.getOutputYamlMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(openApi);
+        String sorted = ctx.getOutputYamlMapper().writerWithDefaultPrettyPrinter().writeValueAsString(openApi);
 
         openApiConfiguration = new SwaggerConfiguration()
                 .resourcePackages(Collections.singleton("com.my.sorted.resources"));
@@ -80,7 +79,7 @@ public class SortedOutputTest {
                 .openApiConfiguration(openApiConfiguration)
                 .init();
 
-        String notSorted = ctx.getOutputYamlMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(openApi);
+        String notSorted = ctx.getOutputYamlMapper().writerWithDefaultPrettyPrinter().writeValueAsString(openApi);
 
         assertEquals(sorted, expectedSorted);
         assertEquals(notSorted, expectedNotSorted);
@@ -176,7 +175,7 @@ public class SortedOutputTest {
                 .init();
 
         OpenAPI openApi = ctx.read();
-        String sorted = ctx.getOutputYamlMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(openApi);
+        String sorted = ctx.getOutputYamlMapper().writerWithDefaultPrettyPrinter().writeValueAsString(openApi);
 
         openApiConfiguration = new SwaggerConfiguration()
                 .resourcePackages(Collections.singleton("com.my.sorted.resources"));
@@ -185,7 +184,7 @@ public class SortedOutputTest {
                 .openApiConfiguration(openApiConfiguration)
                 .init();
 
-        String notSorted = ctx.getOutputYamlMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(openApi);
+        String notSorted = ctx.getOutputYamlMapper().writerWithDefaultPrettyPrinter().writeValueAsString(openApi);
 
         assertEquals(sorted, expectedSorted);
         assertEquals(notSorted, expectedNotSorted);

--- a/modules/swagger-maven-plugin/src/main/java/io/swagger/v3/plugin/maven/SwaggerMojo.java
+++ b/modules/swagger-maven-plugin/src/main/java/io/swagger/v3/plugin/maven/SwaggerMojo.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.plugin.maven;
 
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import io.swagger.v3.core.filter.OpenAPISpecFilter;
 import io.swagger.v3.core.filter.SpecFilter;
 import io.swagger.v3.core.util.Configuration;
@@ -101,14 +100,14 @@ public class SwaggerMojo extends AbstractMojo {
             String openapiYaml = null;
             if (Format.JSON.equals(outputFormat) || Format.JSONANDYAML.equals(outputFormat)) {
                 if (config.isPrettyPrint() != null && config.isPrettyPrint()) {
-                    openapiJson = context.getOutputJsonMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(openAPI);
+                    openapiJson = context.getOutputJsonMapper().writerWithDefaultPrettyPrinter().writeValueAsString(openAPI);
                 } else {
                     openapiJson = context.getOutputJsonMapper().writeValueAsString(openAPI);
                 }
             }
             if (Format.YAML.equals(outputFormat) || Format.JSONANDYAML.equals(outputFormat)) {
                 if (config.isPrettyPrint() != null && config.isPrettyPrint()) {
-                    openapiYaml = context.getOutputYamlMapper().writer(new DefaultPrettyPrinter()).writeValueAsString(openAPI);
+                    openapiYaml = context.getOutputYamlMapper().writerWithDefaultPrettyPrinter().writeValueAsString(openAPI);
                 } else {
                     openapiYaml = context.getOutputYamlMapper().writeValueAsString(openAPI);
                 }

--- a/modules/swagger-models/src/test/java/io/swagger/test/SimpleBuilderTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/test/SimpleBuilderTest.java
@@ -1,7 +1,6 @@
 package io.swagger.test;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -134,6 +133,6 @@ public class SimpleBuilderTest {
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-        return mapper.writer(new DefaultPrettyPrinter()).writeValueAsString(value);
+        return mapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
     }
 }


### PR DESCRIPTION
## Description

Replace explicit `DefaultPrettyPrinter` instantiation with the equivalent `writerWithDefaultPrettyPrinter()` convenience method across the codebase. This is a pure refactoring — no behavioral change.

This also reduces diff noise from the Jackson 3 migration PR ([#5031](https://github.com/swagger-api/swagger-core/pull/5031)) by pulling out the `writerWithDefaultPrettyPrinter` refactoring into its own change.

## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [ ] I have added/updated tests as needed
- [ ] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [ ] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->