### PR TITLE
 feat: support the OpenAPI 3.2 QUERY method in PathItem and the JAX-RS reader

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/PathItemMixin.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/PathItemMixin.java
@@ -1,0 +1,26 @@
+package io.swagger.v3.core.jackson.mixin;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.v3.oas.models.Operation;
+
+import java.util.Map;
+
+/**
+ * Mixin applied to {@link io.swagger.v3.oas.models.PathItem} for OpenAPI 3.0 and 3.1 mappers.
+ *
+ * <p>The {@code query} method is a fixed field of the Path Item Object only as of OpenAPI 3.2,
+ * so it is ignored here to keep 3.0 and 3.1 documents conformant.
+ */
+public abstract class PathItemMixin {
+
+    @JsonAnyGetter
+    public abstract Map<String, Object> getExtensions();
+
+    @JsonAnySetter
+    public abstract void addExtension(String name, Object value);
+
+    @JsonIgnore
+    public abstract Operation getQuery();
+}

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ObjectMapperFactory.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/util/ObjectMapperFactory.java
@@ -31,6 +31,7 @@ import io.swagger.v3.core.jackson.mixin.MediaTypeMixin;
 import io.swagger.v3.core.jackson.mixin.OpenAPI31Mixin;
 import io.swagger.v3.core.jackson.mixin.OpenAPIMixin;
 import io.swagger.v3.core.jackson.mixin.OperationMixin;
+import io.swagger.v3.core.jackson.mixin.PathItemMixin;
 import io.swagger.v3.core.jackson.mixin.Schema31Mixin;
 import io.swagger.v3.core.jackson.mixin.SchemaConverterMixin;
 import io.swagger.v3.core.jackson.mixin.SchemaMixin;
