### PR TITLE
refactor: streamline tag filtering logic in SpecFilter

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
@@ -53,8 +53,7 @@ public class SpecFilter {
         clone.setServers(filteredOpenAPI.getServers());
         clone.tags(filteredOpenAPI.getTags() == null ? null : new ArrayList<>(openAPI.getTags()));
 
-        final Set<String> allowedTags = new HashSet<>();
-        final Set<String> filteredTags = new HashSet<>();
+        final TagFilter tagFilter = new TagFilter();
 
         Paths clonedPaths = new Paths();
         if (filteredOpenAPI.getPaths() != null) {
@@ -62,7 +61,7 @@ public class SpecFilter {
                 PathItem pathItem = filteredOpenAPI.getPaths().get(resourcePath);
 
                 PathItem filteredPathItem = filterPathItem(filter, pathItem, resourcePath, params, cookies, headers);
-                PathItem clonedPathItem = cloneFilteredPathItem(filter,filteredPathItem, resourcePath, params, cookies, headers, allowedTags, filteredTags);
+                PathItem clonedPathItem = cloneFilteredPathItem(filter, filteredPathItem, resourcePath, params, cookies, headers, tagFilter);
 
                 if (clonedPathItem != null) {
                     if (!clonedPathItem.readOperations().isEmpty()) {
@@ -73,22 +72,14 @@ public class SpecFilter {
             clone.paths(clonedPaths);
         }
 
-        filteredTags.removeAll(allowedTags);
-
-        final List<Tag> tags = clone.getTags();
-        if (tags != null && !filteredTags.isEmpty()) {
-            tags.removeIf(tag -> filteredTags.contains(tag.getName()));
-            if (clone.getTags().isEmpty()) {
-                clone.setTags(null);
-            }
-        }
+        filterTopLevelTags(clone, tagFilter);
 
         if (filteredOpenAPI.getWebhooks() != null) {
             for (String resourcePath : filteredOpenAPI.getWebhooks().keySet()) {
                 PathItem pathItem = filteredOpenAPI.getWebhooks().get(resourcePath);
 
                 PathItem filteredPathItem = filterPathItem(filter, pathItem, resourcePath, params, cookies, headers);
-                PathItem clonedPathItem = cloneFilteredPathItem(filter,filteredPathItem, resourcePath, params, cookies, headers, allowedTags, filteredTags);
+                PathItem clonedPathItem = cloneFilteredPathItem(filter, filteredPathItem, resourcePath, params, cookies, headers, tagFilter);
 
                 if (clonedPathItem != null) {
                     if (!clonedPathItem.readOperations().isEmpty()) {
@@ -530,7 +521,13 @@ public class SpecFilter {
         }
     }
 
-    private PathItem cloneFilteredPathItem(OpenAPISpecFilter filter, PathItem filteredPathItem, String resourcePath, Map<String, List<String>> params, Map<String, String> cookies, Map<String, List<String>> headers, Set<String> allowedTags, Set<String> filteredTags) {
+    private PathItem cloneFilteredPathItem(OpenAPISpecFilter filter,
+                                           PathItem filteredPathItem,
+                                           String resourcePath,
+                                           Map<String, List<String>> params,
+                                           Map<String, String> cookies,
+                                           Map<String, List<String>> headers,
+                                           TagFilter tagFilter) {
         if (filteredPathItem == null) {
             return null;
         }
@@ -556,15 +553,48 @@ public class SpecFilter {
             op = filterOperation(filter, op, resourcePath, key.toString(), params, cookies, headers);
             clonedPathItem.operation(key, op);
             if (op == null) {
-                filteredTags.addAll(opTagsBeforeFilter);
+                tagFilter.getFilteredTags().addAll(opTagsBeforeFilter);
             } else {
                 if (op.getTags() != null) {
                     opTagsBeforeFilter.removeAll(op.getTags());
-                    allowedTags.addAll(op.getTags());
+                    tagFilter.getAllowedTags().addAll(op.getTags());
                 }
-                filteredTags.addAll(opTagsBeforeFilter);
+                tagFilter.getFilteredTags().addAll(opTagsBeforeFilter);
             }
         }
         return clonedPathItem;
+    }
+
+    /**
+     * Removes top level tags that are not used in any operation.
+     *
+     * @param openAPI   the OpenAPI object to filter
+     * @param tagFilter the TagFilter object containing allowed and filtered tags
+     */
+    private void filterTopLevelTags(OpenAPI openAPI, TagFilter tagFilter) {
+        tagFilter.getFilteredTags().removeAll(tagFilter.getAllowedTags());
+
+        final List<Tag> tags = openAPI.getTags();
+        if (tags != null && !tagFilter.getFilteredTags().isEmpty()) {
+            tags.removeIf(tag -> tagFilter.getFilteredTags().contains(tag.getName()));
+            if (openAPI.getTags().isEmpty()) {
+                openAPI.setTags(null);
+            }
+        }
+    }
+
+    private static class TagFilter {
+
+        public Set<String> getAllowedTags() {
+            return allowedTags;
+        }
+
+        public Set<String> getFilteredTags() {
+            return filteredTags;
+        }
+
+        private final Set<String> allowedTags = new HashSet<>();
+        private final Set<String> filteredTags = new HashSet<>();
+
     }
 }

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/filter/SpecFilter.java
@@ -262,7 +262,7 @@ public class SpecFilter {
                 try {
                     // TODO solve this, and generally handle clone and passing references
                     Schema clonedModel;
-                    if (filter.isOpenAPI31Filter())  {
+                    if (filter.isOpenAPI31Filter()) {
                         clonedModel = Json31.mapper().readValue(Json31.pretty(definition), Schema.class);
                     } else {
                         clonedModel = Json.mapper().readValue(Json.pretty(definition), Schema.class);
@@ -273,10 +273,10 @@ public class SpecFilter {
                     if (!clonedProperties.isEmpty()) {
                         clonedModel.setProperties(clonedProperties);
                     }
-                    if(clonedModel.getPatternProperties() != null) {
+                    if (clonedModel.getPatternProperties() != null) {
                         clonedModel.getPatternProperties().clear();
                     }
-                    if(!clonedPatternProperties.isEmpty()) {
+                    if (!clonedPatternProperties.isEmpty()) {
                         clonedModel.setPatternProperties(clonedPatternProperties);
                     }
                     clonedComponentsSchema.put(key, clonedModel);
@@ -298,7 +298,7 @@ public class SpecFilter {
             return;
         }
         if (schema.getDiscriminator() != null && schema.getDiscriminator().getMapping() != null) {
-            for (Map.Entry<String, String> mapping: schema.getDiscriminator().getMapping().entrySet()) {
+            for (Map.Entry<String, String> mapping : schema.getDiscriminator().getMapping().entrySet()) {
                 referencedDefinitions.add(mapping.getValue());
             }
         }
@@ -311,7 +311,7 @@ public class SpecFilter {
         }
 
         if (schema.getAdditionalProperties() instanceof Schema) {
-            addSchemaRef((Schema)schema.getAdditionalProperties(), referencedDefinitions);
+            addSchemaRef((Schema) schema.getAdditionalProperties(), referencedDefinitions);
         }
 
         if (schema.getPatternProperties() != null) {
@@ -325,8 +325,7 @@ public class SpecFilter {
             addSchemaRef(schema.getPropertyNames(), referencedDefinitions);
         }
 
-        if (schema instanceof ArraySchema &&
-                ((ArraySchema) schema).getItems() != null) {
+        if (schema instanceof ArraySchema && ((ArraySchema) schema).getItems() != null) {
             addSchemaRef(((ArraySchema) schema).getItems(), referencedDefinitions);
         } else if (schema.getTypes() != null && schema.getTypes().contains("array") && schema.getItems() != null) {
             addSchemaRef(schema.getItems(), referencedDefinitions);
@@ -404,7 +403,7 @@ public class SpecFilter {
     }
 
     private void addRequestBodySchemaRef(RequestBody requestBody, Set<String> referencedDefinitions) {
-            addContentSchemaRef(requestBody.getContent(), referencedDefinitions);
+        addContentSchemaRef(requestBody.getContent(), referencedDefinitions);
     }
 
     private void addParameterSchemaRef(Parameter parameter, Set<String> referencedDefinitions) {
@@ -417,46 +416,46 @@ public class SpecFilter {
         addContentSchemaRef(header.getContent(), referencedDefinitions);
     }
 
-    private void addCallbackSchemaRef(Callback callback, Set<String> referencedDefinitions){
+    private void addCallbackSchemaRef(Callback callback, Set<String> referencedDefinitions) {
         for (PathItem callbackPathItem : callback.values()) {
             addPathItemSchemaRef(callbackPathItem, referencedDefinitions);
         }
     }
 
-    private void addComponentsSchemaRef(Components components, Set<String> referencedDefinitions){
+    private void addComponentsSchemaRef(Components components, Set<String> referencedDefinitions) {
 
-        if (components.getResponses() != null){
+        if (components.getResponses() != null) {
             for (String resourcePath : components.getResponses().keySet()) {
                 ApiResponse apiResponse = components.getResponses().get(resourcePath);
                 addApiResponseSchemaRef(apiResponse, referencedDefinitions);
             }
         }
-        if (components.getRequestBodies() != null){
+        if (components.getRequestBodies() != null) {
             for (String requestBody : components.getRequestBodies().keySet()) {
                 RequestBody requestBody1 = components.getRequestBodies().get(requestBody);
                 addRequestBodySchemaRef(requestBody1, referencedDefinitions);
             }
         }
-        if (components.getParameters() != null){
+        if (components.getParameters() != null) {
             for (String parameter : components.getParameters().keySet()) {
                 Parameter resourceParam = components.getParameters().get(parameter);
                 addParameterSchemaRef(resourceParam, referencedDefinitions);
             }
         }
-        if (components.getHeaders() != null){
+        if (components.getHeaders() != null) {
             for (String header : components.getHeaders().keySet()) {
                 Header resourceHeader = components.getHeaders().get(header);
                 addHeaderSchemaRef(resourceHeader, referencedDefinitions);
             }
         }
-        if (components.getCallbacks() != null){
-            for (String callback : components.getCallbacks().keySet()){
+        if (components.getCallbacks() != null) {
+            for (String callback : components.getCallbacks().keySet()) {
                 Callback resourceCallback = components.getCallbacks().get(callback);
                 addCallbackSchemaRef(resourceCallback, referencedDefinitions);
             }
         }
-        if (components.getPathItems() != null){
-            for (String resourcePath : components.getPathItems().keySet()){
+        if (components.getPathItems() != null) {
+            for (String resourcePath : components.getPathItems().keySet()) {
                 PathItem pathItem = components.getPathItems().get(resourcePath);
                 addPathItemSchemaRef(pathItem, referencedDefinitions);
             }
@@ -475,13 +474,13 @@ public class SpecFilter {
                 addPathItemSchemaRef(pathItem, referencedDefinitions);
             }
         }
-        if (openApi.getWebhooks() != null){
+        if (openApi.getWebhooks() != null) {
             for (String resourcePath : openApi.getWebhooks().keySet()) {
                 PathItem pathItem = openApi.getWebhooks().get(resourcePath);
                 addPathItemSchemaRef(pathItem, referencedDefinitions);
             }
         }
-        if (openApi.getComponents() != null){
+        if (openApi.getComponents() != null) {
             Components components = openApi.getComponents();
             addComponentsSchemaRef(components, referencedDefinitions);
         }


### PR DESCRIPTION
# Pull Request

Thank you for contributing to **swagger-core**!

Please fill out the following information to help us review your PR efficiently.

---

## Description

Introduced an object (`TagFilter`) to couple the `Tag` filtering fields to each other. it also breaks out the filtering logic into a private support method. This is part of making the behavior more understandable with the intent of making the necessary changes needed for the OAS 3.2 `Tag` functionality easier to integrate. Mainly the pruning of filtered `Tags` that are involved with the new `parent` field (i.e., if the parent is removed as part of the regular filtering, then the children should no longer refer to it). 

This change is extracted from the Tag implementation present on [branch](https://github.com/swagger-api/swagger-core/compare/master...Mattias-Sehlstedt:swagger-core:support-oas-32-tags).

<!--
Describe what this PR changes:
- What problem does it solve?
- Is it a bug fix, new feature, or refactor?
- Link to any related issues.
-->

## Type of Change

<!-- Check all that apply: -->

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactor (non-breaking change)
- [ ] 🧪 Tests
- [ ] 📝 Documentation
- [ ] 🧹 Chore (build or tooling)

## Checklist

<!-- Please check all that apply before requesting review: -->

- [x] I have added/updated tests as needed
- [x] I have added/updated documentation where applicable
- [x] The PR title is descriptive
- [x] The code builds and passes tests locally
- [x] I have linked related issues (if any)

## Screenshots / Additional Context

<!-- Optional: Add logs, screenshots, or notes for reviewers -->