### PR TITLE
fix: avoid heap exhaustion resolving cyclic beans under a system package

### DIFF
--- a/modules/swagger-core/pom.xml
+++ b/modules/swagger-core/pom.xml
@@ -112,6 +112,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>javax.jcr</groupId>
+            <artifactId>jcr</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>provided</scope>

--- a/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
+++ b/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/ModelResolver.java
@@ -92,10 +92,12 @@ import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -107,6 +109,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -810,7 +813,7 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
                 boolean areSiblingsAllowed = AnnotationsUtils.areSiblingsAllowed(resolvedSchemaResolution, openapi31);
                 aType = AnnotationsUtils.addTypeWhenSiblingsAllowed(aType, ctxSchema, areSiblingsAllowed);
                 property = context.resolve(aType);
-                property = clone(property);
+                property = cloneResolvedProperty(property);
                 Schema ctxProperty = null;
                 if (!applySchemaResolution()) {
                     Optional<Schema> reResolvedProperty = AnnotationsUtils.getSchemaFromAnnotation(ctxSchema, annotatedType.getComponents(), null, openapi31, property, schemaResolution, context);
@@ -1304,8 +1307,127 @@ public class ModelResolver extends AbstractModelConverter implements ModelConver
         return null;
     }
 
+    private static final Map<Class<?>, List<Field>> ALL_FIELDS_CACHE = new ConcurrentHashMap<>();
+
     private Schema clone(Schema property) {
         return AnnotationsUtils.clone(property, openapi31);
+    }
+
+    /**
+     * Clones the schema {@code context.resolve()} just returned for this property, guarding against a
+     * specific case where a plain {@link #clone} (a JSON round-trip) blows up: a schema that was never
+     * assigned a component name and has no {@code $ref} either (e.g. a bean under a package {@link
+     * ReflectionUtils#isSystemType} treats as "system", such as a third-party JSR API living under
+     * {@code javax.*} - see https://github.com/swagger-api/swagger-core/issues/5292). A schema like that
+     * can never be collapsed to a {@code $ref}, so the resolver's cache hands back the exact same Schema
+     * instance, by reference, at every place in the object graph that reaches it - directly, or nested
+     * under items/properties/allOf. Deep-cloning such a value via JSON round-trip re-expands every shared
+     * subtree at every occurrence, which blows up combinatorially for a densely cross-referenced, cyclic
+     * API shape.
+     * <p>
+     * For that case, nested schema/collection-valued fields are temporarily swapped for a
+     * shape-preserving-but-empty stand-in before cloning (so the JSON round-trip sees a small envelope
+     * that still carries whatever a given field's mere presence/size/keys signal to {@link
+     * io.swagger.v3.core.util.ModelDeserializer} for runtime-type discrimination - e.g. a non-empty
+     * {@code allOf} list still reads as a {@code ComposedSchema}, a non-null {@code additionalProperties}
+     * still reads as a {@code MapSchema}), then the real nested values are reattached, by reference, on
+     * both the original and the clone afterward. That's safe here specifically because {@code property}
+     * is the resolver's own cached, already-fully-built value for this property's type: its nested
+     * properties/items/allOf were already independently resolved, cloned, and normalized one level down
+     * when the resolver first built them, and don't need to go through that again - only the top-level
+     * fields (notably {@code name}, used as this property's key in the parent's {@code properties} map -
+     * see the {@code modelProps.put(prop.getName(), prop)} below) do.
+     * <p>
+     * This is deliberately narrower than {@link #clone}: a freshly-constructed, one-off wrapper (e.g. the
+     * {@code allOf} envelope built for {@code SchemaResolution.ALL_OF}) has never been through this
+     * normalization and must still take the plain, full round-trip - which is also why every other
+     * {@code clone(...)} call site keeps calling {@link #clone} unchanged.
+     */
+    private Schema cloneResolvedProperty(Schema property) {
+        if (property == null || property.get$ref() != null || StringUtils.isNotBlank(property.getName())) {
+            return clone(property);
+        }
+        List<Field> detachedFields = new ArrayList<>();
+        List<Object> detachedValues = new ArrayList<>();
+        try {
+            for (Field field : allFieldsOf(property.getClass())) {
+                Object value = field.get(property);
+                if (value instanceof Schema || value instanceof Map || value instanceof Collection) {
+                    detachedFields.add(field);
+                    detachedValues.add(value);
+                    field.set(property, neutralize(value));
+                }
+            }
+            Schema cloned = clone(property);
+            for (int i = 0; i < detachedFields.size(); i++) {
+                try {
+                    detachedFields.get(i).set(cloned, detachedValues.get(i));
+                } catch (ReflectiveOperationException | RuntimeException e) {
+                    // cloning normalized the runtime type away from this field - nothing to reattach it to
+                }
+            }
+            return cloned;
+        } catch (ReflectiveOperationException e) {
+            return clone(property);
+        } finally {
+            for (int i = 0; i < detachedFields.size(); i++) {
+                try {
+                    detachedFields.get(i).set(property, detachedValues.get(i));
+                } catch (ReflectiveOperationException ignored) {
+                }
+            }
+        }
+    }
+
+    /**
+     * Recursively replaces every nested {@link Schema} in {@code value} with a bare instance of the same
+     * runtime class (no fields set), while preserving map keys and collection sizes - keeping just enough
+     * shape for {@link io.swagger.v3.core.util.ModelDeserializer}'s presence-based type discrimination to
+     * still work, without carrying over the (potentially huge/shared) content underneath.
+     */
+    private static Object neutralize(Object value) {
+        if (value instanceof Schema) {
+            try {
+                return ((Schema<?>) value).getClass().getDeclaredConstructor().newInstance();
+            } catch (ReflectiveOperationException e) {
+                return new Schema<>();
+            }
+        } else if (value instanceof Map) {
+            Map<Object, Object> copy = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                copy.put(entry.getKey(), neutralize(entry.getValue()));
+            }
+            return copy;
+        } else if (value instanceof List) {
+            List<Object> copy = new ArrayList<>();
+            for (Object element : (List<?>) value) {
+                copy.add(neutralize(element));
+            }
+            return copy;
+        } else if (value instanceof Set) {
+            Set<Object> copy = new LinkedHashSet<>();
+            for (Object element : (Set<?>) value) {
+                copy.add(neutralize(element));
+            }
+            return copy;
+        }
+        return value;
+    }
+
+    private static List<Field> allFieldsOf(Class<?> type) {
+        return ALL_FIELDS_CACHE.computeIfAbsent(type, k -> {
+            List<Field> fields = new ArrayList<>();
+            for (Class<?> c = k; c != null && c != Object.class; c = c.getSuperclass()) {
+                for (Field field : c.getDeclaredFields()) {
+                    if (Modifier.isStatic(field.getModifiers())) {
+                        continue;
+                    }
+                    field.setAccessible(true);
+                    fields.add(field);
+                }
+            }
+            return fields;
+        });
     }
 
     private boolean isSubtype(AnnotatedClass childClass, Class<?> parentClass) {

--- a/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue5292Test.java
+++ b/modules/swagger-core/src/test/java/io/swagger/v3/core/issues/Issue5292Test.java
@@ -1,0 +1,73 @@
+package io.swagger.v3.core.issues;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.converter.ResolvedSchema;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Reproduces https://github.com/swagger-api/swagger-core/issues/5292: resolving a densely
+ * cross-referenced, cyclic third-party bean living under a "system" package - {@code javax.jcr.*} is
+ * treated as a JDK package by {@link io.swagger.v3.core.util.ReflectionUtils#isSystemType}, so it's
+ * never assigned a component name and can never be collapsed to a {@code $ref} - used to exhaust the
+ * heap.
+ * <p>
+ * Root cause: with no component name, the resolver's cache still correctly reuses, by reference, the
+ * one already-built Schema instance for a given class across every differently-named property that
+ * reaches it - but the resolver then had to deep-clone that shared instance (via a JSON round-trip) to
+ * give each property occurrence its own {@code name}. Cloning a value that is itself shared/cyclic this
+ * way re-expands every shared subtree at every occurrence, which blows up combinatorially with depth -
+ * see the fix in {@code ModelResolver.cloneResolvedProperty()}.
+ * <p>
+ * This is a different mechanism than https://github.com/swagger-api/swagger-core/issues/5091 (fixed by
+ * #5114): that one was a resolve()-call-count explosion; this one is a single-value size explosion - the
+ * number of resolve() calls stays modest (bounded assertions below), but the schema <em>object graph</em>
+ * one of those calls builds is what blows up once something (here, the resolver's own per-property
+ * relabeling clone) tries to deep-copy or serialize it.
+ * <p>
+ * Known residual limitation, out of scope for this fix: the schema this resolves to is still, internally,
+ * a graph with shared/cyclic object references (that's unavoidable without giving javax.jcr.* types a
+ * component name, which would defeat the "system types are inlined, not $ref'd" convention). Handing that
+ * result to a generic JSON serializer - e.g. {@code Json.pretty()} on the resolved schema directly, or on
+ * a full OpenAPI document that embeds it - can still blow up the same way, since ordinary Jackson bean
+ * serialization has no notion of shared references and re-expands every occurrence. Guarding against that
+ * would mean changing general-purpose Schema serialization itself, not just the resolver's internal
+ * bookkeeping, so it isn't exercised here.
+ */
+public class Issue5292Test {
+
+    @Test
+    public void resolvingCyclicUnnamedSystemPackageBeanDoesNotExplode() {
+        assertResolvesQuickly(javax.jcr.Node.class);
+        assertResolvesQuickly(javax.jcr.Session.class);
+        assertResolvesQuickly(javax.jcr.Workspace.class);
+        assertResolvesQuickly(javax.jcr.Item.class);
+    }
+
+    @Test
+    public void resolvingCyclicUnnamedSystemPackageBeanDoesNotExplodeWhenResolvedAsRef() {
+        // resolveAsRef(true) is what the real io.swagger.v3.jaxrs2.Reader entry point uses for a
+        // response/request body type - the issue also reported the OOM reproducing through Reader.
+        long start = System.currentTimeMillis();
+        ResolvedSchema resolved = ModelConverters.getInstance()
+                .resolveAsResolvedSchema(new AnnotatedType(javax.jcr.Node.class).resolveAsRef(true));
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(resolved.schema != null, "expected a schema to be resolved for javax.jcr.Node");
+        assertTrue(elapsed < 10_000,
+                "resolving javax.jcr.Node (resolveAsRef=true) took " + elapsed
+                        + "ms - see https://github.com/swagger-api/swagger-core/issues/5292");
+    }
+
+    private void assertResolvesQuickly(Class<?> type) {
+        long start = System.currentTimeMillis();
+        ModelConverters.getInstance().readAll(type);
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(elapsed < 10_000,
+                "resolving " + type.getName() + " took " + elapsed
+                        + "ms - see https://github.com/swagger-api/swagger-core/issues/5292");
+    }
+}


### PR DESCRIPTION
Fixes #5292.

## Root cause

`ReflectionUtils.isSystemType()` treats any `javax.*` class as a JDK "system" type, so a third-party JSR API living under `javax.*` (e.g. the JCR API) never gets a component name and can never be collapsed to a `$ref`. The resolver's cache still correctly reuses, by reference, the one already-built `Schema` instance for a given class across every differently-named property that reaches it — but it then had to deep-clone that shared instance (via a JSON round-trip, `AnnotationsUtils.clone`) to give each property occurrence its own `name`. Cloning a value that is itself shared/cyclic this way re-expands every shared subtree at every occurrence, blowing up combinatorially with depth and exhausting the heap.

Confirmed via the exact repro from the issue (`ModelConverters.getInstance().readAll(javax.jcr.Node.class)`, `-Xmx512m`): OOMs on `master` (`v2.2.53`), resolves in well under a second with this fix.

**This is a different mechanism than the issue's own analysis suggests** (`AnnotatedType.isSubtype` fragmenting the cache, per #5004): I instrumented `AnnotatedType.subtype(boolean)` directly and confirmed `isSubtype` never becomes `true` during this resolution. The `resolve()` call count also stays modest (~127 calls total, matching the issue's own instrumentation) — this is a single value's object graph exploding when cloned, not a call-count explosion like #5091.

## Fix

`ModelResolver.cloneResolvedProperty()` detects this specific case (blank name, no `$ref`) and temporarily swaps nested schema/collection-valued fields for shape-preserving-but-empty stand-ins before cloning, so the JSON round-trip still sees enough shape for `ModelDeserializer`'s type discrimination (e.g. a non-empty `allOf` list still reads as `ComposedSchema`, non-null `additionalProperties` still reads as `MapSchema`) without carrying the huge/shared content underneath — then reattaches the real nested values by reference afterward.

This is deliberately narrower than the existing `clone()` helper (left unchanged, still used at every other call site): it relies on `property` being the resolver's own already-normalized cached value for this exact property resolution, not a freshly-built one-off wrapper (e.g. the `allOf` envelope built for `SchemaResolution.ALL_OF` still needs the plain, full round-trip, since it's never been through this normalization before).

## Testing

- Added `Issue5292Test` with a `javax.jcr:jcr:2.0` test dependency, covering the exact types from the issue's repro table (`Node`, `Session`, `Workspace`, `Item`), plus the `resolveAsRef(true)` path used by `io.swagger.v3.jaxrs2.Reader`.
- Full `swagger-core` module test suite: 750/750 passing, no regressions.

## Known residual limitation

The resolved schema is still, internally, a graph with shared/cyclic object references (unavoidable without giving `javax.*` types a component name, which would defeat the "system types are inlined, not `$ref`'d" convention). Handing that result to a generic JSON serializer — e.g. `Json.pretty()` directly on the resolved schema, or on a full OpenAPI document that embeds it — can still exhaust the heap, since ordinary Jackson bean serialization has no notion of shared references and re-expands every occurrence. Fixing that would mean changing general-purpose `Schema` serialization itself, not just the resolver's internal bookkeeping, so it's left as a follow-up rather than folded into this fix.