@@ -186,7 +187,7 @@ public class ObjectMapperFactory {
         sourceMixins.put(OAuthFlow.class, ExtensionsMixin.class);
         sourceMixins.put(OAuthFlows.class, ExtensionsMixin.class);
         sourceMixins.put(Operation.class, OperationMixin.class);
-        sourceMixins.put(PathItem.class, ExtensionsMixin.class);
+        sourceMixins.put(PathItem.class, PathItemMixin.class);
         sourceMixins.put(Paths.class, ExtensionsMixin.class);
         sourceMixins.put(Scopes.class, ExtensionsMixin.class);
         sourceMixins.put(Server.class, ExtensionsMixin.class);
@@ -261,7 +262,7 @@ public class ObjectMapperFactory {
         sourceMixins.put(OpenAPI.class, OpenAPIMixin.class);
         sourceMixins.put(Operation.class, OperationMixin.class);
         sourceMixins.put(Parameter.class, ExtensionsMixin.class);
-        sourceMixins.put(PathItem.class, ExtensionsMixin.class);
+        sourceMixins.put(PathItem.class, PathItemMixin.class);
         sourceMixins.put(Paths.class, ExtensionsMixin.class);
         sourceMixins.put(RequestBody.class, ExtensionsMixin.class);
         sourceMixins.put(Scopes.class, ExtensionsMixin.class);

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/JsonSerializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/JsonSerializationTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 public class JsonSerializationTest {
 
@@ -40,6 +42,32 @@ public class JsonSerializationTest {
 
         final PathItem path = rebuilt.getPaths().get("/health");
         assertEquals(path, expectedPath);
+    }
+
+    @Test
+    public void testSerializeQueryHttpMethod() throws Exception {
+
+        Operation queryOperation = new Operation()
+                .operationId("searchPets")
+                .responses(new ApiResponses()
+                        .addApiResponse("200", new ApiResponse().description("ok")));
+
+        OpenAPI openAPI = new OpenAPI()
+                .path("/pets", new PathItem().query(queryOperation));
+
+        String openAPIJson = Json.mapper().writeValueAsString(openAPI);
+
+        // the OpenAPI 3.2 "query" method must be serialized ...
+        assertTrue(openAPIJson.contains("\"query\""));
+        // ... and unset methods must not leak (NON_NULL inclusion)
+        assertFalse(openAPIJson.contains("\"get\""));
+
+        OpenAPI rebuilt = Json.mapper().readValue(openAPIJson, OpenAPI.class);
+        PathItem rebuiltPath = rebuilt.getPaths().get("/pets");
+
+        assertNotNull(rebuiltPath.getQuery());
+        assertEquals(rebuiltPath.getQuery().getOperationId(), "searchPets");
+        assertEquals(rebuiltPath, openAPI.getPaths().get("/pets"));
     }
 
     @Test

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/JsonSerializationTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/serialization/JsonSerializationTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.dataformat.yaml.JacksonYAMLParseException;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.swagger.v3.core.matchers.SerializationMatchers;
 import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.core.util.ObjectMapperFactory;
 import io.swagger.v3.core.util.ResourceUtils;
 import io.swagger.v3.core.util.Yaml;
@@ -24,6 +25,7 @@ import java.util.Map;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class JsonSerializationTest {
@@ -45,29 +47,43 @@ public class JsonSerializationTest {
     }
 
     @Test
-    public void testSerializeQueryHttpMethod() throws Exception {
+    public void testQueryHttpMethodIsNotSerializedBeforeOpenAPI32() throws Exception {
 
         Operation queryOperation = new Operation()
                 .operationId("searchPets")
                 .responses(new ApiResponses()
                         .addApiResponse("200", new ApiResponse().description("ok")));
 
-        OpenAPI openAPI = new OpenAPI()
-                .path("/pets", new PathItem().query(queryOperation));
+        PathItem pathItem = new PathItem()
+                .get(new Operation().operationId("listPets"))
+                .query(queryOperation);
+        OpenAPI openAPI = new OpenAPI().path("/pets", pathItem);
 
-        String openAPIJson = Json.mapper().writeValueAsString(openAPI);
+        // the model holds the operation ...
+        assertNotNull(openAPI.getPaths().get("/pets").getQuery());
 
-        // the OpenAPI 3.2 "query" method must be serialized ...
-        assertTrue(openAPIJson.contains("\"query\""));
-        // ... and unset methods must not leak (NON_NULL inclusion)
-        assertFalse(openAPIJson.contains("\"get\""));
+        // ... but "query" is a Path Item fixed field only as of OpenAPI 3.2, so neither the
+        // 3.0 nor the 3.1 mapper may emit it, while the other methods serialize as usual
+        for (String json : new String[]{
+                Json.mapper().writeValueAsString(openAPI),
+                Json31.mapper().writeValueAsString(openAPI)}) {
+            assertFalse(json.contains("\"query\""));
+            assertTrue(json.contains("\"listPets\""));
+            assertFalse(json.contains("\"searchPets\""));
+        }
+    }
 
-        OpenAPI rebuilt = Json.mapper().readValue(openAPIJson, OpenAPI.class);
-        PathItem rebuiltPath = rebuilt.getPaths().get("/pets");
+    @Test
+    public void testQueryHttpMethodIsNotDeserializedBeforeOpenAPI32() throws Exception {
 
-        assertNotNull(rebuiltPath.getQuery());
-        assertEquals(rebuiltPath.getQuery().getOperationId(), "searchPets");
-        assertEquals(rebuiltPath, openAPI.getPaths().get("/pets"));
+        String json = "{\"openapi\":\"3.0.1\",\"paths\":{\"/pets\":{"
+                + "\"get\":{\"operationId\":\"listPets\"},"
+                + "\"query\":{\"operationId\":\"searchPets\"}}}}";
+
+        PathItem pathItem = Json.mapper().readValue(json, OpenAPI.class).getPaths().get("/pets");
+
+        assertNotNull(pathItem.getGet());
+        assertNull(pathItem.getQuery());
     }
 
     @Test

--- a/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
+++ b/modules/swagger-jaxrs2/src/main/java/io/swagger/v3/jaxrs2/Reader.java
@@ -99,6 +99,7 @@ public class Reader implements OpenApiReader {
     private static final String TRACE_METHOD = "trace";
     private static final String HEAD_METHOD = "head";
     private static final String OPTIONS_METHOD = "options";
+    private static final String QUERY_METHOD = "query";
 
     public Reader() {
         this(new OpenAPI(), new Paths(), new LinkedHashSet<>(), new Components());
@@ -1397,6 +1398,9 @@ public class Reader implements OpenApiReader {
             case OPTIONS_METHOD:
                 pathItemObject.options(operation);
                 break;
+            case QUERY_METHOD:
+                pathItemObject.query(operation);
+                break;
             default:
                 // Do nothing here
                 break;
@@ -1564,6 +1568,9 @@ public class Reader implements OpenApiReader {
         }
         if (path.getPatch() != null && StringUtils.isNotBlank(path.getPatch().getOperationId())) {
             ids.add(path.getPatch().getOperationId());
+        }
+        if (path.getQuery() != null && StringUtils.isNotBlank(path.getQuery().getOperationId())) {
+            ids.add(path.getQuery().getOperationId());
         }
         return ids;
     }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/QueryMethodTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/QueryMethodTest.java
@@ -1,0 +1,55 @@
+package io.swagger.v3.jaxrs2;
+
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Json31;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.core.util.Yaml31;
+import io.swagger.v3.jaxrs2.resources.QueryMethodResource;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Verifies that the reader maps a custom {@code @HttpMethod("QUERY")} annotation
+ * (OpenAPI 3.2 query method) onto {@link PathItem#getQuery()}.
+ */
+public class QueryMethodTest {
+
+    @Test(description = "read a resource declaring the OpenAPI 3.2 QUERY method")
+    public void testQueryHttpMethod() {
+        Reader reader = new Reader(new OpenAPI());
+        OpenAPI openAPI = reader.read(QueryMethodResource.class);
+
+        PathItem pathItem = openAPI.getPaths().get("/pets/search");
+        assertNotNull(pathItem);
+
+        assertNotNull(pathItem.getQuery());
+        assertEquals(pathItem.getQuery().getOperationId(), "searchPets");
+
+        // the operation must land on query only, not leak onto other methods
+        assertNull(pathItem.getGet());
+        assertNull(pathItem.getPost());
+    }
+
+    @Test(description = "a QUERY operation must not reach OpenAPI 3.0 or 3.1 output")
+    public void testQueryHttpMethodIsNotSerializedBeforeOpenAPI32() throws Exception {
+        Reader reader = new Reader(new OpenAPI());
+        OpenAPI openAPI = reader.read(QueryMethodResource.class);
+
+        // "query" is a Path Item fixed field only as of OpenAPI 3.2, so the operation the
+        // reader resolved stays in the model but is gated out of pre-3.2 documents
+        for (String serialized : new String[]{
+                Yaml.mapper().writeValueAsString(openAPI),
+                Yaml31.mapper().writeValueAsString(openAPI),
+                Json.mapper().writeValueAsString(openAPI),
+                Json31.mapper().writeValueAsString(openAPI)}) {
+            assertFalse(serialized.contains("query"));
+            assertFalse(serialized.contains("searchPets"));
+        }
+    }
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/QUERY.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/QUERY.java
@@ -1,0 +1,23 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import javax.ws.rs.HttpMethod;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Stands in for the {@code @QUERY} binding an application declares itself, since JAX-RS /
+ * Jakarta REST does not ship one for the OpenAPI 3.2 {@code QUERY} method.
+ *
+ * <p>It is meta-annotated with {@link HttpMethod} in the same way {@code javax.ws.rs.PATCH} is,
+ * which is all the reader needs: {@code ReaderUtils.getHttpMethodFromCustomAnnotations} resolves
+ * any such annotation to its lower-cased method name, which is then mapped onto
+ * {@link io.swagger.v3.oas.models.PathItem#getQuery()}.
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@HttpMethod("QUERY")
+public @interface QUERY {
+}

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/QueryMethodResource.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/resources/QueryMethodResource.java
@@ -1,0 +1,19 @@
+package io.swagger.v3.jaxrs2.resources;
+
+import io.swagger.v3.oas.annotations.Operation;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+@Path("/pets")
+public class QueryMethodResource {
+
+    @QUERY
+    @Path("/search")
+    @Produces("application/json")
+    @Operation(operationId = "searchPets", summary = "Search pets")
+    public Response searchPets() {
+        return Response.ok().build();
+    }
+}

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
@@ -14,6 +14,7 @@ import java.util.Map;
  *
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/3.0.4/versions/3.0.4.md#path-item-object">PathItem (OpenAPI 3.0 specification)</a>
  * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/3.1.1/versions/3.1.1.md#path-item-object">PathItem (OpenAPI 3.1 specification)</a>
+ * @see <a href="https://github.com/OAI/OpenAPI-Specification/blob/3.2.0/versions/3.2.0.md#path-item-object">PathItem (OpenAPI 3.2 specification)</a>
  */
 
 public class PathItem {
@@ -27,6 +28,7 @@ public class PathItem {
     private Operation head = null;
     private Operation patch = null;
     private Operation trace = null;
+    private Operation query = null;
     private List<Server> servers = null;
     private List<Parameter> parameters = null;
     private String $ref = null;
@@ -222,6 +224,28 @@ public class PathItem {
         return this;
     }
 
+    /**
+     * returns the query property from a PathItem instance.
+     *
+     * <p>The {@code query} HTTP method was introduced in OpenAPI 3.2.
+     *
+     * @return Operation query
+     * @since OpenAPI 3.2
+     **/
+
+    public Operation getQuery() {
+        return query;
+    }
+
+    public void setQuery(Operation query) {
+        this.query = query;
+    }
+
+    public PathItem query(Operation query) {
+        this.query = query;
+        return this;
+    }
+
     public List<Operation> readOperations() {
         List<Operation> allOperations = new ArrayList<>();
         if (this.get != null) {
@@ -247,6 +271,9 @@ public class PathItem {
         }
         if (this.trace != null) {
             allOperations.add(this.trace);
+        }
+        if (this.query != null) {
+            allOperations.add(this.query);
         }
 
         return allOperations;
@@ -278,6 +305,9 @@ public class PathItem {
             case DELETE:
                 this.delete = operation;
                 break;
+            case QUERY:
+                this.query = operation;
+                break;
             default:
         }
     }
@@ -290,7 +320,8 @@ public class PathItem {
         DELETE,
         HEAD,
         OPTIONS,
-        TRACE
+        TRACE,
+        QUERY
     }
 
     public Map<HttpMethod, Operation> readOperationsMap() {
@@ -319,6 +350,9 @@ public class PathItem {
         }
         if (this.trace != null) {
             result.put(HttpMethod.TRACE, this.trace);
+        }
+        if (this.query != null) {
+            result.put(HttpMethod.QUERY, this.query);
         }
 
         return result;
@@ -468,6 +502,9 @@ public class PathItem {
         if (trace != null ? !trace.equals(pathItem.trace) : pathItem.trace != null) {
             return false;
         }
+        if (query != null ? !query.equals(pathItem.query) : pathItem.query != null) {
+            return false;
+        }
         if (servers != null ? !servers.equals(pathItem.servers) : pathItem.servers != null) {
             return false;
         }
@@ -493,6 +530,7 @@ public class PathItem {
         result = 31 * result + (head != null ? head.hashCode() : 0);
         result = 31 * result + (patch != null ? patch.hashCode() : 0);
         result = 31 * result + (trace != null ? trace.hashCode() : 0);
+        result = 31 * result + (query != null ? query.hashCode() : 0);
         result = 31 * result + (servers != null ? servers.hashCode() : 0);
         result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
         result = 31 * result + ($ref != null ? $ref.hashCode() : 0);
@@ -514,6 +552,7 @@ public class PathItem {
         sb.append("    head: ").append(toIndentedString(head)).append("\n");
         sb.append("    patch: ").append(toIndentedString(patch)).append("\n");
         sb.append("    trace: ").append(toIndentedString(trace)).append("\n");
+        sb.append("    query: ").append(toIndentedString(query)).append("\n");
         sb.append("    servers: ").append(toIndentedString(servers)).append("\n");
         sb.append("    parameters: ").append(toIndentedString(parameters)).append("\n");
         sb.append("    $ref: ").append(toIndentedString($ref)).append("\n");

--- a/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
+++ b/modules/swagger-models/src/main/java/io/swagger/v3/oas/models/PathItem.java
@@ -227,7 +227,9 @@ public class PathItem {
     /**
      * returns the query property from a PathItem instance.
      *
-     * <p>The {@code query} HTTP method was introduced in OpenAPI 3.2.
+     * <p>The {@code query} HTTP method was introduced in OpenAPI 3.2. It is therefore not
+     * serialized by OpenAPI 3.0 and 3.1 mappers, which would otherwise emit a Path Item
+     * field that is not valid for those versions.
      *
      * @return Operation query
      * @since OpenAPI 3.2

--- a/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/PathItemTest.java
+++ b/modules/swagger-models/src/test/java/io/swagger/v3/oas/models/PathItemTest.java
@@ -1,0 +1,80 @@
+package io.swagger.v3.oas.models;
+
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for the OpenAPI 3.2 {@code query} HTTP method support on {@link PathItem}.
+ */
+public class PathItemTest {
+
+    @Test
+    public void testQueryBuilderAndAccessors() {
+        Operation query = new Operation();
+        PathItem pathItem = new PathItem().query(query);
+
+        assertSame(pathItem.getQuery(), query);
+
+        Operation other = new Operation();
+        pathItem.setQuery(other);
+        assertSame(pathItem.getQuery(), other);
+    }
+
+    @Test
+    public void testOperationSetterWithQueryMethod() {
+        Operation query = new Operation();
+        PathItem pathItem = new PathItem();
+        pathItem.operation(PathItem.HttpMethod.QUERY, query);
+
+        assertSame(pathItem.getQuery(), query);
+    }
+
+    @Test
+    public void testHttpMethodEnumContainsQuery() {
+        assertEquals(PathItem.HttpMethod.valueOf("QUERY"), PathItem.HttpMethod.QUERY);
+    }
+
+    @Test
+    public void testReadOperationsIncludesQuery() {
+        Operation query = new Operation();
+        PathItem pathItem = new PathItem().query(query);
+
+        List<Operation> operations = pathItem.readOperations();
+        assertTrue(operations.contains(query));
+    }
+
+    @Test
+    public void testReadOperationsMapIncludesQuery() {
+        Operation query = new Operation();
+        PathItem pathItem = new PathItem().query(query);
+
+        Map<PathItem.HttpMethod, Operation> map = pathItem.readOperationsMap();
+        assertSame(map.get(PathItem.HttpMethod.QUERY), query);
+    }
+
+    @Test
+    public void testEqualsAndHashCodeConsiderQuery() {
+        Operation query = new Operation().operationId("search");
+
+        PathItem passedObj = new PathItem().query(query);
+        PathItem createdObj = new PathItem().query(new Operation().operationId("search"));
+        PathItem emptyObj = new PathItem();
+
+        assertEquals(passedObj, createdObj);
+        assertEquals(passedObj.hashCode(), createdObj.hashCode());
+        assertNotEquals(passedObj, emptyObj);
+    }
+
+    @Test
+    public void testToStringContainsQuery() {
+        PathItem pathItem = new PathItem().query(new Operation());
+        assertTrue(pathItem.toString().contains("query:"));
+    }
+}


### PR DESCRIPTION
Adds support for the `query` HTTP method, which OpenAPI 3.2 introduced as a fixed field of the
[Path Item Object](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.2.0.md#path-item-object),
and maps it from the JAX-RS annotation reader, while keeping it out of OpenAPI 3.0 and 3.1 output,
where the field is not valid.

Three commits, each self-contained:

1. **`swagger-models`**, `PathItem.query`: field, accessors and fluent builder, `HttpMethod.QUERY`,
   and wiring through `readOperations()`, `readOperationsMap()`, `operation()`, `equals`, `hashCode`
   and `toString`.
2. **`swagger-core`**, version gating: a new `PathItemMixin` marks `getQuery()` `@JsonIgnore` for the
   3.0 and 3.1 mappers, so neither can emit a Path Item field that those versions do not define.
3. **`swagger-jaxrs2`**, `Reader.setPathItemOperation` routes `"query"` onto `PathItem.query()`, and
   `extractOperationIdFromPathItem` includes query operationIds in the uniqueness check.

Motivation is swagger-parser's OpenAPI 3.2 work: the parser builds on `swagger-models`, so the model
has to be able to carry a `query` operation before 3.2 documents can be represented at all.

Refs: swagger-api/swagger-parser#2248

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

### Three notes for reviewers

**1. `query` is deliberately not emitted by any current mapper.** swagger-core has no OpenAPI 3.2
support today , `SpecVersion` is `V30`/`V31` only, so there is no mapper that may legitimately write
the field, and both existing ones are gated. The field is therefore enabling work for downstream
consumers rather than something that changes swagger-core's output. Adding `SpecVersion.V32` plus
`Json32`/`Yaml32` is the natural next step, but it is a much larger change (`openapi31` is threaded as
a `boolean` through dozens of signatures across core, jaxrs2, integration and the build plugins), and
it commits the project to a 3.2 design that is better agreed up front than smuggled in here. Happy to
follow up on that in whatever shape you prefer.

**2. The gating applies on read as well as write.** `@JsonIgnore` on a mixin accessor removes the
property in both directions, so the 3.0/3.1 mappers also drop a `query` key when parsing. That is
symmetric with how `SchemaMixin` treats the 3.1-only schema fields (`$id`, `$anchor`, `prefixItems`, …)
under the 3.0 mapper, and it is pinned by an explicit test rather than left implicit.

**3. No new public API in swagger-jaxrs2**:  the only main-source change there is the `Reader` switch
case. `ReaderUtils.getHttpMethodFromCustomAnnotations` already resolves any annotation meta-annotated
with `@HttpMethod` to its lower-cased method name, so an application's own `@QUERY` binding maps onto
`PathItem.query` with no further support needed. The `@QUERY` annotation in this PR lives in test
sources purely as the stand-in for that user-declared binding. If you would rather ship one from
swagger-jaxrs2 as a convenience, that is an easy addition, it just seemed like public surface you
should choose to own, not inherit from this PR.

### Known follow-up

`additionalOperations`, the other new 3.2 Path Item field, is not included. It has its own design
questions like how non-enum methods surface through `readOperations`/`readOperationsMap`, and the spec
rule that the map MUST NOT duplicate methods with fixed fields, so it seemed better kept separate
than bundled here.

### Test results

Full suites, run locally on JDK 21:

| Module | Result |
| --- | --- |
| `swagger-models` | pass |
| `swagger-core` | 749 tests, 0 failures |
| `swagger-jaxrs2` | 227 tests, 0 failures |

New coverage: `PathItemTest` (model wiring, `equals`/`hashCode`, `readOperations*`), two tests in
`JsonSerializationTest` (3.0 and 3.1 mappers omit `query` on write, drop it on read), and
`QueryMethodTest` (reader maps `@QUERY` onto `PathItem.query`; the resulting operation does not reach
`Json`/`Json31`/`Yaml`/`Yaml31` output).
