### PR TITLE
fix: _isSetType now detects indirect Set implementations

### DIFF
--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/AbstractModelConverter.java
@@ -114,17 +114,16 @@ public abstract class AbstractModelConverter implements ModelConverter {
     }
 
     protected boolean _isSetType(Class<?> cls) {
-        if (cls != null) {
-
-            if (java.util.Set.class.equals(cls)) {
+        if (cls == null) {
+            return false;
+        }
+        if (java.util.Set.class.isAssignableFrom(cls)) {
+            return true;
+        }
+        // check for scala Set as well - to avoid bringing in scala runtime
+        for (Class<?> a : cls.getInterfaces()) {
+            if ("interface scala.collection.Set".equals(a.toString())) {
                 return true;
-            } else {
-                for (Class<?> a : cls.getInterfaces()) {
-                    // this is dirty and ugly and needs to be extended into a scala model converter.  But to avoid bringing in scala runtime...
-                    if (java.util.Set.class.equals(a) || "interface scala.collection.Set".equals(a.toString())) {
-                        return true;
-                    }
-                }
             }
         }
         return false;

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/IsSetTypeTest.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/converting/IsSetTypeTest.java
@@ -1,0 +1,69 @@
+package io.swagger.v3.core.converting;
+
+import io.swagger.v3.core.jackson.AbstractModelConverter;
+import io.swagger.v3.core.util.Json;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class IsSetTypeTest {
+
+    private static class TestModelConverter extends AbstractModelConverter {
+        protected TestModelConverter() {
+            super(Json.mapper());
+        }
+
+        public boolean isSetType(Class<?> cls) {
+            return _isSetType(cls);
+        }
+    }
+
+    private final TestModelConverter converter = new TestModelConverter();
+
+    @Test
+    public void testIsSetTypeWithNull() {
+        assertFalse(converter.isSetType(null));
+    }
+
+    @Test
+    public void testIsSetTypeWithSetInterface() {
+        assertTrue(converter.isSetType(Set.class));
+    }
+
+    @Test
+    public void testIsSetTypeWithHashSet() {
+        assertTrue(converter.isSetType(HashSet.class));
+    }
+
+    @Test
+    public void testIsSetTypeWithLinkedHashSet() {
+        assertTrue(converter.isSetType(LinkedHashSet.class));
+    }
+
+    @Test
+    public void testIsSetTypeWithTreeSet() {
+        assertTrue(converter.isSetType(TreeSet.class));
+    }
+
+    @Test
+    public void testIsSetTypeWithNonSetCollection() {
+        assertFalse(converter.isSetType(List.class));
+        assertFalse(converter.isSetType(ArrayList.class));
+    }
+
+    @Test
+    public void testIsSetTypeWithNonCollection() {
+        assertFalse(converter.isSetType(String.class));
+        assertFalse(converter.isSetType(Integer.class));
+        assertFalse(converter.isSetType(Map.class));
+    }
+}


### PR DESCRIPTION
### Problem

`_isSetType` in `AbstractModelConverter` failed to recognize indirect `Set` implementations such as `LinkedHashSet`, `HashSet`, and `TreeSet`.

The old implementation only matched an exact `Set.class` equality check, plus a direct interface scan via `Class.getInterfaces()`. Because `getInterfaces()` only returns directly implemented interfaces, subclasses that inherit `Set` behavior through a parent class (for example a custom class extending `AbstractSet` or a collection extending a concrete Set) were not detected, so `uniqueItems` was not set on the generated schema.

### Change

- Replaced `Set.class.equals(cls)` with `Set.class.isAssignableFrom(cls)` in `protected boolean _isSetType(Class<?> cls)`.
- Preserved the existing scala Set detection (checked via direct interfaces) to avoid pulling the scala runtime dependency.
- Made the null case explicit (returns `false`).

### Tests

Added `IsSetTypeTest` with 7 test cases:

- `null` -> not a Set
- `Set` interface -> Set
- `HashSet` -> Set
- `LinkedHashSet` -> Set
- `TreeSet` -> Set
- non-Set collections (`List`, `ArrayList`) -> not a Set
- non-collection types (`String`, `Integer`, `Map`) -> not a Set

All 7 tests pass.