### PR TITLE
test: use SpecVersion enum in tests in preparation for OAS 3.2

### DIFF
--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue4838Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue4838Test.java
@@ -1,6 +1,5 @@
 package io.swagger.v3.core.issues;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverterContextImpl;
 import io.swagger.v3.core.jackson.ModelResolver;
@@ -8,6 +7,7 @@ import io.swagger.v3.core.util.Configuration;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.models.SpecVersion;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.testng.annotations.Test;
 
@@ -22,7 +22,7 @@ public class Issue4838Test {
 
     @Test
     public void defaultValueShouldBeNullForEmptyStringFieldInOas30() {
-        final ModelConverterContextImpl context = getModelConverterContext(Json.mapper(), false);
+        final ModelConverterContextImpl context = getModelConverterContext(SpecVersion.V30);
 
         final io.swagger.v3.oas.models.media.Schema model = context
                 .resolve(new AnnotatedType(NullableStringModel.class));
@@ -37,7 +37,7 @@ public class Issue4838Test {
 
     @Test
     public void defaultValueShouldBeNullForIntegerFieldInOas30() {
-        final ModelConverterContextImpl context = getModelConverterContext(Json.mapper(), false);
+        final ModelConverterContextImpl context = getModelConverterContext(SpecVersion.V30);
 
         final io.swagger.v3.oas.models.media.Schema model = context
                 .resolve(new AnnotatedType(NullableIntegerModel.class));
@@ -54,7 +54,7 @@ public class Issue4838Test {
 
     @Test
     public void defaultValueShouldBeProvidedFromBigDecimalSchemaForOas30() {
-        final ModelConverterContextImpl context = getModelConverterContext(Json.mapper(), false);
+        final ModelConverterContextImpl context = getModelConverterContext(SpecVersion.V30);
 
         final io.swagger.v3.oas.models.media.Schema model = context
                 .resolve(new AnnotatedType(NullableBigDecimalModel.class));
@@ -70,7 +70,7 @@ public class Issue4838Test {
 
     @Test
     public void defaultValueShouldBeNullProvidedFromBooleanSchemaForOas30() {
-        final ModelConverterContextImpl context = getModelConverterContext(Json.mapper(), false);
+        final ModelConverterContextImpl context = getModelConverterContext(SpecVersion.V30);
 
         final io.swagger.v3.oas.models.media.Schema model = context
                 .resolve(new AnnotatedType(NullableBooleanModel.class));
@@ -86,7 +86,7 @@ public class Issue4838Test {
 
     @Test
     public void defaultValueShouldBeNullForEmptyStringFieldInOas31() {
-        final ModelConverterContextImpl context = getModelConverterContext(Json31.mapper(), true);
+        final ModelConverterContextImpl context = getModelConverterContext(SpecVersion.V31);
 
         final io.swagger.v3.oas.models.media.Schema model = context
                 .resolve(new AnnotatedType(NullableStringModel.class));
@@ -101,7 +101,7 @@ public class Issue4838Test {
 
     @Test
     public void defaultValueShouldBeNullForIntegerFieldInOas31() {
-        final ModelConverterContextImpl context = getModelConverterContext(Json31.mapper(), true);
+        final ModelConverterContextImpl context = getModelConverterContext(SpecVersion.V31);
 
         final io.swagger.v3.oas.models.media.Schema model = context
                 .resolve(new AnnotatedType(NullableIntegerModel.class));
@@ -117,7 +117,7 @@ public class Issue4838Test {
 
     @Test
     public void defaultValueShouldBeProvidedFromBigDecimalSchemaForOas31() {
-        final ModelConverterContextImpl context = getModelConverterContext(Json31.mapper(), true);
+        final ModelConverterContextImpl context = getModelConverterContext(SpecVersion.V31);
 
         final io.swagger.v3.oas.models.media.Schema model = context
                 .resolve(new AnnotatedType(NullableBigDecimalModel.class));
@@ -134,7 +134,7 @@ public class Issue4838Test {
 
     @Test
     public void defaultValueShouldBeNullProvidedFromBooleanSchemaForOas31() {
-        final ModelConverterContextImpl context = getModelConverterContext(Json31.mapper(), true);
+        final ModelConverterContextImpl context = getModelConverterContext(SpecVersion.V31);
 
         final io.swagger.v3.oas.models.media.Schema model = context
                 .resolve(new AnnotatedType(NullableBooleanModel.class));
@@ -148,10 +148,10 @@ public class Issue4838Test {
         assertNull(nullableBooleanField.getDefault());
     }
 
-    private static @NonNull ModelConverterContextImpl getModelConverterContext(ObjectMapper mapper, boolean openAPI31) {
-        final ModelResolver modelResolver = new ModelResolver(mapper);
+    private static @NonNull ModelConverterContextImpl getModelConverterContext(SpecVersion specVersion) {
+        final ModelResolver modelResolver = new ModelResolver(specVersion.equals(SpecVersion.V31) ? Json31.mapper() : Json.mapper());
         Configuration configuration = new Configuration();
-        configuration.setOpenAPI31(openAPI31);
+        configuration.setOpenAPI31(specVersion.equals(SpecVersion.V31));
         modelResolver.setConfiguration(configuration);
         return new ModelConverterContextImpl(modelResolver);
     }

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/PetResourceTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/PetResourceTest.java
@@ -48,6 +48,7 @@ import io.swagger.v3.jaxrs2.petstore.tags.TagOpenAPIDefinitionResource;
 import io.swagger.v3.jaxrs2.petstore.tags.TagOperationResource;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.SpecVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -128,7 +129,7 @@ public class PetResourceTest extends AbstractAnnotationTest {
     }
 
     @Test(description = "Test RequestBody resource)")
-    public void tetRequestBodyResource() {
+    public void testRequestBodyResource() {
         compare(RequestBodyResource.class, REQUEST_BODIES_SOURCE);
         compare(RequestBodyParameterPriorityResource.class, REQUEST_BODIES_SOURCE);
         compare(RequestBodyMethodPriorityResource.class, REQUEST_BODIES_SOURCE);
@@ -268,37 +269,37 @@ public class PetResourceTest extends AbstractAnnotationTest {
 
     @Test(description = "Test a resource with Links and Content)")
     public void testLinksAndContent31Resource() {
-        compare(LinksAndContent31Resource.class, LINKS_SOURCE, true);
+        compare(LinksAndContent31Resource.class, LINKS_SOURCE, SpecVersion.V31);
     }
 
     @Test(description = "Test OpenAPIDefinition resource)")
     public void testOpenAPI31DefinitionResource() {
-        compare(OpenAPI31DefinitionResource.class, PETSTORE_SOURCE, true);
+        compare(OpenAPI31DefinitionResource.class, PETSTORE_SOURCE, SpecVersion.V31);
     }
 
     @Test(description = "Test Parameters resources)")
     public void testParameters31Resource() {
-        compare(Parameters31Resource.class, PARAMETERS_SOURCE, true);
+        compare(Parameters31Resource.class, PARAMETERS_SOURCE, SpecVersion.V31);
     }
 
     @Test(description = "Test some resources with Callbacks)")
     public void testCallBacks31Resources() {
-        compare(ComplexCallback31Resource.class, CALLBACKS_SOURCE, true);
+        compare(ComplexCallback31Resource.class, CALLBACKS_SOURCE, SpecVersion.V31);
     }
 
     @Test(description = "Test some resources with Request Body)")
     public void testRequestBody31Resources() {
-        compare(RequestBody31Resource.class, REQUEST_BODIES_SOURCE, true);
+        compare(RequestBody31Resource.class, REQUEST_BODIES_SOURCE, SpecVersion.V31);
     }
 
     @Test(description = "Test webhook resources")
     public void testWebhooksResource() {
-        compare(WebHookResource.class, PETSTORE_SOURCE, true);
+        compare(WebHookResource.class, PETSTORE_SOURCE, SpecVersion.V31);
     }
 
     @Test(description = "Test method resources with array annotations")
     public void testMethodArrayResponseResource() {
-        compare(MethodArrayResponseResource.class, RESPONSES_SOURCE, true);
+        compare(MethodArrayResponseResource.class, RESPONSES_SOURCE, SpecVersion.V31);
     }
 
     /**
@@ -308,13 +309,13 @@ public class PetResourceTest extends AbstractAnnotationTest {
      * @param source where is the yaml.
      */
     private void compare(final Class clazz, final String source) {
-        compare(clazz, source, false);
+        compare(clazz, source, SpecVersion.V30);
     }
 
-    private void compare(final Class clazz, final String source, boolean openapi31) {
+    private void compare(final Class clazz, final String source, SpecVersion specVersion) {
         final String file = source + clazz.getSimpleName() + YAML_EXTENSION;
         try {
-            if (openapi31) {
+            if (specVersion.equals(SpecVersion.V31)) {
                 compareAsYamlOAS31(clazz, getOpenAPIAsString(file));
             } else {
                 compareAsYaml(clazz, getOpenAPIAsString(file));

--- a/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
+++ b/modules/swagger-jaxrs2/src/test/java/io/swagger/v3/jaxrs2/ReaderTest.java
@@ -3168,7 +3168,7 @@ public class ReaderTest {
 
     @Test(description = "Test ArraySchema implementation annotations")
     public void testArraySchemaImplementation() {
-        SwaggerConfiguration config = new SwaggerConfiguration().openAPI31(true).openAPI(new OpenAPI());
+        SwaggerConfiguration config = swaggerConfiguration31();
         Reader reader = new Reader(config);
 
         OpenAPI openAPI = reader.read(ArraySchemaImplementationResource.class);
@@ -3317,7 +3317,7 @@ public class ReaderTest {
 
     @Test
     public void testOas31Petstore() {
-        SwaggerConfiguration config = new SwaggerConfiguration().openAPI31(true).openAPI(new OpenAPI());
+        SwaggerConfiguration config = swaggerConfiguration31();
         Reader reader = new Reader(config);
 
         OpenAPI openAPI = reader.read(PetResource.class);
@@ -3610,7 +3610,7 @@ public class ReaderTest {
 
     @Test
     public void test31RefSiblings() {
-        SwaggerConfiguration config = new SwaggerConfiguration().openAPI31(true).openAPI(new OpenAPI());
+        SwaggerConfiguration config = swaggerConfiguration31();
         Reader reader = new Reader(config);
 
         OpenAPI openAPI = reader.read(TagResource.class);
@@ -3660,7 +3660,7 @@ public class ReaderTest {
 
     @Test
     public void testSiblings() {
-        Reader reader = new Reader(new SwaggerConfiguration().openAPI(new OpenAPI()).openAPI31(true));
+        Reader reader = new Reader(swaggerConfiguration31());
 
         OpenAPI openAPI = reader.read(SiblingsResource.class);
         String yaml = "openapi: 3.1.0\n" +
@@ -3696,7 +3696,7 @@ public class ReaderTest {
 
     @Test
     public void testSiblingsOnResource() {
-        Reader reader = new Reader(new SwaggerConfiguration().openAPI(new OpenAPI()).openAPI31(true));
+        Reader reader = new Reader(swaggerConfiguration31());
 
         OpenAPI openAPI = reader.read(SiblingsResourceSimple.class);
         String yaml = "openapi: 3.1.0\n" +
@@ -3734,7 +3734,7 @@ public class ReaderTest {
 
     @Test
     public void testSiblingsOnResourceResponse() {
-        Reader reader = new Reader(new SwaggerConfiguration().openAPI(new OpenAPI()).openAPI31(true));
+        Reader reader = new Reader(swaggerConfiguration31());
 
         OpenAPI openAPI = reader.read(SiblingsResourceResponse.class);
         String yaml = "openapi: 3.1.0\n" +
@@ -3782,7 +3782,7 @@ public class ReaderTest {
 
     @Test
     public void testSiblingsOnResourceRequestBody() {
-        Reader reader = new Reader(new SwaggerConfiguration().openAPI(new OpenAPI()).openAPI31(true));
+        Reader reader = new Reader(swaggerConfiguration31());
 
         OpenAPI openAPI = reader.read(SiblingsResourceRequestBody.class);
         String yaml = "openapi: 3.1.0\n" +
@@ -3827,7 +3827,7 @@ public class ReaderTest {
 
     @Test
     public void testSiblingsOnResourceRequestBodyMultiple() {
-        Reader reader = new Reader(new SwaggerConfiguration().openAPI(new OpenAPI()).openAPI31(true));
+        Reader reader = new Reader(swaggerConfiguration31());
 
         OpenAPI openAPI = reader.read(SiblingsResourceRequestBodyMultiple.class);
         String yaml = "openapi: 3.1.0\n" +
@@ -3903,7 +3903,7 @@ public class ReaderTest {
 
     @Test
     public void testSiblingsOnProperty() {
-        Reader reader = new Reader(new SwaggerConfiguration().openAPI(new OpenAPI()).openAPI31(true));
+        Reader reader = new Reader(swaggerConfiguration31());
         Set<Class<?>> classes = new HashSet<>(Arrays.asList(SiblingPropResource.class, WebHookResource.class));
         OpenAPI openAPI = reader.read(classes);
         String yaml = "openapi: 3.1.0\n" +
@@ -3992,7 +3992,7 @@ public class ReaderTest {
 
     @Test
     public void testMisc31() {
-        Reader reader = new Reader(new SwaggerConfiguration().openAPI(new OpenAPI()).openAPI31(true));
+        Reader reader = new Reader(swaggerConfiguration31());
         Set<Class<?>> classes = new HashSet<>(Arrays.asList(Misc31Resource.class));
         OpenAPI openAPI = reader.read(classes);
         String yaml = "openapi: 3.1.0\n" +
@@ -4167,7 +4167,7 @@ public class ReaderTest {
 
     @Test
     public void testParameterMaximumValue() {
-        Reader reader = new Reader(new SwaggerConfiguration().openAPI(new OpenAPI()).openAPI31(true));
+        Reader reader = new Reader(swaggerConfiguration31());
 
         OpenAPI openAPI = reader.read(ParameterMaximumValueResource.class);
         String yaml = "openapi: 3.1.0\n" +
@@ -5678,5 +5678,9 @@ public class ReaderTest {
         public boolean isOpenAPI31Filter() {
             return true;
         }
+    }
+
+    private SwaggerConfiguration swaggerConfiguration31() {
+        return new SwaggerConfiguration().openAPI31(true).openAPI(new OpenAPI());
     }
 }


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

The swagger ecosystem has started moving towards [supporting OAS 3.2](https://swagger.io/blog/swagger-launches-support-for-openapi-3-2-0/). As part of enabling that in swagger-core, it would be helpful to move away from the previous binary `openapi31` boolean configuration, and instead attempting to move to using the `SpecVersion` enum (which can then be extended with V32 and any version that comes after that).

I have for example introduced support for OAS 3.2 `tags` on a [branch](https://github.com/swagger-api/swagger-core/compare/master...Mattias-Sehlstedt:swagger-core:support-oas-32-tags), but it is more difficulty to review and reason about due to the changes to the version handling necessary. Thus I would find it beneficial if we could remove the usage of the boolean flag before any 3.2 functionality was introduced. The same applies to another [recent PR](https://github.com/swagger-api/swagger-core/pull/5253) tied to 3.2 `QUERY` operation functionality.

My general approach is to implement the functionality first, and analyze what workflows are cumbersome, and then extract the fixes for the cumbersome parts as a separate PR without the new functionality.

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->

Relates to https://github.com/swagger-api/swagger-core/issues/5181

## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (non-breaking change)
- [x] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->